### PR TITLE
generator mounts Triannon::Engine at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ rails g triannon:install
 Edit the `config/triannon.yml` file:
 
 * `ldp_url:` Points to the root annotations container on your LDP server
-* `triannon_base_url:` Used as the base url for all annotations hosted by your Triannon server.  Identifiers from the LDP server will be appended to this base-url.
+* `triannon_base_url:` Used as the base url for all annotations hosted by your Triannon server.  Identifiers from the LDP server will be appended to this base-url.  Generally something like "https://your-triannon-rails-box/annotations", as "/annotations" is added to the path by the Triannon gem
 
 Generate the root annotations container on the LDP server
 

--- a/app/controllers/triannon/annotations_controller.rb
+++ b/app/controllers/triannon/annotations_controller.rb
@@ -6,12 +6,12 @@ module Triannon
     before_action :set_annotation, only: [:show, :edit, :update, :destroy]
     rescue_from Triannon::ExternalReferenceError, with: :ext_ref_error
 
-    # GET /annotations/annotations
+    # GET /annotations
     def index
       @annotations = Annotation.all
     end
 
-    # GET /annotations/annotations/1
+    # GET /annotations/1
     def show
       respond_to do |format|
         format.jsonld { render_jsonld_per_context (params[:jsonld_context]) }
@@ -31,17 +31,17 @@ module Triannon
       end
     end
 
-    # GET /annotations/annotations/new
+    # GET /annotations/new
     def new
       @annotation = Annotation.new
     end
 
     # NOT YET IMPLEMENTED
-    # GET /annotations/annotations/1/edit    
+    # GET /annotations/1/edit    
 #    def edit
 #    end
 
-    # POST /annotations/annotations
+    # POST /annotations
     def create
       # FIXME: this is probably a bad way of allowing app form to be used as well as direct post requests
       if params["annotation"]
@@ -63,7 +63,7 @@ module Triannon
     end
 
     # NOT YET IMPLEMENTED
-    # PATCH/PUT /annotations/annotations/1
+    # PATCH/PUT /annotations/1
 #    def update
 #      if @annotation.update(params)
 #        redirect_to @annotation, notice: 'Annotation was successfully updated.'
@@ -72,7 +72,7 @@ module Triannon
 #      end
 #    end
 
-    # DELETE /annotations/annotations/1
+    # DELETE /annotations/1
     def destroy
       @annotation.destroy
       redirect_to annotations_url, status: 204, notice: 'Annotation was successfully destroyed.'

--- a/lib/generators/triannon/install_generator.rb
+++ b/lib/generators/triannon/install_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators'
 module Triannon
   class Install < Rails::Generators::Base
     def inject_Triannon_routes
-      route "mount Triannon::Engine, at: 'annotations'"
+      route "mount Triannon::Engine, at: ''"
     end
 
     def create_triannon_yml_file

--- a/spec/features/annotations_spec.rb
+++ b/spec/features/annotations_spec.rb
@@ -5,7 +5,7 @@ describe "viewing an annotation", :vcr, type: :feature do
     before(:each) do
       annotation = create_annotation('body-chars.json')
       allow(Triannon::Annotation).to receive(:find).and_return(annotation)
-      visit "/annotations/annotations/#{annotation.id}.html"
+      visit "/annotations/#{annotation.id}.html"
     end
 
     it "has a page title" do
@@ -23,7 +23,7 @@ describe "viewing an annotation", :vcr, type: :feature do
       it "multiple" do
         anno = create_annotation('mult-motivations.json')
         allow(Triannon::Annotation).to receive(:find).with(anno.id).and_return(anno)
-        visit "/annotations/annotations/#{anno.id}.html"
+        visit "/annotations/#{anno.id}.html"
         expect(page).to have_content "http://www.w3.org/ns/oa#moderating"
         expect(page).to have_content "http://www.w3.org/ns/oa#tagging"
       end


### PR DESCRIPTION
(we made this change to triannon-service to avoid  "annotations/annotations/" in the anno URL paths)