### PR TITLE
more prep for using Content-Type HTTP header

### DIFF
--- a/app/controllers/triannon/annotations_controller.rb
+++ b/app/controllers/triannon/annotations_controller.rb
@@ -44,7 +44,9 @@ module Triannon
     # POST /annotations
     def create
       # FIXME: this is probably a bad way of allowing app form to be used as well as direct post requests
-      if params["annotation"]
+      # see https://github.com/sul-dlss/triannon/issues/90 -- prob just want to fix the form to do a POST
+      #  note that need to check for empty? if HTTP Header Content-Type is json (but not jsonld).
+      if params["annotation"] && !params["annotation"].empty?
         # it's from app html form
         params.require(:annotation).permit(:data)
         if params["annotation"]["data"]

--- a/spec/fixtures/annotations/body-chars.rdf
+++ b/spec/fixtures/annotations/body-chars.rdf
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <rdf:RDF xmlns:ns0='http://www.w3.org/ns/oa#' xmlns:ns1='http://www.w3.org/2011/content#' xmlns:ns2='http://purl.org/dc/dcmitype/' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-	<ns0:Annotation rdf:about='http://example.org/annos/annotation/body-chars.ttl'>
+	<ns0:Annotation>
 		<ns0:hasBody>
-			<ns1:ContentAsText rdf:nodeID='g2233368480'>
+			<ns1:ContentAsText>
 				<rdf:type rdf:resource='http://purl.org/dc/dcmitype/Text'></rdf:type>
 				<ns1:chars>I love this!</ns1:chars>
 			</ns1:ContentAsText>

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_destroy/calls_solr_delete_method_after_successful_destroy_in_LDP_store.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_destroy/calls_solr_delete_method_after_successful_destroy_in_LDP_store.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ca3515177eac79e9d1a6ae8c29e67e883e1f5897"'
+      - '"65093147b7c9f3c09272c2669862ec0f4196385a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820
+      - http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820
+      string: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820
+    uri: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ec5fa22ca9eea9c08f6b86924ed22cf5331cd634"'
+      - '"e7d382a831b7f10503b2f1e0dbab863f686c8dab"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t
+      - http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t
+      string: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t
+    uri: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9cd28cc33f58841120de0dabb6c1e6ea1309dfaf"'
+      - '"89359f305b8add4f91b27143b849f7937a1aa00c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e
+      - http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e
+      string: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820
+    uri: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e95de544430a2a01f0c93aebe1045b7a873b2a0b"'
+      - '"2b104956318a8d94a3c3c831e1356c9057648f91"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -175,39 +175,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820>
-        .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4c09c9d2-c3fe-41dd-8ecf-be95845f309e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"69801cf1-9900-4667-b4fa-4ed76257cfbb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:18.532Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:53.571Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:18.546Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:53.586Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e
+    uri: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9cd28cc33f58841120de0dabb6c1e6ea1309dfaf"'
+      - '"89359f305b8add4f91b27143b849f7937a1aa00c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3565'
       Content-Type:
       - application/x-turtle
     body:
@@ -258,31 +258,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t>
+        <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820/t/068a74f6-5430-4bed-bab4-3483a8bf8e2e/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942/t/cee6d618-665b-4259-87f2-d5106a89dd5f>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"227e74e7-b12a-4495-a398-1ea796ae7472\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"175775c6-a49f-40b0-bb0d-ac9b6a3a72e5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:18.565Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:53.6Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:18.565Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:53.6Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -306,7 +306,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -320,7 +320,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:18 GMT
+      - Thu, 05 Mar 2015 01:26:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1436,16 +1436,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">28b8d866-fd12-4a33-be4c-eca18b8dd820</field><field name="motivation">bookmarking</field><field
+        name="id">5024ee8e-2ea3-40d6-aff1-85f2903a7942</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/28b8d866-fd12-4a33-be4c-eca18b8dd820","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/5024ee8e-2ea3-40d6-aff1-85f2903a7942","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1463,10 +1463,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/28b8d866-fd12-4a33-be4c-eca18b8dd820
+    uri: http://localhost:8983/fedora/rest/anno/5024ee8e-2ea3-40d6-aff1-85f2903a7942
     body:
       encoding: US-ASCII
       string: ''
@@ -1486,5 +1486,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_find/sets_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_find/sets_anno_id.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2eaf906dafaa361282a5aa2888747677b26cc31a"'
+      - '"a5717c582f4126bb9773317660e12401838f90b7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+      - http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+      string: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bc1fc08ab546dddee43c46407b9c41baa9deb705"'
+      - '"1ae5689b36cf9161f320b726426c582d23ce1c20"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b
+      - http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b
+      string: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"38785c2b0eac8830d7f65785cc360a86d16fa75c"'
+      - '"cf2dd75a4784275b06181feeb04c333829c36681"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff
+      - http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff
+      string: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8557a6132abc44ab85be4181ef163ad13a53ef1d"'
+      - '"1bed0e343ddc0e5509f74a45150c3bbd9b796da9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t
+      - http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t
+      string: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"95c8296083ff9f916b32f86836576a6fda7461b3"'
+      - '"6f32fa7194ac94cbd4499a98eeec67d752f4c2db"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21
+      - http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21
+      string: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0af9a4f8332f899643cefb15d09a6b9116341b23"'
+      - '"5486a6ea4d4f09984c88f505d36efb777cb70b8a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4511'
       Content-Type:
       - application/x-turtle
     body:
@@ -262,44 +262,43 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        , <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        , <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        , <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        , <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"9da4630e-4393-46a1-bc4a-410dffcbdf17\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"751bd9b8-c127-4f3f-a517-5565c34fa41d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.216Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.753Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:58.263Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6
     body:
       encoding: US-ASCII
       string: ''
@@ -316,9 +315,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"38785c2b0eac8830d7f65785cc360a86d16fa75c"'
+      - '"cf2dd75a4784275b06181feeb04c333829c36681"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -331,7 +330,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3745'
+      - '3862'
       Content-Type:
       - application/x-turtle
     body:
@@ -350,35 +349,36 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"72931d68-9ef0-4ac1-a9af-51bb5f082009\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"058f865f-b38b-4e4f-acfe-95c11e04b079\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.739Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.739Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.246Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:58.246Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543
     body:
       encoding: US-ASCII
       string: ''
@@ -395,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"95c8296083ff9f916b32f86836576a6fda7461b3"'
+      - '"6f32fa7194ac94cbd4499a98eeec67d752f4c2db"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -410,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3686'
       Content-Type:
       - application/x-turtle
     body:
@@ -429,31 +429,32 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"f76c2be2-1674-41f6-b700-7957a42bbfb2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"9b1051a9-b822-4ce7-8a59-fa623e4ed581\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:58.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -477,7 +478,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:23 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -491,7 +492,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:23 GMT
+      - Thu, 05 Mar 2015 01:26:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1607,18 +1608,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:23 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">22028072-15e0-4c44-a7d1-a19a465cd243</field><field name="motivation">commenting</field><field
+        name="id">4b23fceb-0e5e-4987-9ec9-37ff5fecb82c</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70118468912000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/22028072-15e0-4c44-a7d1-a19a465cd243","@type":"oa:Annotation","hasBody":"_:g70118468912000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121669652720","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c","@type":"oa:Annotation","hasBody":"_:g70121669652720","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1634,12 +1635,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:23 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c
     body:
       encoding: US-ASCII
       string: ''
@@ -1656,9 +1657,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0af9a4f8332f899643cefb15d09a6b9116341b23"'
+      - '"5486a6ea4d4f09984c88f505d36efb777cb70b8a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1671,7 +1672,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4511'
       Content-Type:
       - application/x-turtle
     body:
@@ -1690,44 +1691,43 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        , <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        , <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        , <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        , <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"9da4630e-4393-46a1-bc4a-410dffcbdf17\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"751bd9b8-c127-4f3f-a517-5565c34fa41d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.216Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.753Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:58.263Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:23 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6
     body:
       encoding: US-ASCII
       string: ''
@@ -1744,9 +1744,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"38785c2b0eac8830d7f65785cc360a86d16fa75c"'
+      - '"cf2dd75a4784275b06181feeb04c333829c36681"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1759,7 +1759,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3745'
+      - '3862'
       Content-Type:
       - application/x-turtle
     body:
@@ -1778,35 +1778,36 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/b/8641b317-577c-4bb1-9dd7-5fc96cb998ff/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/b/98f7f310-5931-4c9c-9a55-4347a332b0c6>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"72931d68-9ef0-4ac1-a9af-51bb5f082009\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"058f865f-b38b-4e4f-acfe-95c11e04b079\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.739Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.739Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.246Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:58.246Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:23 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21
+    uri: http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543
     body:
       encoding: US-ASCII
       string: ''
@@ -1823,9 +1824,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"95c8296083ff9f916b32f86836576a6fda7461b3"'
+      - '"6f32fa7194ac94cbd4499a98eeec67d752f4c2db"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:22 GMT
+      - Wed, 04 Mar 2015 19:26:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1838,7 +1839,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3686'
       Content-Type:
       - application/x-turtle
     body:
@@ -1857,29 +1858,30 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t>
+        <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/22028072-15e0-4c44-a7d1-a19a465cd243/t/f46ceb70-ca88-44e1-a73a-90f149c7ca21>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4b23fceb-0e5e-4987-9ec9-37ff5fecb82c/t/71738b2a-8053-4e0a-845c-23939722d543>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"f76c2be2-1674-41f6-b700-7957a42bbfb2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"9b1051a9-b822-4ce7-8a59-fa623e4ed581\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:22.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:22.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:58.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:58.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:23 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/calls_solr_save_method_after_successful_save_to_LDP_Store.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/calls_solr_save_method_after_successful_save_to_LDP_Store.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"725ba218f649e8d8e1a66500f580e47c8780e095"'
+      - '"d9afe85182ee30774546cabc4241566fc051ac0a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf
+      - http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf
+      string: http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf
+    uri: http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"15b88b272316ce5c162be1c6e6954649cc331941"'
+      - '"0ce90a70c600a11e94757e990a09123366af1ee6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf/t
+      - http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf/t
+      string: http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf/t
+    uri: http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770/t
     body:
       encoding: UTF-8
       string: |
@@ -108,18 +108,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f42606ec310d335cfbcb52a79ecd58d8fc1424d2"'
+      - '"501de00b313ee009b4dea0454ecb2f1e0850d519"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf/t/caf33147-bac7-42e5-ac30-a079e6c889f2
+      - http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770/t/5f8a09dc-7df7-450c-abb5-ad709a4b3e31
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf/t/caf33147-bac7-42e5-ac30-a079e6c889f2
+      string: http://localhost:8983/fedora/rest/anno/95520d99-7a50-4c41-82ba-d93c072bf770/t/5f8a09dc-7df7-450c-abb5-ad709a4b3e31
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/doesn_t_call_solr_save_method_after_exception_for_LDP_store_create.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/doesn_t_call_solr_save_method_after_exception_for_LDP_store_create.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"86ac4fb3efc0257b15250985cc264b61713816a5"'
+      - '"f7d20a82a94aa46e2c6ae9a51e9d6869d02796b9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5
+      - http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5
+      string: http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5
+    uri: http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8ddf1d05494675c77c283eb4db8b555f1cee91a9"'
+      - '"39c31a3df1086bb9ab5c6e360a2d6ead61166e78"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5/t
+      - http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5/t
+      string: http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5/t
+    uri: http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00/t
     body:
       encoding: UTF-8
       string: |
@@ -108,18 +108,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"dbeeb7ed1f463269aec2b5ef2dd835e63e5e1356"'
+      - '"fc1f5ce2ac4c8c210207063b2084db85defbc7bd"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:18 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5/t/83a06df1-b37b-47d8-8c3b-a84c0763c467
+      - http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00/t/f52d4efa-2f92-4e85-a4f5-f815b26108ea
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5/t/83a06df1-b37b-47d8-8c3b-a84c0763c467
+      string: http://localhost:8983/fedora/rest/anno/33c73a2d-a156-4943-9747-25f272821f00/t/f52d4efa-2f92-4e85-a4f5-f815b26108ea
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/sets_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/sets_anno_id.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2d7183e21920546a9d8f84228334f9b3f4921f58"'
+      - '"fe1843278cad740e442b95e5f411aae158c7499c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:52 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f
+      - http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f
+      string: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f
+    uri: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c520602feed2624215ffca246dea932d9e1f1006"'
+      - '"96802ba8c997c7abc07abaff6f25bcc8ef239fa9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:52 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t
+      - http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t
+      string: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t
+    uri: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6f16f8f0db257327c3f01a15268e0541d6d567ce"'
+      - '"b69294421dd155ca0e17536e62081bc11f59fbaf"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:52 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054
+      - http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054
+      string: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f
+    uri: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a52321f5a3df204d1f8c601c1f6e86010e61bce4"'
+      - '"cc37feaaae365e6b220524a4218dfd2a4b3de819"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4020'
+      - '4099'
       Content-Type:
       - application/x-turtle
     body:
@@ -175,39 +175,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c6af3040-b80f-45b3-af7f-af5375448f4f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"97f9519a-98c4-4b59-8a72-f56ef6aae211\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:17.72Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:52.895Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:17.738Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:52.913Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054
+    uri: http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6f16f8f0db257327c3f01a15268e0541d6d567ce"'
+      - '"b69294421dd155ca0e17536e62081bc11f59fbaf"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3684'
       Content-Type:
       - application/x-turtle
     body:
@@ -258,32 +258,32 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t>
+        <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f/t/a745422b-1676-4be7-b4ca-86d5a960c054>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30e85454-819f-468c-aa98-b3ff3360098d/t/fb2307f3-090f-4433-a8b5-f2a12d98e6da>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"d230fda7-8530-4d62-9c8f-578a42f554b0\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"36aabd14-974c-4960-9283-cb46648bf5f4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:17.756Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:17.756Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:52.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:52.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -307,7 +307,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:17 GMT
+      - Wed, 04 Mar 2015 19:26:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -321,7 +321,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:17 GMT
+      - Thu, 05 Mar 2015 01:26:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1437,16 +1437,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">df9e1c44-d305-4fa0-b163-c2ad669e690f</field><field name="motivation">bookmarking</field><field
+        name="id">30e85454-819f-468c-aa98-b3ff3360098d</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/df9e1c44-d305-4fa0-b163-c2ad669e690f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/30e85454-819f-468c-aa98-b3ff3360098d","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1462,7 +1462,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_SolrWriter_add_with_solr_hash.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_SolrWriter_add_with_solr_hash.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1f9562323fda0b487f1698484fe619afdfa4ae10"'
+      - '"a6c01575ca7a29799179f70d8b557723fab43730"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559
+      - http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559
+      string: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c2db9a64d4f218cd5c46d2a3a0871c88621691cc"'
+      - '"09a0b91b2327530ee689ae29e69f5ba581ae765c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t
+      - http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t
+      string: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1a22a830ff0e0e521d1d8bd9d85315e5d31a8c86"'
+      - '"0dfa50a7a8e69b05c90c0e88547871cd497afbd8"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291
+      - http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291
+      string: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a7fd7a0506ce488df8bf96c6f4b601cc3957dfd8"'
+      - '"a871257f092886983908d07d4b479df5e1035e60"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4099'
+      - '4021'
       Content-Type:
       - application/x-turtle
     body:
@@ -175,39 +175,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"44616059-4253-4a1d-9076-c777aa24b609\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4590808-2d2a-4c75-8f97-a36eac076ff1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.099Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:21.557Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.114Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1a22a830ff0e0e521d1d8bd9d85315e5d31a8c86"'
+      - '"0dfa50a7a8e69b05c90c0e88547871cd497afbd8"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -258,32 +258,32 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"13a8b479-2959-4219-85b8-e6c3532dde3d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"c2e57e36-7d61-4d0d-9545-5a53abaef686\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:21.58Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:21.58Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -307,7 +307,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -321,7 +321,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:21 GMT
+      - Thu, 05 Mar 2015 01:26:56 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1437,16 +1437,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">1516300a-7723-436c-9957-fe0d7b36f559</field><field name="motivation">bookmarking</field><field
+        name="id">4bd81d14-6f0b-493b-993d-46eb838eaff5</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/1516300a-7723-436c-9957-fe0d7b36f559","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/4bd81d14-6f0b-493b-993d-46eb838eaff5","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1464,10 +1464,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5
     body:
       encoding: US-ASCII
       string: ''
@@ -1484,9 +1484,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a7fd7a0506ce488df8bf96c6f4b601cc3957dfd8"'
+      - '"a871257f092886983908d07d4b479df5e1035e60"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1499,7 +1499,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4099'
+      - '4021'
       Content-Type:
       - application/x-turtle
     body:
@@ -1518,39 +1518,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"44616059-4253-4a1d-9076-c777aa24b609\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4590808-2d2a-4c75-8f97-a36eac076ff1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.099Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:21.557Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.114Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291
+    uri: http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b
     body:
       encoding: US-ASCII
       string: ''
@@ -1567,9 +1567,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1a22a830ff0e0e521d1d8bd9d85315e5d31a8c86"'
+      - '"0dfa50a7a8e69b05c90c0e88547871cd497afbd8"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1601,30 +1601,30 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559/t/fb17af82-3097-4c93-912e-34b65c36d291>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4bd81d14-6f0b-493b-993d-46eb838eaff5/t/b7417f66-ca6f-454f-bc96-082eab9bfb2b>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"13a8b479-2959-4219-85b8-e6c3532dde3d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"c2e57e36-7d61-4d0d-9545-5a53abaef686\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:21.58Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:21.58Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_Triannon_LdpLoader_load.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_Triannon_LdpLoader_load.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b150e1680d0de4a14311fca939e9297dcc4ae23d"'
+      - '"005fd00ab04643b7b893fbd69c1cf3b7319897f3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+      - http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+      string: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"863b7a98d1f8cdb74f6cde690f51522decd6b9c1"'
+      - '"b263e214ce89548cbfbd179f855d900a675497c2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t
+      - http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t
+      string: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5caab56124240cc7ead71804fe82ca3fc23cb41c"'
+      - '"d7fbcae8e1c54daff757862e66269710d0063f18"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177
+      - http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177
+      string: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9204461624a606f62771728ec2ab1b070e3b3ded"'
+      - '"a0893f68938a900a541a0823e57951c1a44c5ed5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -175,39 +175,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c3236e0a-b786-461a-9c2e-316406ae2b35\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"0eaa7400-f053-4737-9173-5a4c665dbfbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.263Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.189Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:19.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:54.204Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5caab56124240cc7ead71804fe82ca3fc23cb41c"'
+      - '"d7fbcae8e1c54daff757862e66269710d0063f18"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -258,31 +258,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"373759cc-94da-4428-ba83-5ab33f5e0b39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6b314104-4c4a-4659-a058-a875c523ad62\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -306,7 +306,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -320,7 +320,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:19 GMT
+      - Thu, 05 Mar 2015 01:26:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1436,10 +1436,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
     body:
       encoding: US-ASCII
       string: ''
@@ -1456,9 +1456,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9204461624a606f62771728ec2ab1b070e3b3ded"'
+      - '"a0893f68938a900a541a0823e57951c1a44c5ed5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1490,39 +1490,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c3236e0a-b786-461a-9c2e-316406ae2b35\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"0eaa7400-f053-4737-9173-5a4c665dbfbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.263Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.189Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:19.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:54.204Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807
     body:
       encoding: US-ASCII
       string: ''
@@ -1539,9 +1539,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5caab56124240cc7ead71804fe82ca3fc23cb41c"'
+      - '"d7fbcae8e1c54daff757862e66269710d0063f18"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1554,7 +1554,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -1573,34 +1573,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"373759cc-94da-4428-ba83-5ab33f5e0b39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6b314104-4c4a-4659-a058-a875c523ad62\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e
     body:
       encoding: US-ASCII
       string: ''
@@ -1617,9 +1617,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9204461624a606f62771728ec2ab1b070e3b3ded"'
+      - '"a0893f68938a900a541a0823e57951c1a44c5ed5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1651,39 +1651,39 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c3236e0a-b786-461a-9c2e-316406ae2b35\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"0eaa7400-f053-4737-9173-5a4c665dbfbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.263Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.189Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:19.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:54.204Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177
+    uri: http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807
     body:
       encoding: US-ASCII
       string: ''
@@ -1700,9 +1700,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5caab56124240cc7ead71804fe82ca3fc23cb41c"'
+      - '"d7fbcae8e1c54daff757862e66269710d0063f18"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:19 GMT
+      - Wed, 04 Mar 2015 19:26:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1715,7 +1715,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -1734,31 +1734,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t>
+        <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8/t/58b26d83-b094-4349-8d0d-0092036ec177>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/29cf1da9-5df4-4b24-bb3e-dcc065264d6e/t/c143a3ca-2cbc-4e4e-bb58-04c0878f5807>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"373759cc-94da-4428-ba83-5ab33f5e0b39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6b314104-4c4a-4659-a058-a875c523ad62\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:19.29Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:54.219Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1782,7 +1782,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1796,7 +1796,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:20 GMT
+      - Thu, 05 Mar 2015 01:26:55 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2912,5 +2912,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_solr_hash_on_triannon_graph_returned_from_LdpLoader.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_solr_hash_on_triannon_graph_returned_from_LdpLoader.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ae6138b93d9747ba5b54c4dd49a3d6e22bdec7c8"'
+      - '"afc42e6336bcbd8b61883d77d11d97806be65160"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb
+      - http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb
+      string: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"da949826e6cc44d0ab7d23e6a239dda9b7510a63"'
+      - '"c6207bded60f16ddaac5b86fdbf0508e9f7fb0f6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t
+      - http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t
+      string: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4eb607e37b712206e7c34a4ec44e8b443e29c966"'
+      - '"7dfdc8e2c186abe026d15ecdf41c2c5d5c5ec4d9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb
+      - http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb
+      string: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34c311b21d3562a7e4415f064bf47cf70936f8be"'
+      - '"8a655578cec9d99c3a0eef305044e020d8451d0d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4019'
+      - '4021'
       Content-Type:
       - application/x-turtle
     body:
@@ -175,38 +175,38 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"936ae28d-8c98-4353-aa0f-bc1662177cc7\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"079b585a-1d6a-481d-a474-29c07ee64d5a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:20.7Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:55.407Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:20.714Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:55.422Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168
     body:
       encoding: US-ASCII
       string: ''
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4eb607e37b712206e7c34a4ec44e8b443e29c966"'
+      - '"7dfdc8e2c186abe026d15ecdf41c2c5d5c5ec4d9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -238,7 +238,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3567'
       Content-Type:
       - application/x-turtle
     body:
@@ -257,32 +257,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"3093549c-b8d1-4317-b28d-ebd3b84d934b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6bb803d0-a732-4a35-8745-982f732894df\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:20.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:55.44Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:20.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        \"2015-03-04T19:26:55.44Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -306,7 +305,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -320,7 +319,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:08:20 GMT
+      - Thu, 05 Mar 2015 01:26:55 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1436,16 +1435,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">ca323317-c423-46fa-99cc-766b6eedc6bb</field><field name="motivation">bookmarking</field><field
+        name="id">468c816f-7cb3-4028-89bd-65462d84f2e9</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/ca323317-c423-46fa-99cc-766b6eedc6bb","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/468c816f-7cb3-4028-89bd-65462d84f2e9","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1461,12 +1460,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9
     body:
       encoding: US-ASCII
       string: ''
@@ -1483,9 +1482,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34c311b21d3562a7e4415f064bf47cf70936f8be"'
+      - '"8a655578cec9d99c3a0eef305044e020d8451d0d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1498,7 +1497,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4019'
+      - '4021'
       Content-Type:
       - application/x-turtle
     body:
@@ -1517,38 +1516,38 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"936ae28d-8c98-4353-aa0f-bc1662177cc7\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"079b585a-1d6a-481d-a474-29c07ee64d5a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:20.7Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:55.407Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:08:20.714Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:55.422Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb
+    uri: http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168
     body:
       encoding: US-ASCII
       string: ''
@@ -1565,9 +1564,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4eb607e37b712206e7c34a4ec44e8b443e29c966"'
+      - '"7dfdc8e2c186abe026d15ecdf41c2c5d5c5ec4d9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:08:20 GMT
+      - Wed, 04 Mar 2015 19:26:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1580,7 +1579,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3567'
       Content-Type:
       - application/x-turtle
     body:
@@ -1599,30 +1598,29 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb/t/c205f25f-8419-4010-8a72-130a88c712eb>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/468c816f-7cb3-4028-89bd-65462d84f2e9/t/57fcd651-6815-49af-92c7-5c3aac794168>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"3093549c-b8d1-4317-b28d-ebd3b84d934b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6bb803d0-a732-4a35-8745-982f732894df\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:08:20.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:55.44Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:20.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        \"2015-03-04T19:26:55.44Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_not_call_SolrWriter_add_when_solr_hash_is_empty.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_not_call_SolrWriter_add_when_solr_hash_is_empty.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4918d94b9762ca98ff003befbe76cd724c10d3f4"'
+      - '"4a01cd6684ab64b57e50fc5ece2641b9c28c04fc"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e
+      - http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e
+      string: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:54 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"846a17cf3a1f8cfafb15b862fe9ddfd0325ecb3c"'
+      - '"a5ad0cf38d1ea4fc2b86f08a3a894636dc62e3e8"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t
+      - http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t
+      string: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:54 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c4233715e64baadd9987c8f04089f2619ceb98bb"'
+      - '"cd4f14baa509bd8973a98817b1ab8b406fa2a522"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9
+      - http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9
+      string: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:54 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a21a1aa9fea9828c40b92a2e71fb5ce5345b44f3"'
+      - '"886b69774f3507c59d2c955f773f5ddfbbfe2814"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4051'
+      - '4098'
       Content-Type:
       - application/x-turtle
     body:
@@ -164,50 +164,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4739832c-1dac-4011-9277-8a07f9ed34e4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2e65ee17-9173-43de-94a5-edb1c1e5ce2c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:54.886Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.805Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-09T23:59:54.968Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.82Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c4233715e64baadd9987c8f04089f2619ceb98bb"'
+      - '"cd4f14baa509bd8973a98817b1ab8b406fa2a522"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3521'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -247,42 +247,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
+        <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"04f5702e-184b-4f5a-ad7c-744d119b8976\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"a578248d-7a9c-4439-8bbe-44b85d934d8f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:54.992Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-09T23:59:54.992Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:56 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -306,7 +306,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Feb 2015 23:59:55 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -320,7 +320,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 10 Feb 2015 05:59:55 GMT
+      - Thu, 05 Mar 2015 01:26:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1436,16 +1436,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">b42e1901-9f1b-4cf4-87ae-b0d31274b46e</field><field name="motivation">bookmarking</field><field
+        name="id">8fc3b373-1f0e-43c5-a51a-57568c261e55</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/b42e1901-9f1b-4cf4-87ae-b0d31274b46e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/8fc3b373-1f0e-43c5-a51a-57568c261e55","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1461,12 +1461,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>75}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55
     body:
       encoding: US-ASCII
       string: ''
@@ -1483,9 +1483,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a21a1aa9fea9828c40b92a2e71fb5ce5345b44f3"'
+      - '"886b69774f3507c59d2c955f773f5ddfbbfe2814"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1498,7 +1498,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4051'
+      - '4098'
       Content-Type:
       - application/x-turtle
     body:
@@ -1506,50 +1506,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4739832c-1dac-4011-9277-8a07f9ed34e4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2e65ee17-9173-43de-94a5-edb1c1e5ce2c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:54.886Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.805Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-09T23:59:54.968Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.82Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9
+    uri: http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07
     body:
       encoding: US-ASCII
       string: ''
@@ -1566,9 +1566,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c4233715e64baadd9987c8f04089f2619ceb98bb"'
+      - '"cd4f14baa509bd8973a98817b1ab8b406fa2a522"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:54 GMT
+      - Wed, 04 Mar 2015 19:26:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1581,7 +1581,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3521'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -1589,40 +1589,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t>
+        <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b42e1901-9f1b-4cf4-87ae-b0d31274b46e/t/26eeb084-2428-431f-8fde-e1740a41aea9>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8fc3b373-1f0e-43c5-a51a-57568c261e55/t/ec35f7d3-6cd6-4b3c-9a8a-3ad274930c07/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"04f5702e-184b-4f5a-ad7c-744d119b8976\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"a578248d-7a9c-4439-8bbe-44b85d934d8f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:54.992Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-09T23:59:54.992Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:56.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:56.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/raises_exception_when_Solr_add_is_not_successful.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/raises_exception_when_Solr_add_is_not_successful.yml
@@ -1,447 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"3371e66ce769189b9a73544d70e6f3286b5a63db"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 00:08:21 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Type:
-      - application/x-turtle
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/c7b04da5-ffc5-412a-9b3a-a49a2aa97df2>
-        , <http://localhost:8983/fedora/rest/anno/950e2a75-a6d6-432e-bc3a-f39b86a7ff40>
-        , <http://localhost:8983/fedora/rest/anno/e671ede0-b712-4855-bbef-5f08515950de>
-        , <http://localhost:8983/fedora/rest/anno/a2738ef4-02f7-4a5d-b400-6b39ce3b56dc>
-        , <http://localhost:8983/fedora/rest/anno/8444698d-0f5d-4fcc-b2e5-c50f7cc38ab6>
-        , <http://localhost:8983/fedora/rest/anno/904c1ba4-e771-49bb-9b70-2413a47bc10a>
-        , <http://localhost:8983/fedora/rest/anno/e53a32a6-f958-4b3f-80d0-33a66787dda3>
-        , <http://localhost:8983/fedora/rest/anno/f22880a4-37bd-4cfc-a042-c7aabaffbe65>
-        , <http://localhost:8983/fedora/rest/anno/7f70b1bb-f70c-4a72-bda7-ec5ca946ee12>
-        , <http://localhost:8983/fedora/rest/anno/646de11b-8177-4420-a805-b06a24389117>
-        , <http://localhost:8983/fedora/rest/anno/7ed64451-eafb-4b4f-89ea-8809fd10efb8>
-        , <http://localhost:8983/fedora/rest/anno/45a797b4-aa40-4dcd-890a-9dde632ffc47>
-        , <http://localhost:8983/fedora/rest/anno/9a1f4668-1fe3-479d-abc1-ff8887e8c0d3>
-        , <http://localhost:8983/fedora/rest/anno/12326275-9565-4287-809c-c1df7e2685ec>
-        , <http://localhost:8983/fedora/rest/anno/a540f07e-c67c-4ce1-b6c7-6fc1a3b917d9>
-        , <http://localhost:8983/fedora/rest/anno/05403de6-a3ae-45a0-9f28-060c2e520a34>
-        , <http://localhost:8983/fedora/rest/anno/cb0d25f8-8e3e-4ddd-aa1a-81fcbaccc74e>
-        , <http://localhost:8983/fedora/rest/anno/17dbc079-0a32-42cf-9b86-b6403c0d41f6>
-        , <http://localhost:8983/fedora/rest/anno/21183262-f652-42de-9af0-e689c32521b6>
-        , <http://localhost:8983/fedora/rest/anno/3a72af7d-64a3-4833-8434-c397f09a67f6>
-        , <http://localhost:8983/fedora/rest/anno/5df0717f-220f-4b42-955f-b24aefc41bcb>
-        , <http://localhost:8983/fedora/rest/anno/e8cf0e90-905a-4666-a856-fade5fbb25f0>
-        , <http://localhost:8983/fedora/rest/anno/97563251-a349-408d-8d12-fab49d7b7e05>
-        , <http://localhost:8983/fedora/rest/anno/000a399c-7cee-4494-b27c-4e13eb891975>
-        , <http://localhost:8983/fedora/rest/anno/40b97fd2-244b-43e9-b73e-ba86d6cd34a9>
-        , <http://localhost:8983/fedora/rest/anno/664e5d8a-ea7d-42d8-a748-14a044a7ffa6>
-        , <http://localhost:8983/fedora/rest/anno/5b6bbd47-c783-429a-a161-f5e18c7fae81>
-        , <http://localhost:8983/fedora/rest/anno/ed7ce5e6-02e0-465a-aeab-5cbd34bc45bc>
-        , <http://localhost:8983/fedora/rest/anno/a928bca3-ce1f-4659-ad61-fc4a2c7ab9b5>
-        , <http://localhost:8983/fedora/rest/anno/c3b9101d-e4ca-4d2a-83f5-098fb42241ab>
-        , <http://localhost:8983/fedora/rest/anno/0bb5b25b-ee61-47ac-9b90-c0a27fd48403>
-        , <http://localhost:8983/fedora/rest/anno/a44f6dc3-6521-4ac6-b2c9-4fd5e8ddd615>
-        , <http://localhost:8983/fedora/rest/anno/bc4c0e1f-14c0-419b-aa33-26875f53e346>
-        , <http://localhost:8983/fedora/rest/anno/14697c81-714b-491f-9834-4a8e4e07a36b>
-        , <http://localhost:8983/fedora/rest/anno/7b98ff08-3fed-482b-be4d-75fd4045b5dd>
-        , <http://localhost:8983/fedora/rest/anno/5067a6b2-82fb-46b5-b603-a383c821e882>
-        , <http://localhost:8983/fedora/rest/anno/2207054d-ac82-47e9-9392-798809049758>
-        , <http://localhost:8983/fedora/rest/anno/8b641366-7638-45a0-a83e-b777546f2d13>
-        , <http://localhost:8983/fedora/rest/anno/56b6b63c-6e98-433e-87f5-075e6945dbfd>
-        , <http://localhost:8983/fedora/rest/anno/18f297b4-a5c8-415e-bbb2-aaf6a2e53426>
-        , <http://localhost:8983/fedora/rest/anno/61492181-5ca1-4b66-a124-fb417d18d42a>
-        , <http://localhost:8983/fedora/rest/anno/fbb2ac0b-9111-4b8c-a510-169c71b91100>
-        , <http://localhost:8983/fedora/rest/anno/15d11333-0182-4e48-aa14-60d61bb16984>
-        , <http://localhost:8983/fedora/rest/anno/81ffaf10-32e2-4f6b-a302-16b7541cadeb>
-        , <http://localhost:8983/fedora/rest/anno/457009b1-46fe-4226-9f6a-8c475bfde10d>
-        , <http://localhost:8983/fedora/rest/anno/b0aa9773-8aae-43e4-b86d-0e571d78fa1c>
-        , <http://localhost:8983/fedora/rest/anno/3c1bd6db-4875-45b2-ad74-f9b69befda90>
-        , <http://localhost:8983/fedora/rest/anno/68887250-ba44-4ff1-a434-f18098796667>
-        , <http://localhost:8983/fedora/rest/anno/5aaaafb3-366f-40a8-ad77-9f3ef0e3a312>
-        , <http://localhost:8983/fedora/rest/anno/a5f61d36-f24d-4a05-baab-d643708c7b9f>
-        , <http://localhost:8983/fedora/rest/anno/7457e592-9151-4e13-9a43-668f5ff7a161>
-        , <http://localhost:8983/fedora/rest/anno/ae8eb8c3-cf57-4881-a008-fd649d43865e>
-        , <http://localhost:8983/fedora/rest/anno/31e8d232-f5a8-4a15-9ca4-082f7f6fe154>
-        , <http://localhost:8983/fedora/rest/anno/709f4093-219d-4d84-a1c6-3516e0397981>
-        , <http://localhost:8983/fedora/rest/anno/cb8ef8c2-ba90-4573-acb3-aeea006ad7d1>
-        , <http://localhost:8983/fedora/rest/anno/e61241dd-f2b9-4ba2-9201-d3ff42a7f3bd>
-        , <http://localhost:8983/fedora/rest/anno/e9cb3bdd-5ed9-4c6b-bd33-e18bc72461cc>
-        , <http://localhost:8983/fedora/rest/anno/af6fff36-3662-452d-a67d-10fc0fe1fadb>
-        , <http://localhost:8983/fedora/rest/anno/b2e283ce-77fd-4921-b6a6-9a8fba93bcb2>
-        , <http://localhost:8983/fedora/rest/anno/12b5a28a-4126-45df-926c-c23fdb75ac31>
-        , <http://localhost:8983/fedora/rest/anno/ccaa9df3-1d53-40b1-985f-4a22e5e08895>
-        , <http://localhost:8983/fedora/rest/anno/46fe7fe3-4e64-403d-bfe9-1c0041432d1b>
-        , <http://localhost:8983/fedora/rest/anno/8eafa5c8-f3dc-47ed-9dfc-febd96127e36>
-        , <http://localhost:8983/fedora/rest/anno/e7bdf336-df62-4216-b19f-609a8cecf423>
-        , <http://localhost:8983/fedora/rest/anno/4cb50ac4-86cc-4184-a380-1ecc7e5c5cb3>
-        , <http://localhost:8983/fedora/rest/anno/1a7f67a2-a6cd-4465-aeeb-8d125fd674a4>
-        , <http://localhost:8983/fedora/rest/anno/c8dbedfc-0647-4f2f-af1d-91c4f2a818e1>
-        , <http://localhost:8983/fedora/rest/anno/f3a82323-432f-4f51-8810-f2adaba1b179>
-        , <http://localhost:8983/fedora/rest/anno/439af672-094c-46df-bc65-ca4f2e9f0b77>
-        , <http://localhost:8983/fedora/rest/anno/6a8fa17c-737b-4a4a-a714-efe05128e4c3>
-        , <http://localhost:8983/fedora/rest/anno/32230d44-28f7-4d20-849f-9c7846ef06a0>
-        , <http://localhost:8983/fedora/rest/anno/c13f2a93-c6b0-4b12-983a-8969231b841e>
-        , <http://localhost:8983/fedora/rest/anno/5ade72e8-3a3e-457b-a697-5652d52e6976>
-        , <http://localhost:8983/fedora/rest/anno/b85d7af9-8206-4dbb-ad32-955e724153ed>
-        , <http://localhost:8983/fedora/rest/anno/76b8d554-ddf3-40ec-becb-b68cfdd2ea45>
-        , <http://localhost:8983/fedora/rest/anno/ececb8e6-9fea-49fd-9203-9e9d9ea7ab5b>
-        , <http://localhost:8983/fedora/rest/anno/08402b42-283f-4354-8465-4d56c86c1dd5>
-        , <http://localhost:8983/fedora/rest/anno/3f6a4e8d-67ed-4e51-bf27-99b240cab3b1>
-        , <http://localhost:8983/fedora/rest/anno/c923d5fa-c55f-422f-99bd-8fec48413a2a>
-        , <http://localhost:8983/fedora/rest/anno/c1251b21-bb13-4d50-8f90-23b01e30f62f>
-        , <http://localhost:8983/fedora/rest/anno/a4fd0661-af9d-4604-91ce-def326b6d5f8>
-        , <http://localhost:8983/fedora/rest/anno/ab351d80-b280-43a5-bb0c-fe29d023f11b>
-        , <http://localhost:8983/fedora/rest/anno/07534e91-0983-46b3-8d28-b3408d343cdb>
-        , <http://localhost:8983/fedora/rest/anno/12db4d5d-1ef9-4efe-bb2b-927a2ca71dd1>
-        , <http://localhost:8983/fedora/rest/anno/0e5ceada-d7f9-47ae-a33c-ff2f82ed8d32>
-        , <http://localhost:8983/fedora/rest/anno/811ad800-c974-44f2-bbd3-96a387fd4225>
-        , <http://localhost:8983/fedora/rest/anno/9cc7b9bf-efe8-4168-b356-7e7cbada0cc1>
-        , <http://localhost:8983/fedora/rest/anno/e8b405c8-43aa-46c1-b0f9-09b8507010df>
-        , <http://localhost:8983/fedora/rest/anno/b74dac55-a1b8-4da3-b7de-d16e1a77d3f2>
-        , <http://localhost:8983/fedora/rest/anno/c4a91076-3f89-4814-b7f8-8c175d7e922c>
-        , <http://localhost:8983/fedora/rest/anno/7f0ed504-fedf-4525-97ea-6197e3e8aae9>
-        , <http://localhost:8983/fedora/rest/anno/b3aa3db7-cb57-4155-94bd-6577a3b70d4b>
-        , <http://localhost:8983/fedora/rest/anno/e98b019b-20fd-49f1-8c68-1517f283d5b6>
-        , <http://localhost:8983/fedora/rest/anno/04f60c0b-d594-4f42-98bd-eb5fb3b6f28e>
-        , <http://localhost:8983/fedora/rest/anno/9d0a7a27-f893-4f49-86c3-9d0115201611>
-        , <http://localhost:8983/fedora/rest/anno/50a8914e-327d-4dd2-b815-76175ed6022c>
-        , <http://localhost:8983/fedora/rest/anno/dcb68694-70d8-4f69-bf61-6e9060b5659b>
-        , <http://localhost:8983/fedora/rest/anno/e766ee05-6561-4127-9d7d-cb6973dd1b55>
-        , <http://localhost:8983/fedora/rest/anno/8583cfda-3406-4753-b539-119c81c3584d>
-        , <http://localhost:8983/fedora/rest/anno/14e46491-7f0f-49aa-9493-81163b81313a>
-        , <http://localhost:8983/fedora/rest/anno/445890c0-1101-4724-932e-c5f8374433ea>
-        , <http://localhost:8983/fedora/rest/anno/eac54055-f1d2-4314-a4f5-92c695fd9e5d>
-        , <http://localhost:8983/fedora/rest/anno/4704e4a3-4b63-4ec3-9d59-b3bf18adc47a>
-        , <http://localhost:8983/fedora/rest/anno/46d4618b-55f5-41cb-9614-f1a7a21bd77d>
-        , <http://localhost:8983/fedora/rest/anno/59a1e717-42bb-4e59-aab7-a6bd3f8bce4e>
-        , <http://localhost:8983/fedora/rest/anno/33e7c767-b252-437d-8fba-75dee511a1a3>
-        , <http://localhost:8983/fedora/rest/anno/1363e791-0c3e-4650-bfe1-83623a47bc0c>
-        , <http://localhost:8983/fedora/rest/anno/f12aec29-12cd-423b-820a-8a658a5c5a11>
-        , <http://localhost:8983/fedora/rest/anno/14117928-8549-41aa-94d0-a5e847402120>
-        , <http://localhost:8983/fedora/rest/anno/55825c51-dc1c-42b6-b9f2-157bc2802b7c>
-        , <http://localhost:8983/fedora/rest/anno/10ecf5f7-297c-44f0-9018-bb6508343843>
-        , <http://localhost:8983/fedora/rest/anno/0cecba71-b507-478b-acdf-6eedcf4462c9>
-        , <http://localhost:8983/fedora/rest/anno/5e3750cd-07b2-407d-98dd-47c7e298353f>
-        , <http://localhost:8983/fedora/rest/anno/c38feae7-e735-4b6b-a86f-6de90002acfc>
-        , <http://localhost:8983/fedora/rest/anno/ec075d3c-c0cd-4a1f-a460-8e44b4c3d71b>
-        , <http://localhost:8983/fedora/rest/anno/0651b5f2-4f5a-4f8c-8532-0444c7e6a2b2>
-        , <http://localhost:8983/fedora/rest/anno/ea16fc3a-d26c-4098-ac54-0a2b900426c0>
-        , <http://localhost:8983/fedora/rest/anno/9f316b87-21bc-451a-b9f9-4e7585cf9c4d>
-        , <http://localhost:8983/fedora/rest/anno/57a1f597-8410-4da8-96aa-85b9624967d7>
-        , <http://localhost:8983/fedora/rest/anno/802ceab2-c123-4184-8f94-afc8ce4107d1>
-        , <http://localhost:8983/fedora/rest/anno/0dee34d4-52aa-450d-bc1c-cda66b0009ac>
-        , <http://localhost:8983/fedora/rest/anno/2c88a3d8-0811-4274-88cc-6c7986b6ac37>
-        , <http://localhost:8983/fedora/rest/anno/49cfdadd-d41a-4fc4-a794-dbbc28ca368b>
-        , <http://localhost:8983/fedora/rest/anno/ce70d6f8-126e-4979-bbf3-2e6a9940b328>
-        , <http://localhost:8983/fedora/rest/anno/de38f49c-6ea4-4e58-af22-be2093ae51de>
-        , <http://localhost:8983/fedora/rest/anno/13df1a5b-49df-43f8-9a63-81941148d0d2>
-        , <http://localhost:8983/fedora/rest/anno/88197d91-05ec-4930-8721-96e8ca951ce8>
-        , <http://localhost:8983/fedora/rest/anno/78d54f52-4d42-4410-be9d-13e30e796ad4>
-        , <http://localhost:8983/fedora/rest/anno/81ff0efa-f266-4008-9434-ac9a349a2f15>
-        , <http://localhost:8983/fedora/rest/anno/1b432f83-5e3a-475c-8d41-fcf39671dbc4>
-        , <http://localhost:8983/fedora/rest/anno/e8023047-cfaa-4e60-848c-15bd325ed491>
-        , <http://localhost:8983/fedora/rest/anno/de9e03cb-c5c2-448e-8469-c5c90de111c6>
-        , <http://localhost:8983/fedora/rest/anno/140c5673-e859-4efc-a813-740b5527bba6>
-        , <http://localhost:8983/fedora/rest/anno/27f1d5de-4705-45d0-9a43-57dadda641bb>
-        , <http://localhost:8983/fedora/rest/anno/15805844-ebad-415e-b344-4414fa98d895>
-        , <http://localhost:8983/fedora/rest/anno/92f1fe4e-e9a7-48b7-9c08-47388fb32e86>
-        , <http://localhost:8983/fedora/rest/anno/aa8722c2-66c9-49ce-afa8-15ebd057dcfc>
-        , <http://localhost:8983/fedora/rest/anno/28c30314-c6c2-4400-b134-39bb032896cd>
-        , <http://localhost:8983/fedora/rest/anno/08ce6897-b5e3-4eb6-a971-1ac336b06548>
-        , <http://localhost:8983/fedora/rest/anno/986b819f-fb96-4431-94d1-70cfd7906633>
-        , <http://localhost:8983/fedora/rest/anno/e0beffbc-6486-4e2a-bcdb-31ecce3a1311>
-        , <http://localhost:8983/fedora/rest/anno/f12a6bb4-1c8d-4b8f-820c-355efed18153>
-        , <http://localhost:8983/fedora/rest/anno/547caf50-65dd-4f11-a404-541d7ff83e2d>
-        , <http://localhost:8983/fedora/rest/anno/96337ace-49b6-46fb-99a6-16adcd15ab9e>
-        , <http://localhost:8983/fedora/rest/anno/8655ea5e-6ba0-44f4-812f-d05a63f13469>
-        , <http://localhost:8983/fedora/rest/anno/14beca0f-16f1-4885-98ee-7d392f22ef83>
-        , <http://localhost:8983/fedora/rest/anno/494a2ef9-e4fa-46ef-83b8-1429e1ef9308>
-        , <http://localhost:8983/fedora/rest/anno/acbe3762-b6f8-4644-bbf0-936f65d5de4f>
-        , <http://localhost:8983/fedora/rest/anno/194c9428-51f7-45f2-acf7-84a2ac8fb311>
-        , <http://localhost:8983/fedora/rest/anno/729a0d3a-6b77-4bb3-a718-8e2904af5938>
-        , <http://localhost:8983/fedora/rest/anno/ca00496b-2983-477d-8b57-e78b2aa637c8>
-        , <http://localhost:8983/fedora/rest/anno/0b475457-d76e-416b-aef6-ec81b5ee5ee6>
-        , <http://localhost:8983/fedora/rest/anno/1bc59170-7a89-41fa-a4c2-dd2e79976743>
-        , <http://localhost:8983/fedora/rest/anno/70d266ea-cbdf-4dba-8c42-4fb34f1e9d25>
-        , <http://localhost:8983/fedora/rest/anno/a5b953df-8f6b-4cb3-91f3-a2916875933f>
-        , <http://localhost:8983/fedora/rest/anno/f5c2ee2c-a1be-4612-a1e4-111dfa3ba724>
-        , <http://localhost:8983/fedora/rest/anno/756861da-76f7-4dff-ad1f-723a7ba945de>
-        , <http://localhost:8983/fedora/rest/anno/ca759f0d-181c-4530-8396-b6fd7032c441>
-        , <http://localhost:8983/fedora/rest/anno/5fef08e0-eecb-49e1-8b7f-2b3a801317bf>
-        , <http://localhost:8983/fedora/rest/anno/488f17a9-0488-42a7-b39b-14dbfab1a7f3>
-        , <http://localhost:8983/fedora/rest/anno/e4eec2ec-92a7-45d5-9a85-a205e1be794f>
-        , <http://localhost:8983/fedora/rest/anno/10a4e37b-f08a-4afe-9099-358e26ed4023>
-        , <http://localhost:8983/fedora/rest/anno/712d5510-3110-435a-8b92-a831e13481fa>
-        , <http://localhost:8983/fedora/rest/anno/ce8dacfe-0125-4be4-9da8-31a061eeec0e>
-        , <http://localhost:8983/fedora/rest/anno/fccd45e6-5ae5-4dc9-8dfb-6641bbfa7483>
-        , <http://localhost:8983/fedora/rest/anno/ced669be-41da-4bbc-a80a-b4a0afc41eb2>
-        , <http://localhost:8983/fedora/rest/anno/ee990685-95ba-44a9-a545-777aeaea8df5>
-        , <http://localhost:8983/fedora/rest/anno/18d68876-cbb8-4277-9fca-404da3226bd5>
-        , <http://localhost:8983/fedora/rest/anno/c33b31ff-735e-4e26-aba4-4be643630a44>
-        , <http://localhost:8983/fedora/rest/anno/1d5f7730-f678-44f7-8b19-9c03a4b53694>
-        , <http://localhost:8983/fedora/rest/anno/b41f4ce7-d75a-4ac7-9d9d-501222feb176>
-        , <http://localhost:8983/fedora/rest/anno/a47ca158-d330-4436-b882-89748aaeae32>
-        , <http://localhost:8983/fedora/rest/anno/af0852be-1fdc-404b-9626-f8f6895d8e61>
-        , <http://localhost:8983/fedora/rest/anno/fcd3d5f5-5f04-4924-9222-2db3a0664e1b>
-        , <http://localhost:8983/fedora/rest/anno/50ace8e0-ba3d-48ad-9db7-66a104a4df3f>
-        , <http://localhost:8983/fedora/rest/anno/c7cd1fdb-d6ab-4521-94d8-8386a1956e3f>
-        , <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        , <http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf>
-        , <http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5>
-        , <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        , <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        , <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c7b04da5-ffc5-412a-9b3a-a49a2aa97df2>
-        , <http://localhost:8983/fedora/rest/anno/950e2a75-a6d6-432e-bc3a-f39b86a7ff40>
-        , <http://localhost:8983/fedora/rest/anno/e671ede0-b712-4855-bbef-5f08515950de>
-        , <http://localhost:8983/fedora/rest/anno/a2738ef4-02f7-4a5d-b400-6b39ce3b56dc>
-        , <http://localhost:8983/fedora/rest/anno/8444698d-0f5d-4fcc-b2e5-c50f7cc38ab6>
-        , <http://localhost:8983/fedora/rest/anno/904c1ba4-e771-49bb-9b70-2413a47bc10a>
-        , <http://localhost:8983/fedora/rest/anno/e53a32a6-f958-4b3f-80d0-33a66787dda3>
-        , <http://localhost:8983/fedora/rest/anno/f22880a4-37bd-4cfc-a042-c7aabaffbe65>
-        , <http://localhost:8983/fedora/rest/anno/7f70b1bb-f70c-4a72-bda7-ec5ca946ee12>
-        , <http://localhost:8983/fedora/rest/anno/646de11b-8177-4420-a805-b06a24389117>
-        , <http://localhost:8983/fedora/rest/anno/7ed64451-eafb-4b4f-89ea-8809fd10efb8>
-        , <http://localhost:8983/fedora/rest/anno/45a797b4-aa40-4dcd-890a-9dde632ffc47>
-        , <http://localhost:8983/fedora/rest/anno/9a1f4668-1fe3-479d-abc1-ff8887e8c0d3>
-        , <http://localhost:8983/fedora/rest/anno/12326275-9565-4287-809c-c1df7e2685ec>
-        , <http://localhost:8983/fedora/rest/anno/a540f07e-c67c-4ce1-b6c7-6fc1a3b917d9>
-        , <http://localhost:8983/fedora/rest/anno/05403de6-a3ae-45a0-9f28-060c2e520a34>
-        , <http://localhost:8983/fedora/rest/anno/cb0d25f8-8e3e-4ddd-aa1a-81fcbaccc74e>
-        , <http://localhost:8983/fedora/rest/anno/17dbc079-0a32-42cf-9b86-b6403c0d41f6>
-        , <http://localhost:8983/fedora/rest/anno/21183262-f652-42de-9af0-e689c32521b6>
-        , <http://localhost:8983/fedora/rest/anno/3a72af7d-64a3-4833-8434-c397f09a67f6>
-        , <http://localhost:8983/fedora/rest/anno/5df0717f-220f-4b42-955f-b24aefc41bcb>
-        , <http://localhost:8983/fedora/rest/anno/e8cf0e90-905a-4666-a856-fade5fbb25f0>
-        , <http://localhost:8983/fedora/rest/anno/97563251-a349-408d-8d12-fab49d7b7e05>
-        , <http://localhost:8983/fedora/rest/anno/000a399c-7cee-4494-b27c-4e13eb891975>
-        , <http://localhost:8983/fedora/rest/anno/40b97fd2-244b-43e9-b73e-ba86d6cd34a9>
-        , <http://localhost:8983/fedora/rest/anno/664e5d8a-ea7d-42d8-a748-14a044a7ffa6>
-        , <http://localhost:8983/fedora/rest/anno/5b6bbd47-c783-429a-a161-f5e18c7fae81>
-        , <http://localhost:8983/fedora/rest/anno/ed7ce5e6-02e0-465a-aeab-5cbd34bc45bc>
-        , <http://localhost:8983/fedora/rest/anno/a928bca3-ce1f-4659-ad61-fc4a2c7ab9b5>
-        , <http://localhost:8983/fedora/rest/anno/c3b9101d-e4ca-4d2a-83f5-098fb42241ab>
-        , <http://localhost:8983/fedora/rest/anno/0bb5b25b-ee61-47ac-9b90-c0a27fd48403>
-        , <http://localhost:8983/fedora/rest/anno/a44f6dc3-6521-4ac6-b2c9-4fd5e8ddd615>
-        , <http://localhost:8983/fedora/rest/anno/bc4c0e1f-14c0-419b-aa33-26875f53e346>
-        , <http://localhost:8983/fedora/rest/anno/14697c81-714b-491f-9834-4a8e4e07a36b>
-        , <http://localhost:8983/fedora/rest/anno/7b98ff08-3fed-482b-be4d-75fd4045b5dd>
-        , <http://localhost:8983/fedora/rest/anno/5067a6b2-82fb-46b5-b603-a383c821e882>
-        , <http://localhost:8983/fedora/rest/anno/2207054d-ac82-47e9-9392-798809049758>
-        , <http://localhost:8983/fedora/rest/anno/8b641366-7638-45a0-a83e-b777546f2d13>
-        , <http://localhost:8983/fedora/rest/anno/56b6b63c-6e98-433e-87f5-075e6945dbfd>
-        , <http://localhost:8983/fedora/rest/anno/18f297b4-a5c8-415e-bbb2-aaf6a2e53426>
-        , <http://localhost:8983/fedora/rest/anno/61492181-5ca1-4b66-a124-fb417d18d42a>
-        , <http://localhost:8983/fedora/rest/anno/fbb2ac0b-9111-4b8c-a510-169c71b91100>
-        , <http://localhost:8983/fedora/rest/anno/15d11333-0182-4e48-aa14-60d61bb16984>
-        , <http://localhost:8983/fedora/rest/anno/81ffaf10-32e2-4f6b-a302-16b7541cadeb>
-        , <http://localhost:8983/fedora/rest/anno/457009b1-46fe-4226-9f6a-8c475bfde10d>
-        , <http://localhost:8983/fedora/rest/anno/b0aa9773-8aae-43e4-b86d-0e571d78fa1c>
-        , <http://localhost:8983/fedora/rest/anno/3c1bd6db-4875-45b2-ad74-f9b69befda90>
-        , <http://localhost:8983/fedora/rest/anno/68887250-ba44-4ff1-a434-f18098796667>
-        , <http://localhost:8983/fedora/rest/anno/5aaaafb3-366f-40a8-ad77-9f3ef0e3a312>
-        , <http://localhost:8983/fedora/rest/anno/a5f61d36-f24d-4a05-baab-d643708c7b9f>
-        , <http://localhost:8983/fedora/rest/anno/7457e592-9151-4e13-9a43-668f5ff7a161>
-        , <http://localhost:8983/fedora/rest/anno/ae8eb8c3-cf57-4881-a008-fd649d43865e>
-        , <http://localhost:8983/fedora/rest/anno/31e8d232-f5a8-4a15-9ca4-082f7f6fe154>
-        , <http://localhost:8983/fedora/rest/anno/709f4093-219d-4d84-a1c6-3516e0397981>
-        , <http://localhost:8983/fedora/rest/anno/cb8ef8c2-ba90-4573-acb3-aeea006ad7d1>
-        , <http://localhost:8983/fedora/rest/anno/e61241dd-f2b9-4ba2-9201-d3ff42a7f3bd>
-        , <http://localhost:8983/fedora/rest/anno/e9cb3bdd-5ed9-4c6b-bd33-e18bc72461cc>
-        , <http://localhost:8983/fedora/rest/anno/af6fff36-3662-452d-a67d-10fc0fe1fadb>
-        , <http://localhost:8983/fedora/rest/anno/b2e283ce-77fd-4921-b6a6-9a8fba93bcb2>
-        , <http://localhost:8983/fedora/rest/anno/12b5a28a-4126-45df-926c-c23fdb75ac31>
-        , <http://localhost:8983/fedora/rest/anno/ccaa9df3-1d53-40b1-985f-4a22e5e08895>
-        , <http://localhost:8983/fedora/rest/anno/46fe7fe3-4e64-403d-bfe9-1c0041432d1b>
-        , <http://localhost:8983/fedora/rest/anno/8eafa5c8-f3dc-47ed-9dfc-febd96127e36>
-        , <http://localhost:8983/fedora/rest/anno/e7bdf336-df62-4216-b19f-609a8cecf423>
-        , <http://localhost:8983/fedora/rest/anno/4cb50ac4-86cc-4184-a380-1ecc7e5c5cb3>
-        , <http://localhost:8983/fedora/rest/anno/1a7f67a2-a6cd-4465-aeeb-8d125fd674a4>
-        , <http://localhost:8983/fedora/rest/anno/c8dbedfc-0647-4f2f-af1d-91c4f2a818e1>
-        , <http://localhost:8983/fedora/rest/anno/f3a82323-432f-4f51-8810-f2adaba1b179>
-        , <http://localhost:8983/fedora/rest/anno/439af672-094c-46df-bc65-ca4f2e9f0b77>
-        , <http://localhost:8983/fedora/rest/anno/6a8fa17c-737b-4a4a-a714-efe05128e4c3>
-        , <http://localhost:8983/fedora/rest/anno/32230d44-28f7-4d20-849f-9c7846ef06a0>
-        , <http://localhost:8983/fedora/rest/anno/c13f2a93-c6b0-4b12-983a-8969231b841e>
-        , <http://localhost:8983/fedora/rest/anno/5ade72e8-3a3e-457b-a697-5652d52e6976>
-        , <http://localhost:8983/fedora/rest/anno/b85d7af9-8206-4dbb-ad32-955e724153ed>
-        , <http://localhost:8983/fedora/rest/anno/76b8d554-ddf3-40ec-becb-b68cfdd2ea45>
-        , <http://localhost:8983/fedora/rest/anno/ececb8e6-9fea-49fd-9203-9e9d9ea7ab5b>
-        , <http://localhost:8983/fedora/rest/anno/08402b42-283f-4354-8465-4d56c86c1dd5>
-        , <http://localhost:8983/fedora/rest/anno/3f6a4e8d-67ed-4e51-bf27-99b240cab3b1>
-        , <http://localhost:8983/fedora/rest/anno/c923d5fa-c55f-422f-99bd-8fec48413a2a>
-        , <http://localhost:8983/fedora/rest/anno/c1251b21-bb13-4d50-8f90-23b01e30f62f>
-        , <http://localhost:8983/fedora/rest/anno/a4fd0661-af9d-4604-91ce-def326b6d5f8>
-        , <http://localhost:8983/fedora/rest/anno/ab351d80-b280-43a5-bb0c-fe29d023f11b>
-        , <http://localhost:8983/fedora/rest/anno/07534e91-0983-46b3-8d28-b3408d343cdb>
-        , <http://localhost:8983/fedora/rest/anno/12db4d5d-1ef9-4efe-bb2b-927a2ca71dd1>
-        , <http://localhost:8983/fedora/rest/anno/0e5ceada-d7f9-47ae-a33c-ff2f82ed8d32>
-        , <http://localhost:8983/fedora/rest/anno/811ad800-c974-44f2-bbd3-96a387fd4225>
-        , <http://localhost:8983/fedora/rest/anno/9cc7b9bf-efe8-4168-b356-7e7cbada0cc1>
-        , <http://localhost:8983/fedora/rest/anno/e8b405c8-43aa-46c1-b0f9-09b8507010df>
-        , <http://localhost:8983/fedora/rest/anno/b74dac55-a1b8-4da3-b7de-d16e1a77d3f2>
-        , <http://localhost:8983/fedora/rest/anno/c4a91076-3f89-4814-b7f8-8c175d7e922c>
-        , <http://localhost:8983/fedora/rest/anno/7f0ed504-fedf-4525-97ea-6197e3e8aae9>
-        , <http://localhost:8983/fedora/rest/anno/b3aa3db7-cb57-4155-94bd-6577a3b70d4b>
-        , <http://localhost:8983/fedora/rest/anno/e98b019b-20fd-49f1-8c68-1517f283d5b6>
-        , <http://localhost:8983/fedora/rest/anno/04f60c0b-d594-4f42-98bd-eb5fb3b6f28e>
-        , <http://localhost:8983/fedora/rest/anno/9d0a7a27-f893-4f49-86c3-9d0115201611>
-        , <http://localhost:8983/fedora/rest/anno/50a8914e-327d-4dd2-b815-76175ed6022c>
-        , <http://localhost:8983/fedora/rest/anno/dcb68694-70d8-4f69-bf61-6e9060b5659b>
-        , <http://localhost:8983/fedora/rest/anno/e766ee05-6561-4127-9d7d-cb6973dd1b55>
-        , <http://localhost:8983/fedora/rest/anno/8583cfda-3406-4753-b539-119c81c3584d>
-        , <http://localhost:8983/fedora/rest/anno/14e46491-7f0f-49aa-9493-81163b81313a>
-        , <http://localhost:8983/fedora/rest/anno/445890c0-1101-4724-932e-c5f8374433ea>
-        , <http://localhost:8983/fedora/rest/anno/eac54055-f1d2-4314-a4f5-92c695fd9e5d>
-        , <http://localhost:8983/fedora/rest/anno/4704e4a3-4b63-4ec3-9d59-b3bf18adc47a>
-        , <http://localhost:8983/fedora/rest/anno/46d4618b-55f5-41cb-9614-f1a7a21bd77d>
-        , <http://localhost:8983/fedora/rest/anno/59a1e717-42bb-4e59-aab7-a6bd3f8bce4e>
-        , <http://localhost:8983/fedora/rest/anno/33e7c767-b252-437d-8fba-75dee511a1a3>
-        , <http://localhost:8983/fedora/rest/anno/1363e791-0c3e-4650-bfe1-83623a47bc0c>
-        , <http://localhost:8983/fedora/rest/anno/f12aec29-12cd-423b-820a-8a658a5c5a11>
-        , <http://localhost:8983/fedora/rest/anno/14117928-8549-41aa-94d0-a5e847402120>
-        , <http://localhost:8983/fedora/rest/anno/55825c51-dc1c-42b6-b9f2-157bc2802b7c>
-        , <http://localhost:8983/fedora/rest/anno/10ecf5f7-297c-44f0-9018-bb6508343843>
-        , <http://localhost:8983/fedora/rest/anno/0cecba71-b507-478b-acdf-6eedcf4462c9>
-        , <http://localhost:8983/fedora/rest/anno/5e3750cd-07b2-407d-98dd-47c7e298353f>
-        , <http://localhost:8983/fedora/rest/anno/c38feae7-e735-4b6b-a86f-6de90002acfc>
-        , <http://localhost:8983/fedora/rest/anno/ec075d3c-c0cd-4a1f-a460-8e44b4c3d71b>
-        , <http://localhost:8983/fedora/rest/anno/0651b5f2-4f5a-4f8c-8532-0444c7e6a2b2>
-        , <http://localhost:8983/fedora/rest/anno/ea16fc3a-d26c-4098-ac54-0a2b900426c0>
-        , <http://localhost:8983/fedora/rest/anno/9f316b87-21bc-451a-b9f9-4e7585cf9c4d>
-        , <http://localhost:8983/fedora/rest/anno/57a1f597-8410-4da8-96aa-85b9624967d7>
-        , <http://localhost:8983/fedora/rest/anno/802ceab2-c123-4184-8f94-afc8ce4107d1>
-        , <http://localhost:8983/fedora/rest/anno/0dee34d4-52aa-450d-bc1c-cda66b0009ac>
-        , <http://localhost:8983/fedora/rest/anno/2c88a3d8-0811-4274-88cc-6c7986b6ac37>
-        , <http://localhost:8983/fedora/rest/anno/49cfdadd-d41a-4fc4-a794-dbbc28ca368b>
-        , <http://localhost:8983/fedora/rest/anno/ce70d6f8-126e-4979-bbf3-2e6a9940b328>
-        , <http://localhost:8983/fedora/rest/anno/de38f49c-6ea4-4e58-af22-be2093ae51de>
-        , <http://localhost:8983/fedora/rest/anno/13df1a5b-49df-43f8-9a63-81941148d0d2>
-        , <http://localhost:8983/fedora/rest/anno/88197d91-05ec-4930-8721-96e8ca951ce8>
-        , <http://localhost:8983/fedora/rest/anno/78d54f52-4d42-4410-be9d-13e30e796ad4>
-        , <http://localhost:8983/fedora/rest/anno/81ff0efa-f266-4008-9434-ac9a349a2f15>
-        , <http://localhost:8983/fedora/rest/anno/1b432f83-5e3a-475c-8d41-fcf39671dbc4>
-        , <http://localhost:8983/fedora/rest/anno/e8023047-cfaa-4e60-848c-15bd325ed491>
-        , <http://localhost:8983/fedora/rest/anno/de9e03cb-c5c2-448e-8469-c5c90de111c6>
-        , <http://localhost:8983/fedora/rest/anno/140c5673-e859-4efc-a813-740b5527bba6>
-        , <http://localhost:8983/fedora/rest/anno/27f1d5de-4705-45d0-9a43-57dadda641bb>
-        , <http://localhost:8983/fedora/rest/anno/15805844-ebad-415e-b344-4414fa98d895>
-        , <http://localhost:8983/fedora/rest/anno/92f1fe4e-e9a7-48b7-9c08-47388fb32e86>
-        , <http://localhost:8983/fedora/rest/anno/aa8722c2-66c9-49ce-afa8-15ebd057dcfc>
-        , <http://localhost:8983/fedora/rest/anno/28c30314-c6c2-4400-b134-39bb032896cd>
-        , <http://localhost:8983/fedora/rest/anno/08ce6897-b5e3-4eb6-a971-1ac336b06548>
-        , <http://localhost:8983/fedora/rest/anno/986b819f-fb96-4431-94d1-70cfd7906633>
-        , <http://localhost:8983/fedora/rest/anno/e0beffbc-6486-4e2a-bcdb-31ecce3a1311>
-        , <http://localhost:8983/fedora/rest/anno/f12a6bb4-1c8d-4b8f-820c-355efed18153>
-        , <http://localhost:8983/fedora/rest/anno/547caf50-65dd-4f11-a404-541d7ff83e2d>
-        , <http://localhost:8983/fedora/rest/anno/96337ace-49b6-46fb-99a6-16adcd15ab9e>
-        , <http://localhost:8983/fedora/rest/anno/8655ea5e-6ba0-44f4-812f-d05a63f13469>
-        , <http://localhost:8983/fedora/rest/anno/14beca0f-16f1-4885-98ee-7d392f22ef83>
-        , <http://localhost:8983/fedora/rest/anno/494a2ef9-e4fa-46ef-83b8-1429e1ef9308>
-        , <http://localhost:8983/fedora/rest/anno/acbe3762-b6f8-4644-bbf0-936f65d5de4f>
-        , <http://localhost:8983/fedora/rest/anno/194c9428-51f7-45f2-acf7-84a2ac8fb311>
-        , <http://localhost:8983/fedora/rest/anno/729a0d3a-6b77-4bb3-a718-8e2904af5938>
-        , <http://localhost:8983/fedora/rest/anno/ca00496b-2983-477d-8b57-e78b2aa637c8>
-        , <http://localhost:8983/fedora/rest/anno/0b475457-d76e-416b-aef6-ec81b5ee5ee6>
-        , <http://localhost:8983/fedora/rest/anno/1bc59170-7a89-41fa-a4c2-dd2e79976743>
-        , <http://localhost:8983/fedora/rest/anno/70d266ea-cbdf-4dba-8c42-4fb34f1e9d25>
-        , <http://localhost:8983/fedora/rest/anno/a5b953df-8f6b-4cb3-91f3-a2916875933f>
-        , <http://localhost:8983/fedora/rest/anno/f5c2ee2c-a1be-4612-a1e4-111dfa3ba724>
-        , <http://localhost:8983/fedora/rest/anno/756861da-76f7-4dff-ad1f-723a7ba945de>
-        , <http://localhost:8983/fedora/rest/anno/ca759f0d-181c-4530-8396-b6fd7032c441>
-        , <http://localhost:8983/fedora/rest/anno/5fef08e0-eecb-49e1-8b7f-2b3a801317bf>
-        , <http://localhost:8983/fedora/rest/anno/488f17a9-0488-42a7-b39b-14dbfab1a7f3>
-        , <http://localhost:8983/fedora/rest/anno/e4eec2ec-92a7-45d5-9a85-a205e1be794f>
-        , <http://localhost:8983/fedora/rest/anno/10a4e37b-f08a-4afe-9099-358e26ed4023>
-        , <http://localhost:8983/fedora/rest/anno/712d5510-3110-435a-8b92-a831e13481fa>
-        , <http://localhost:8983/fedora/rest/anno/ce8dacfe-0125-4be4-9da8-31a061eeec0e>
-        , <http://localhost:8983/fedora/rest/anno/fccd45e6-5ae5-4dc9-8dfb-6641bbfa7483>
-        , <http://localhost:8983/fedora/rest/anno/ced669be-41da-4bbc-a80a-b4a0afc41eb2>
-        , <http://localhost:8983/fedora/rest/anno/ee990685-95ba-44a9-a545-777aeaea8df5>
-        , <http://localhost:8983/fedora/rest/anno/18d68876-cbb8-4277-9fca-404da3226bd5>
-        , <http://localhost:8983/fedora/rest/anno/c33b31ff-735e-4e26-aba4-4be643630a44>
-        , <http://localhost:8983/fedora/rest/anno/1d5f7730-f678-44f7-8b19-9c03a4b53694>
-        , <http://localhost:8983/fedora/rest/anno/b41f4ce7-d75a-4ac7-9d9d-501222feb176>
-        , <http://localhost:8983/fedora/rest/anno/a47ca158-d330-4436-b882-89748aaeae32>
-        , <http://localhost:8983/fedora/rest/anno/af0852be-1fdc-404b-9626-f8f6895d8e61>
-        , <http://localhost:8983/fedora/rest/anno/fcd3d5f5-5f04-4924-9222-2db3a0664e1b>
-        , <http://localhost:8983/fedora/rest/anno/50ace8e0-ba3d-48ad-9db7-66a104a4df3f>
-        , <http://localhost:8983/fedora/rest/anno/c7cd1fdb-d6ab-4521-94d8-8386a1956e3f>
-        , <http://localhost:8983/fedora/rest/anno/df9e1c44-d305-4fa0-b163-c2ad669e690f>
-        , <http://localhost:8983/fedora/rest/anno/33d11f37-f0dd-4428-bba7-b33bb32d2dcf>
-        , <http://localhost:8983/fedora/rest/anno/42d73f06-a000-467c-887a-b9c1a53e10f5>
-        , <http://localhost:8983/fedora/rest/anno/121394ba-f770-44ab-9edb-93308f9ccbb8>
-        , <http://localhost:8983/fedora/rest/anno/ca323317-c423-46fa-99cc-766b6eedc6bb>
-        , <http://localhost:8983/fedora/rest/anno/1516300a-7723-436c-9957-fe0d7b36f559>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/> ;\n\tfedora:writable
-        \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno> a <http://www.jcp.org/jcr/nt/1.0folder>
-        , <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
-        , <http://www.jcp.org/jcr/mix/1.0created> , fedora:resource , fedora:object
-        , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
-        , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6c26b357-bca6-49d7-8932-5de3c35e0777\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-01-30T23:13:12.468Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:08:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:08:22 GMT
-- request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
     body:
@@ -467,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7b3e81f0d417f7e1459c6bff419edaa7f127c6c6"'
+      - '"3bbd5c61b05d9cc68476c330b1ac872e6da7f656"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378
+      - http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378
+      string: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec
     body:
       encoding: UTF-8
       string: |
@@ -493,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -511,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"070ec909204548ab0c6202f7ba9a3b954947f611"'
+      - '"7b9d5b63ad780245c19117791bbdeb27364cb044"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t
+      - http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t
+      string: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t
     body:
       encoding: UTF-8
       string: |
@@ -549,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4d82595e987d9b2cc85120cc7ff27ef4f18f33c6"'
+      - '"13d0bd8c638a90513a028b3717011973c423909f"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a
+      - http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a
+      string: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec
     body:
       encoding: US-ASCII
       string: ''
@@ -582,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d068744c6ae795ba30112823b71c05c60f0fdd15"'
+      - '"6738a62600f6eea7ff4aefc84a3530531115dda9"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -597,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4051'
+      - '4099'
       Content-Type:
       - application/x-turtle
     body:
@@ -605,50 +164,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/fcr:export?format=jcr/xml>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"74c94745-ba09-4488-a2a5-421d5d56ba07\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"0b7609a8-b0b3-4345-97fb-61e354b44027\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:56.028Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:57.511Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-09T23:59:56.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:57.539Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87
     body:
       encoding: US-ASCII
       string: ''
@@ -665,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4d82595e987d9b2cc85120cc7ff27ef4f18f33c6"'
+      - '"13d0bd8c638a90513a028b3717011973c423909f"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -680,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3521'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -688,42 +247,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"60810341-7fa0-489e-b5b2-1ef4601b614a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"684a5364-a65e-4b89-a354-0ec1c2ea0df5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:56.076Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:57.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-09T23:59:56.076Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:57.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -747,7 +306,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -761,7 +320,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Tue, 10 Feb 2015 05:59:56 GMT
+      - Thu, 05 Mar 2015 01:26:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1877,16 +1436,16 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">92e14931-3751-4b12-8fec-0a1018a3b378</field><field name="motivation">bookmarking</field><field
+        name="id">600625a9-e7cc-404c-89f9-46715d249aec</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/92e14931-3751-4b12-8fec-0a1018a3b378","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@id":"http://your.triannon-server.com/annotations/600625a9-e7cc-404c-89f9-46715d249aec","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1902,12 +1461,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec
     body:
       encoding: US-ASCII
       string: ''
@@ -1924,9 +1483,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d068744c6ae795ba30112823b71c05c60f0fdd15"'
+      - '"6738a62600f6eea7ff4aefc84a3530531115dda9"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1939,7 +1498,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4051'
+      - '4099'
       Content-Type:
       - application/x-turtle
     body:
@@ -1947,50 +1506,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/fcr:export?format=jcr/xml>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"74c94745-ba09-4488-a2a5-421d5d56ba07\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"0b7609a8-b0b3-4345-97fb-61e354b44027\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:56.028Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:57.511Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-09T23:59:56.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:57.539Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a
+    uri: http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87
     body:
       encoding: US-ASCII
       string: ''
@@ -2007,9 +1566,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4d82595e987d9b2cc85120cc7ff27ef4f18f33c6"'
+      - '"13d0bd8c638a90513a028b3717011973c423909f"'
       Last-Modified:
-      - Mon, 09 Feb 2015 23:59:56 GMT
+      - Wed, 04 Mar 2015 19:26:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -2022,7 +1581,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3521'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -2030,40 +1589,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
-        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
-        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
-        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
+        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
+        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
+        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a/fcr:export?format=jcr/xml>
-        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/92e14931-3751-4b12-8fec-0a1018a3b378/t/56aa2bd4-35ff-4a5c-8f34-a1a97388b75a>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/600625a9-e7cc-404c-89f9-46715d249aec/t/ae3d971e-9800-4099-be2a-5caee8d98e87>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"60810341-7fa0-489e-b5b2-1ef4601b614a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"684a5364-a65e-4b89-a354-0ec1c2ea0df5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-09T23:59:56.076Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:57.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-09T23:59:56.076Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:57.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Mon, 09 Feb 2015 23:59:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e10fdde678983655582d266801148cb61b071375"'
+      - '"d952193a7eebe417619aba43c27b282110ca84a2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad
+      - http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad
+      string: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"40f710ad80c065d5f102ae19183a8e283ebc89c8"'
+      - '"0e495f8a2c8bb0cb852f7bd06af3217e580b6ca5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b
+      - http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b
+      string: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9417fc242ac1967384520888fd247adda0f86448"'
+      - '"fd977cb3a09c37ffe5c4a3fb77c66e679155274c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7
+      - http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7
+      string: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"44fe79547e69a2404a5cee7cb4dac09187c340e7"'
+      - '"d6162769ad1c7d2d86b7b96c9716f1f4677bc03b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t
+      - http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t
+      string: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b84d93aedee4c43fc34099bfef60c2fbc144fcb8"'
+      - '"ca8ee6fa93254cab3bc9f1b9d9285d07f57892de"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64
+      - http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64
+      string: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1530aee786bfca62749690f10888079de32e134a"'
+      - '"95975f4d65679018aa745664a29558eeb8692313"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,55 +251,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b>
-        , <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b>
-        , <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad>
+        <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b>
+        , <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b>
+        , <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4d4347ef-7fdd-48af-bd0d-c45a6892da43\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"f43694c6-61b9-42a3-bbdd-21a76c714818\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:58.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:17.328Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:17:58.689Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:17.396Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6
     body:
       encoding: US-ASCII
       string: ''
@@ -316,9 +316,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9417fc242ac1967384520888fd247adda0f86448"'
+      - '"fd977cb3a09c37ffe5c4a3fb77c66e679155274c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -331,7 +331,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3862'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -339,47 +339,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/b/1159f7e9-2b40-46d6-877e-dbbe0819c9c7>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/b/2a7cd9b9-139e-4836-8008-e5f7c0b5c7e6>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"1778e10d-2b3c-481e-9527-bf2216b9e44f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"de2151ea-7d8f-4e04-b7e4-747e5f2dedbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:58.672Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:17:58.672Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:17.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:17.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64
+    uri: http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f
     body:
       encoding: US-ASCII
       string: ''
@@ -396,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b84d93aedee4c43fc34099bfef60c2fbc144fcb8"'
+      - '"ca8ee6fa93254cab3bc9f1b9d9285d07f57892de"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -411,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -419,42 +418,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ba0dc837-8c1b-4a51-953c-02141ed9ccad/t/b0178470-c8d9-4fbd-bbe5-b9ee47b93b64>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/767112ab-db23-4965-8ddc-b9911ad3cc18/t/ba09d2d8-6ec9-4e99-854d-15b478a8ba0f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4c56b9d6-0407-4c43-8f5b-47b5a05924f1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"29318def-0392-4ac2-8e6c-b5bde7c5e4b6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:17.417Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:17:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:17.417Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -478,7 +477,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -492,7 +491,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:17:58 GMT
+      - Thu, 05 Mar 2015 01:26:17 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1608,18 +1607,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">ba0dc837-8c1b-4a51-953c-02141ed9ccad</field><field name="motivation">commenting</field><field
+        name="id">767112ab-db23-4965-8ddc-b9911ad3cc18</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70208964505060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/ba0dc837-8c1b-4a51-953c-02141ed9ccad","@type":"oa:Annotation","hasBody":"_:g70208964505060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121664233860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/767112ab-db23-4965-8ddc-b9911ad3cc18","@type":"oa:Annotation","hasBody":"_:g70121664233860","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1637,5 +1636,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"48746104a5ddccc73b72b9d2f6715b863e3f7a29"'
+      - '"bfb8a65ffbc347cd9843add68e977bd37af282af"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f
+      - http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f
+      string: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f0a9f17774464b1ccea235d6f5e4dee62dc340db"'
+      - '"69614a15467bb29c36d42c067eb41974149ec20f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b
+      - http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b
+      string: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a82678e24f8c79650d7597007efcbf97147508d6"'
+      - '"4eeaef218fe9be3ef7106b7cc410f489b87046d5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70
+      - http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70
+      string: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3371d93efbc1d2fb99a6285e566e3b89ce0701b6"'
+      - '"e6608ce0e286f7a04a07105bbc982feb480a0b4c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t
+      - http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t
+      string: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"28c4cdcd73b124fc306ccfe48b2ee1f3fd6a9537"'
+      - '"bd2da7a2b2d29a39eade985719e592535da46cfb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098
+      - http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098
+      string: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8db4976c9bcce09bc53ec2d9fd034cf20068903c"'
+      - '"e87ae71514e7014c3580fcf286b7f8bf2440c7d2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,54 +251,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b>
-        , <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b>
-        , <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b>
+        , <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b>
+        , <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"b0773e4a-4800-4549-bcbd-6248b1d3cbbb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"836cda7e-405c-4d10-af5d-f5792ef9c8d6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:57.754Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:16.349Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:17:57.812Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:16.432Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b
     body:
       encoding: US-ASCII
       string: ''
@@ -315,9 +315,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a82678e24f8c79650d7597007efcbf97147508d6"'
+      - '"4eeaef218fe9be3ef7106b7cc410f489b87046d5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -330,7 +330,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3745'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -338,46 +338,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/b/415aed03-3771-4bdd-9209-6fe3c9191b70/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/b/3d687dcc-1475-49e2-a872-0e3e14ab866b/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"86463f80-ddc3-420b-b2a4-6bd593863670\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"4f43f67c-d8a6-41f1-ae4a-7a2c190525c4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:57.796Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:17:57.796Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:16.409Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:16.409Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098
+    uri: http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06
     body:
       encoding: US-ASCII
       string: ''
@@ -394,9 +394,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"28c4cdcd73b124fc306ccfe48b2ee1f3fd6a9537"'
+      - '"bd2da7a2b2d29a39eade985719e592535da46cfb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:17:57 GMT
+      - Wed, 04 Mar 2015 19:26:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -409,7 +409,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -417,42 +417,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/5e794e8b-3837-4d52-8e67-94d4aa152f3f/t/68cecda9-655a-4be1-9d0c-3d9e7545f098/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7/t/e489e108-3e87-4561-8431-f83a8f395c06>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"a7bdee34-f112-4c8e-b907-8a9dab272817\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"b39dd0ac-646c-4058-92da-4a60a1b16e55\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:17:57.825Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:16.454Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:17:57.825Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:16.454Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:16 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -476,7 +476,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:17:58 GMT
+      - Wed, 04 Mar 2015 19:26:17 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -490,7 +490,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:17:58 GMT
+      - Thu, 05 Mar 2015 01:26:17 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1606,18 +1606,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">5e794e8b-3837-4d52-8e67-94d4aa152f3f</field><field name="motivation">commenting</field><field
+        name="id">bc00b7e2-3734-4098-9cd4-0161dc9b1fb7</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70208953333820","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/5e794e8b-3837-4d52-8e67-94d4aa152f3f","@type":"oa:Annotation","hasBody":"_:g70208953333820","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121665790160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/bc00b7e2-3734-4098-9cd4-0161dc9b1fb7","@type":"oa:Annotation","hasBody":"_:g70121665790160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1633,7 +1633,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>109}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/returns_204_status_code_for_successful_delete.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/returns_204_status_code_for_successful_delete.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"46a4f60143cf160e258f3ec378eb569faba0fca0"'
+      - '"154fa3f1b39c37ec75dacc019365b20d52f98fbe"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+      - http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+      string: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0db7041c86b385c920383b06f31e8ecde1735fd5"'
+      - '"17ee695e584aec7128b38892a6bce84522340016"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b
+      - http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b
+      string: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"be4117d51364a7e7ae7bc101b2055d18cbf7a363"'
+      - '"16ad7828c90ab0c6b1e998ce6ba9f2bfb7178863"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8
+      - http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8
+      string: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"92f7b1e002e99ed173aa3ab7c7cde467162c4ee4"'
+      - '"0d8e01f3e0fd9068647e07b7773ee0d7bbb4f8bb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t
+      - http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t
+      string: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e5f281607c13a972fdd37f9353f638e35269c0ea"'
+      - '"2e87c7adfd1b6f440a07a5e707df48c55bbbf30c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229
+      - http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229
+      string: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"51329b24f3234639fdd85305a322126ed0c46470"'
+      - '"d5c3f57575f90864265c2d348288e9d6aa70d758"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,55 +251,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"acf65687-a570-49fc-bbf9-85307b313f18\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"93e2a0f3-4168-44a0-aff6-53bcf6274b3a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.014Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.575Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.079Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.636Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f
     body:
       encoding: US-ASCII
       string: ''
@@ -316,9 +315,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"be4117d51364a7e7ae7bc101b2055d18cbf7a363"'
+      - '"16ad7828c90ab0c6b1e998ce6ba9f2bfb7178863"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -331,7 +330,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3860'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -339,47 +338,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"b34a025b-8c61-4883-851a-2000dbd68bb5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b171954d-bdcf-4bbb-a09a-a937568e1b02\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8
     body:
       encoding: US-ASCII
       string: ''
@@ -396,9 +394,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5f281607c13a972fdd37f9353f638e35269c0ea"'
+      - '"2e87c7adfd1b6f440a07a5e707df48c55bbbf30c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -411,7 +409,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -419,43 +417,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"e146e839-b378-4b69-b72f-f52c6aa83241\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"c2726a5c-d618-4b26-9d18-f678cc59f4a7\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:20 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -479,7 +476,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:21 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -493,7 +490,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:08 GMT
+      - Thu, 05 Mar 2015 01:26:21 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1609,18 +1606,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">af62686d-d107-4dcc-9253-e0f9eed28828</field><field name="motivation">commenting</field><field
+        name="id">ae854f08-4ba7-460c-b8de-cee607730605</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70208953022420","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/af62686d-d107-4dcc-9253-e0f9eed28828","@type":"oa:Annotation","hasBody":"_:g70208953022420","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121680857140","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/ae854f08-4ba7-460c-b8de-cee607730605","@type":"oa:Annotation","hasBody":"_:g70121680857140","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1638,10 +1635,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: US-ASCII
       string: ''
@@ -1658,9 +1655,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"51329b24f3234639fdd85305a322126ed0c46470"'
+      - '"d5c3f57575f90864265c2d348288e9d6aa70d758"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1673,7 +1670,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1681,55 +1678,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"acf65687-a570-49fc-bbf9-85307b313f18\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"93e2a0f3-4168-44a0-aff6-53bcf6274b3a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.014Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.575Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.079Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.636Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f
     body:
       encoding: US-ASCII
       string: ''
@@ -1746,9 +1742,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"be4117d51364a7e7ae7bc101b2055d18cbf7a363"'
+      - '"16ad7828c90ab0c6b1e998ce6ba9f2bfb7178863"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1761,7 +1757,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3860'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -1769,47 +1765,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"b34a025b-8c61-4883-851a-2000dbd68bb5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b171954d-bdcf-4bbb-a09a-a937568e1b02\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8
     body:
       encoding: US-ASCII
       string: ''
@@ -1826,9 +1821,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5f281607c13a972fdd37f9353f638e35269c0ea"'
+      - '"2e87c7adfd1b6f440a07a5e707df48c55bbbf30c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1841,7 +1836,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1849,46 +1844,45 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"e146e839-b378-4b69-b72f-f52c6aa83241\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"c2726a5c-d618-4b26-9d18-f678cc59f4a7\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: US-ASCII
       string: ''
@@ -1905,9 +1899,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"51329b24f3234639fdd85305a322126ed0c46470"'
+      - '"d5c3f57575f90864265c2d348288e9d6aa70d758"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1920,7 +1914,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1928,55 +1922,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        , <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        , <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"acf65687-a570-49fc-bbf9-85307b313f18\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"93e2a0f3-4168-44a0-aff6-53bcf6274b3a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.014Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.575Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.079Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.636Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f
     body:
       encoding: US-ASCII
       string: ''
@@ -1993,9 +1986,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"be4117d51364a7e7ae7bc101b2055d18cbf7a363"'
+      - '"16ad7828c90ab0c6b1e998ce6ba9f2bfb7178863"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -2008,7 +2001,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3860'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -2016,47 +2009,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/b/aa2d9795-cca5-4fda-90e5-fe95b5d99ec8>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/b/cb25b8a0-7573-4cae-8b16-b556653b559f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"b34a025b-8c61-4883-851a-2000dbd68bb5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b171954d-bdcf-4bbb-a09a-a937568e1b02\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.06Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8
     body:
       encoding: US-ASCII
       string: ''
@@ -2073,9 +2065,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5f281607c13a972fdd37f9353f638e35269c0ea"'
+      - '"2e87c7adfd1b6f440a07a5e707df48c55bbbf30c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:26:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -2088,7 +2080,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -2096,46 +2088,45 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828/t/28ad0485-5681-432b-9f58-bf2b093da229>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605/t/d08a8fea-3063-4fb4-928b-747fb3d158b8>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"e146e839-b378-4b69-b72f-f52c6aa83241\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"c2726a5c-d618-4b26-9d18-f678cc59f4a7\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:18:08.093Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:20.655Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/af62686d-d107-4dcc-9253-e0f9eed28828
+    uri: http://localhost:8983/fedora/rest/anno/ae854f08-4ba7-460c-b8de-cee607730605
     body:
       encoding: US-ASCII
       string: ''
@@ -2155,13 +2146,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>af62686d-d107-4dcc-9253-e0f9eed28828</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>ae854f08-4ba7-460c-b8de-cee607730605</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2177,9 +2168,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -2201,7 +2192,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>20}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>36}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/iiif/behaves_like_jsonld_context_respected/response_has_correct_context.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/iiif/behaves_like_jsonld_context_respected/response_has_correct_context.yml
@@ -23,11 +23,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:07 GMT
+      - Wed, 04 Mar 2015 19:18:24 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
-      - Tue, 16 Dec 2014 00:30:20 GMT
+      - Wed, 25 Feb 2015 17:30:43 GMT
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -35,7 +35,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 05 Feb 2015 00:18:07 GMT
+      - Thu, 05 Mar 2015 19:18:24 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -101,7 +101,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:31 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -125,11 +125,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:07 GMT
+      - Wed, 04 Mar 2015 19:18:24 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
-      - Tue, 16 Dec 2014 00:30:20 GMT
+      - Wed, 25 Feb 2015 17:30:43 GMT
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -137,7 +137,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 05 Feb 2015 00:18:07 GMT
+      - Thu, 05 Mar 2015 19:18:24 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -203,5 +203,5 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/oa/behaves_like_jsonld_context_respected/response_has_correct_context.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/oa/behaves_like_jsonld_context_respected/response_has_correct_context.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:00 GMT
+      - Wed, 04 Mar 2015 19:17:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:00 GMT
+      - Thu, 05 Mar 2015 01:17:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,7 +1153,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1177,7 +1177,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:01 GMT
+      - Wed, 04 Mar 2015 19:17:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1191,7 +1191,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:01 GMT
+      - Thu, 05 Mar 2015 01:17:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2307,5 +2307,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/pays_attention_to_jsonld_context_for_all_jsonld_and_json_accept_formats/behaves_like_jsonld_context_respected/response_has_correct_context.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/pays_attention_to_jsonld_context_for_all_jsonld_and_json_accept_formats/behaves_like_jsonld_context_respected/response_has_correct_context.yml
@@ -23,11 +23,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:18:26 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
-      - Tue, 16 Dec 2014 00:30:20 GMT
+      - Wed, 25 Feb 2015 17:30:43 GMT
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -35,7 +35,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 05 Feb 2015 00:18:08 GMT
+      - Thu, 05 Mar 2015 19:18:26 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -101,7 +101,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:33 GMT
 - request:
     method: get
     uri: http://iiif.io/api/presentation/2/context.json
@@ -125,11 +125,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:08 GMT
+      - Wed, 04 Mar 2015 19:18:26 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
-      - Tue, 16 Dec 2014 00:30:20 GMT
+      - Wed, 25 Feb 2015 17:30:43 GMT
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -137,7 +137,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Thu, 05 Feb 2015 00:18:08 GMT
+      - Thu, 05 Mar 2015 19:18:26 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -203,7 +203,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:33 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -227,7 +227,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:02 GMT
+      - Wed, 04 Mar 2015 19:17:34 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -241,7 +241,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:02 GMT
+      - Thu, 05 Mar 2015 01:17:34 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1357,7 +1357,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1381,7 +1381,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:03 GMT
+      - Wed, 04 Mar 2015 19:17:34 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1395,7 +1395,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:03 GMT
+      - Thu, 05 Mar 2015 01:17:34 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2511,5 +2511,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/returns_OA_context_jsonld_when_context_is_missing_in_path.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/returns_OA_context_jsonld_when_context_is_missing_in_path.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:17:59 GMT
+      - Wed, 04 Mar 2015 19:17:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:17:59 GMT
+      - Thu, 05 Mar 2015 01:17:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/returns_OA_context_jsonld_when_neither_iiif_or_oa_is_in_path.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/jsonld_context_param/returns_OA_context_jsonld_when_neither_iiif_or_oa_is_in_path.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:17:59 GMT
+      - Wed, 04 Mar 2015 19:17:30 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:17:59 GMT
+      - Thu, 05 Mar 2015 01:17:30 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:17:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/_/_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/_/_gets_json-ld.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:04 GMT
+      - Wed, 04 Mar 2015 19:17:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:04 GMT
+      - Thu, 05 Mar 2015 01:17:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:05 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/empty_string_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/empty_string_gets_json-ld.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:03 GMT
+      - Wed, 04 Mar 2015 19:17:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:03 GMT
+      - Thu, 05 Mar 2015 01:17:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/json.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:06 GMT
+      - Wed, 04 Mar 2015 19:17:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:06 GMT
+      - Thu, 05 Mar 2015 01:17:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:06 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/jsonrequest.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/jsonrequest.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:07 GMT
+      - Wed, 04 Mar 2015 19:17:37 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:07 GMT
+      - Thu, 05 Mar 2015 01:17:37 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:07 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/ld_json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/application/ld_json.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:05 GMT
+      - Wed, 04 Mar 2015 19:17:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:05 GMT
+      - Thu, 05 Mar 2015 01:17:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:06 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/text/x-json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/json/behaves_like_accept_header_determines_media_type/text/x-json.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:06 GMT
+      - Wed, 04 Mar 2015 19:17:37 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:06 GMT
+      - Thu, 05 Mar 2015 01:17:37 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:06 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/multiple_formats/uses_first_known_format.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/multiple_formats/uses_first_known_format.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:07 GMT
+      - Wed, 04 Mar 2015 19:17:38 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:07 GMT
+      - Thu, 05 Mar 2015 01:17:38 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:07 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/nil_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/response_format/nil_gets_json-ld.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:18:04 GMT
+      - Wed, 04 Mar 2015 19:17:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:18:04 GMT
+      - Thu, 05 Mar 2015 01:17:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:18:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/has_OA_context.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/has_OA_context.yml
@@ -19,11 +19,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:18 GMT
+      - Wed, 04 Mar 2015 19:18:50 GMT
       Server:
       - Apache/2.2.15 (Red Hat)
       Last-Modified:
-      - Tue, 16 Dec 2014 00:30:20 GMT
+      - Wed, 25 Feb 2015 17:30:43 GMT
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -31,7 +31,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400
       Expires:
-      - Wed, 04 Feb 2015 22:50:18 GMT
+      - Thu, 05 Mar 2015 19:18:50 GMT
       Content-Type:
       - application/ld+json
       Access-Control-Allow-Origin:
@@ -97,7 +97,7 @@ http_interactions:
         \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
         \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:12 GMT
+      - Wed, 04 Mar 2015 19:17:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -135,7 +135,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:12 GMT
+      - Thu, 05 Mar 2015 01:17:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1251,7 +1251,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:58 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1275,7 +1275,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:12 GMT
+      - Wed, 04 Mar 2015 19:17:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1289,7 +1289,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:12 GMT
+      - Thu, 05 Mar 2015 01:17:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2405,7 +2405,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:59 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2429,7 +2429,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:13 GMT
+      - Wed, 04 Mar 2015 19:17:59 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2443,7 +2443,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:13 GMT
+      - Thu, 05 Mar 2015 01:17:59 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -3559,5 +3559,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/has_non-empty_id_value_for_outer_node.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/has_non-empty_id_value_for_outer_node.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:13 GMT
+      - Wed, 04 Mar 2015 19:17:59 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:13 GMT
+      - Thu, 05 Mar 2015 01:17:59 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/is_a_String.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/is_a_String.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:09 GMT
+      - Wed, 04 Mar 2015 19:17:56 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:09 GMT
+      - Thu, 05 Mar 2015 01:17:56 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/is_entire_anno_as_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/anno_jsonld/is_entire_anno_as_jsonld.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:10 GMT
+      - Wed, 04 Mar 2015 19:17:57 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:10 GMT
+      - Thu, 05 Mar 2015 01:17:57 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:10 GMT
+      - Wed, 04 Mar 2015 19:17:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:10 GMT
+      - Thu, 05 Mar 2015 01:17:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:11 GMT
+      - Wed, 04 Mar 2015 19:17:57 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:11 GMT
+      - Thu, 05 Mar 2015 01:17:57 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,7 +2347,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:57 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2371,7 +2371,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:11 GMT
+      - Wed, 04 Mar 2015 19:17:58 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2385,7 +2385,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:11 GMT
+      - Thu, 05 Mar 2015 01:17:58 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -3501,5 +3501,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/calls_Time_parse.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/calls_Time_parse.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:55 GMT
+      - Wed, 04 Mar 2015 19:17:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:55 GMT
+      - Thu, 05 Mar 2015 01:17:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/calls_annotated_at.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/calls_annotated_at.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:54 GMT
+      - Wed, 04 Mar 2015 19:17:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:54 GMT
+      - Thu, 05 Mar 2015 01:17:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:55 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/format_accepted_by_Solr_for_date_field.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/format_accepted_by_Solr_for_date_field.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:54 GMT
+      - Wed, 04 Mar 2015 19:17:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:54 GMT
+      - Thu, 05 Mar 2015 01:17:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:54 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/is_a_String.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/is_a_String.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:53 GMT
+      - Wed, 04 Mar 2015 19:17:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:53 GMT
+      - Thu, 05 Mar 2015 01:17:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:54 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/nil_if_date_won_t_parse_cleanly.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/annotated_at/nil_if_date_won_t_parse_cleanly.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:55 GMT
+      - Wed, 04 Mar 2015 19:17:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:55 GMT
+      - Thu, 05 Mar 2015 01:17:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/calls_body_chars.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/calls_body_chars.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:02 GMT
+      - Wed, 04 Mar 2015 19:17:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:02 GMT
+      - Thu, 05 Mar 2015 01:17:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/empty_Array_if_no_bodies_are_contentAsText.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/empty_Array_if_no_bodies_are_contentAsText.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:03 GMT
+      - Wed, 04 Mar 2015 19:17:51 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:03 GMT
+      - Thu, 05 Mar 2015 01:17:51 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:04 GMT
+      - Wed, 04 Mar 2015 19:17:51 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:04 GMT
+      - Thu, 05 Mar 2015 01:17:51 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:04 GMT
+      - Wed, 04 Mar 2015 19:17:52 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:04 GMT
+      - Thu, 05 Mar 2015 01:17:52 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,5 +2347,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:52 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/is_an_Array_of_Strings.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/is_an_Array_of_Strings.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:02 GMT
+      - Wed, 04 Mar 2015 19:17:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:02 GMT
+      - Thu, 05 Mar 2015 01:17:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/strips_the_Strings.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_chars_exact/strips_the_Strings.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:03 GMT
+      - Wed, 04 Mar 2015 19:17:51 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:03 GMT
+      - Thu, 05 Mar 2015 01:17:51 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/has_all_types_represented_by_multiple_bodies.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/has_all_types_represented_by_multiple_bodies.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:07 GMT
+      - Wed, 04 Mar 2015 19:17:54 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:07 GMT
+      - Thu, 05 Mar 2015 01:17:54 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:07 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:54 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:07 GMT
+      - Wed, 04 Mar 2015 19:17:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:07 GMT
+      - Thu, 05 Mar 2015 01:17:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:08 GMT
+      - Wed, 04 Mar 2015 19:17:55 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:08 GMT
+      - Thu, 05 Mar 2015 01:17:55 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,5 +2347,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/includes_content_as_text_if_a_body_is_as_such.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/includes_content_as_text_if_a_body_is_as_such.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:07 GMT
+      - Wed, 04 Mar 2015 19:17:54 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:07 GMT
+      - Thu, 05 Mar 2015 01:17:54 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:07 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/is_an_Array_with_external_URI_if_a_body_is_a_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/is_an_Array_with_external_URI_if_a_body_is_a_url.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:05 GMT
+      - Wed, 04 Mar 2015 19:17:52 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:05 GMT
+      - Thu, 05 Mar 2015 01:17:52 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:05 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:05 GMT
+      - Wed, 04 Mar 2015 19:17:52 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:05 GMT
+      - Thu, 05 Mar 2015 01:17:52 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:05 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:52 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:05 GMT
+      - Wed, 04 Mar 2015 19:17:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:05 GMT
+      - Thu, 05 Mar 2015 01:17:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,7 +2347,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:06 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -2371,7 +2371,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:06 GMT
+      - Wed, 04 Mar 2015 19:17:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -2385,7 +2385,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:06 GMT
+      - Thu, 05 Mar 2015 01:17:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -3501,7 +3501,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:06 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:53 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -3525,7 +3525,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:06 GMT
+      - Wed, 04 Mar 2015 19:17:53 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -3539,7 +3539,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:06 GMT
+      - Thu, 05 Mar 2015 01:17:53 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -4655,5 +4655,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:07 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/is_no_body_if_there_is_no_body.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_type/is_no_body_if_there_is_no_body.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:08 GMT
+      - Wed, 04 Mar 2015 19:17:55 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:08 GMT
+      - Thu, 05 Mar 2015 01:17:55 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:08 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:08 GMT
+      - Wed, 04 Mar 2015 19:17:55 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:08 GMT
+      - Thu, 05 Mar 2015 01:17:55 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:55 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:09 GMT
+      - Wed, 04 Mar 2015 19:17:56 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:09 GMT
+      - Thu, 05 Mar 2015 01:17:56 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,5 +2347,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/calls_predicate_urls_with_hasBody.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/calls_predicate_urls_with_hasBody.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:01 GMT
+      - Wed, 04 Mar 2015 19:17:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:01 GMT
+      - Thu, 05 Mar 2015 01:17:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/is_an_Array_of_urls_as_Strings.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/is_an_Array_of_urls_as_Strings.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:00 GMT
+      - Wed, 04 Mar 2015 19:17:48 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:00 GMT
+      - Thu, 05 Mar 2015 01:17:48 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:00 GMT
+      - Wed, 04 Mar 2015 19:17:48 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:00 GMT
+      - Thu, 05 Mar 2015 01:17:48 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:00 GMT
+      - Wed, 04 Mar 2015 19:17:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:00 GMT
+      - Thu, 05 Mar 2015 01:17:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,5 +2347,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/is_empty_array_if_no_bodies_are_urls.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/body_url/is_empty_array_if_no_bodies_are_urls.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:50:01 GMT
+      - Wed, 04 Mar 2015 19:17:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:50:01 GMT
+      - Thu, 05 Mar 2015 01:17:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/calls_id_as_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/calls_id_as_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:51 GMT
+      - Wed, 04 Mar 2015 19:17:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:51 GMT
+      - Thu, 05 Mar 2015 01:17:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:52 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/is_a_String.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/is_a_String.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:50 GMT
+      - Wed, 04 Mar 2015 19:17:40 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:50 GMT
+      - Thu, 05 Mar 2015 01:17:40 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:50 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/only_the_uuid_not_the_full_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/only_the_uuid_not_the_full_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:50 GMT
+      - Wed, 04 Mar 2015 19:17:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:50 GMT
+      - Thu, 05 Mar 2015 01:17:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:50 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/slash_not_part_of_base_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/id/slash_not_part_of_base_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:51 GMT
+      - Wed, 04 Mar 2015 19:17:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:51 GMT
+      - Thu, 05 Mar 2015 01:17:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:51 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/calls_motivated_by.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/calls_motivated_by.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:52 GMT
+      - Wed, 04 Mar 2015 19:17:42 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:52 GMT
+      - Thu, 05 Mar 2015 01:17:42 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:53 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/is_an_Array.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/is_an_Array.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:52 GMT
+      - Wed, 04 Mar 2015 19:17:42 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:52 GMT
+      - Thu, 05 Mar 2015 01:17:42 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:52 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/uses_short_Strings_not_the_full_urls.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/motivation/uses_short_Strings_not_the_full_urls.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:53 GMT
+      - Wed, 04 Mar 2015 19:17:43 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:53 GMT
+      - Thu, 05 Mar 2015 01:17:43 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:53 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/has_external_URI_once_if_multiple_targets.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/has_external_URI_once_if_multiple_targets.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Temporary Redirect
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:58 GMT
+      - Wed, 04 Mar 2015 19:17:47 GMT
       Server:
       - Apache/2
       Location:
@@ -27,7 +27,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:58 GMT
+      - Thu, 05 Mar 2015 01:17:47 GMT
       Content-Length:
       - '240'
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
         <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
         </body></html>
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -63,7 +63,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:58 GMT
+      - Wed, 04 Mar 2015 19:17:47 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -77,7 +77,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:58 GMT
+      - Thu, 05 Mar 2015 01:17:47 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1193,7 +1193,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1217,7 +1217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:59 GMT
+      - Wed, 04 Mar 2015 19:17:47 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1231,7 +1231,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:59 GMT
+      - Thu, 05 Mar 2015 01:17:47 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2347,5 +2347,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/is_an_Array_with_external_URI_if_a_target_is_a_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/is_an_Array_with_external_URI_if_a_target_is_a_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:57 GMT
+      - Wed, 04 Mar 2015 19:17:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:57 GMT
+      - Thu, 05 Mar 2015 01:17:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/is_nil_if_no_target_is_a_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_type/is_nil_if_no_target_is_a_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:59 GMT
+      - Wed, 04 Mar 2015 19:17:48 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:59 GMT
+      - Thu, 05 Mar 2015 01:17:48 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:50:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/calls_predicate_urls_with_hasTarget.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/calls_predicate_urls_with_hasTarget.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:56 GMT
+      - Wed, 04 Mar 2015 19:17:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:56 GMT
+      - Thu, 05 Mar 2015 01:17:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/is_an_Array_of_urls_as_Strings.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/is_an_Array_of_urls_as_Strings.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:56 GMT
+      - Wed, 04 Mar 2015 19:17:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:56 GMT
+      - Thu, 05 Mar 2015 01:17:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/is_empty_array_if_no_target_is_a_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Graph/solr_hash/target_url/is_empty_array_if_no_target_is_a_url.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 03 Feb 2015 22:49:57 GMT
+      - Wed, 04 Mar 2015 19:17:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 04:49:57 GMT
+      - Thu, 05 Mar 2015 01:17:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,5 +1153,5 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Tue, 03 Feb 2015 22:49:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:17:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"18717813e4715e6b02c340d9bdad589348393333"'
+      - '"76ef48e2ba748f946f942f104197b1873a53a0a0"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+      - http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+      string: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"303a5b9a40887bf2cc2058eb6b66272395dc8cd2"'
+      - '"45386e28e847c1f3e6ba6f142427e947c8d604d3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b
+      - http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b
+      string: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b
     body:
       encoding: UTF-8
       string: |
@@ -125,23 +125,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e7aded94cb473940c065119557c295533c30fa47"'
+      - '"d0ecefff80dc3602f5cf6a909f40274663a8998e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92
+      - http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92
+      string: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
     body:
       encoding: UTF-8
       string: |
@@ -151,7 +151,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -169,23 +169,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"545ecb027bc1b27c46058da0df47992137990220"'
+      - '"a0176644b20467571903176012c722f29e2e000a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t
+      - http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t
+      string: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t
     body:
       encoding: UTF-8
       string: |
@@ -207,23 +207,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5653c9b58757353624eca284649a688f440213ec"'
+      - '"72e936d8bd48bd50c02753a38edf7ffb0dd49a19"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee
+      - http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee
+      string: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
     body:
       encoding: US-ASCII
       string: ''
@@ -240,9 +240,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"525e72410f9db0ab0ce7750282fb1ef1e5e72f22"'
+      - '"6aee5b45499a733d053529b81b3adbba43de054d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -255,7 +255,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4541'
       Content-Type:
       - application/x-turtle
     body:
@@ -263,55 +263,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        , <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        , <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        , <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        , <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"14c7b732-545e-4451-a602-5456b3e8139d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b7de0d9b-1d73-47e6-b8f1-a316d2313a06\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.465Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.708Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:56.524Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:24.782Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9
     body:
       encoding: US-ASCII
       string: ''
@@ -328,9 +328,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e7aded94cb473940c065119557c295533c30fa47"'
+      - '"d0ecefff80dc3602f5cf6a909f40274663a8998e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -343,7 +343,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '5716'
+      - '5545'
       Content-Type:
       - application/x-turtle
     body:
@@ -351,66 +351,66 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/2b81d670-d911-4825-8bed-24367b32048f>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/4e17994c-1236-47f4-a415-50a6c50efd04>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:blanknode , content:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tns001:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"f9cbd81f-eaa1-49a8-bfc2-5bcf122e1527\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"b2ede2ba-5b35-452a-bb29-e40e21081946\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcontent:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/1823503c-e3d0-4dad-9f2a-4d861aebcd3f>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8417bb11-7f06-4af5-8c70-e73ee92bd57c>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:blanknode , content:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tns001:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"72bdbb3e-2c8b-466f-8060-8ccf9fca5e17\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"ab05f46d-c15b-4844-a3d0-9aef47d9b4ac\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcontent:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"ecaf45a6-db7f-45c1-9c28-58984652f517\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"017454f0-fd51-4184-ae32-3cb2377df2d5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.506Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:56.506Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.762Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:24.762Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/.well-known/genid/2b81d670-d911-4825-8bed-24367b32048f>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/.well-known/genid/1823503c-e3d0-4dad-9f2a-4d861aebcd3f>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/.well-known/genid/4e17994c-1236-47f4-a415-50a6c50efd04>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/.well-known/genid/8417bb11-7f06-4af5-8c70-e73ee92bd57c>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc
     body:
       encoding: US-ASCII
       string: ''
@@ -427,9 +427,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5653c9b58757353624eca284649a688f440213ec"'
+      - '"72e936d8bd48bd50c02753a38edf7ffb0dd49a19"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -442,7 +442,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -450,42 +450,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"eabe873d-3486-4c6a-899c-bf5cbc4bb8c1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"1dbc6c61-ca75-438e-b1f9-74d6572d255a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.801Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:56.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:24.801Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:56 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:24 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -509,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -523,7 +523,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:56 GMT
+      - Thu, 05 Mar 2015 01:26:25 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1639,10 +1639,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6
     body:
       encoding: US-ASCII
       string: ''
@@ -1659,9 +1659,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"525e72410f9db0ab0ce7750282fb1ef1e5e72f22"'
+      - '"6aee5b45499a733d053529b81b3adbba43de054d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1674,7 +1674,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4541'
       Content-Type:
       - application/x-turtle
     body:
@@ -1682,55 +1682,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        , <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        , <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        , <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        , <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"14c7b732-545e-4451-a602-5456b3e8139d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b7de0d9b-1d73-47e6-b8f1-a316d2313a06\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.465Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.708Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:56.524Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:24.782Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9
     body:
       encoding: US-ASCII
       string: ''
@@ -1747,9 +1747,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e7aded94cb473940c065119557c295533c30fa47"'
+      - '"d0ecefff80dc3602f5cf6a909f40274663a8998e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1762,7 +1762,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '5716'
+      - '5545'
       Content-Type:
       - application/x-turtle
     body:
@@ -1770,66 +1770,66 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/2b81d670-d911-4825-8bed-24367b32048f>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/4e17994c-1236-47f4-a415-50a6c50efd04>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:blanknode , content:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tns001:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"f9cbd81f-eaa1-49a8-bfc2-5bcf122e1527\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"b2ede2ba-5b35-452a-bb29-e40e21081946\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcontent:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/1823503c-e3d0-4dad-9f2a-4d861aebcd3f>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8417bb11-7f06-4af5-8c70-e73ee92bd57c>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:blanknode , content:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tns001:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"72bdbb3e-2c8b-466f-8060-8ccf9fca5e17\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"ab05f46d-c15b-4844-a3d0-9aef47d9b4ac\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcontent:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/b/16c70c6c-0884-477d-be39-ea1791b1cb92>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/b/e4518164-ba1a-45ff-8165-365f754fdbf9>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"ecaf45a6-db7f-45c1-9c28-58984652f517\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"017454f0-fd51-4184-ae32-3cb2377df2d5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.506Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:56.506Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.762Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:24.762Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/.well-known/genid/2b81d670-d911-4825-8bed-24367b32048f>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/.well-known/genid/1823503c-e3d0-4dad-9f2a-4d861aebcd3f>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/.well-known/genid/4e17994c-1236-47f4-a415-50a6c50efd04>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/.well-known/genid/8417bb11-7f06-4af5-8c70-e73ee92bd57c>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee
+    uri: http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc
     body:
       encoding: US-ASCII
       string: ''
@@ -1846,9 +1846,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5653c9b58757353624eca284649a688f440213ec"'
+      - '"72e936d8bd48bd50c02753a38edf7ffb0dd49a19"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:56 GMT
+      - Wed, 04 Mar 2015 19:26:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1861,7 +1861,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1869,40 +1869,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3701f6e7-19d3-4c43-8738-30af01997ca0/t/219f19f5-7060-4a7d-b6ec-233131a7afee/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/30d52440-c0ae-44ca-8595-c92db5814af6/t/b408d767-5a95-4ae9-84ed-d436b29277cc/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"eabe873d-3486-4c6a-899c-bf5cbc4bb8c1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"1dbc6c61-ca75-438e-b1f9-74d6572d255a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:56.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:24.801Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:56.551Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:24.801Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d8766dca399feac7e6fb10f85661aac7709384e2"'
+      - '"a159ba04ca5decc9e19a9a4e9d3ab7b7a8eea2e1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+      - http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+      string: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"641be93c6ff96c19fa4a0afaaf1168ddcdcce20e"'
+      - '"ca5eeb9484c6a718063df5007b33d16673be1610"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b
+      - http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b
+      string: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b
     body:
       encoding: UTF-8
       string: |
@@ -123,23 +123,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9cc09db57057d36a882122090d1093e8dd5bcae1"'
+      - '"e6c179fd367c36ea93fd42ee4f1b0e3f28f0f7c7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89
+      - http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89
+      string: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
     body:
       encoding: UTF-8
       string: |
@@ -149,7 +149,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -167,23 +167,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f3e0898e7591c182350f447bb9069625856b511"'
+      - '"f398c9ea83357a808a3bb64ab9fb95855b5c8805"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t
+      - http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t
+      string: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t
     body:
       encoding: UTF-8
       string: |
@@ -205,23 +205,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"764603331be6e7bfc3817a538f6046480ee06fe0"'
+      - '"6b5ebbda48c329231fd8ed4887a537c1047d842c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a
+      - http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a
+      string: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
     body:
       encoding: US-ASCII
       string: ''
@@ -238,9 +238,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0966def9709f56bb96cdc3ce1e1f25915c902960"'
+      - '"df38ffc16025c82462769de68fac05fae60413e3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -253,7 +253,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -261,55 +261,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        , <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        , <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        , <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        , <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6b0d1b04-66e5-4896-baf4-c2515d79875e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"bfa71cad-56bf-4e92-9e83-5dbddb402e8e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.567Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.751Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.814Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf
     body:
       encoding: US-ASCII
       string: ''
@@ -326,9 +326,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9cc09db57057d36a882122090d1093e8dd5bcae1"'
+      - '"e6c179fd367c36ea93fd42ee4f1b0e3f28f0f7c7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -341,7 +341,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6639'
+      - '6702'
       Content-Type:
       - application/x-turtle
     body:
@@ -349,76 +349,75 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#item1>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8c69946a-8fdf-4441-be5a-1cf4c9cbe2e0\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://text.transcriptions.com> ;\n\tfcrepo:mixinTypes
-        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#default>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Sound , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"777964fe-4541-4e06-812d-9bf213b931c9\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"944199c4-a1a4-42cc-a1e6-2d85a4793378\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:mixinTypes
         \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#item1>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ac8a2626-7ea9-4dec-ac38-3cef41afdcbe\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://text.transcriptions.com> ;\n\tfcrepo:mixinTypes
+        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"7ca1bfde-2fe2-4999-98a5-a7a4abf4e76f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"6eda60a0-0f31-4c77-96bb-c7f1feddfad2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:25 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543
     body:
       encoding: US-ASCII
       string: ''
@@ -435,9 +434,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"764603331be6e7bfc3817a538f6046480ee06fe0"'
+      - '"6b5ebbda48c329231fd8ed4887a537c1047d842c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -450,7 +449,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -458,43 +457,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0ccd5a9e-bb51-4254-8877-f764c4dd742a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"3cb429e2-fdf2-4835-af7e-a577bcb28152\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.831Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:25.831Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:57 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -518,7 +517,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -532,7 +531,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:57 GMT
+      - Thu, 05 Mar 2015 01:26:26 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1648,10 +1647,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d
     body:
       encoding: US-ASCII
       string: ''
@@ -1668,9 +1667,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0966def9709f56bb96cdc3ce1e1f25915c902960"'
+      - '"df38ffc16025c82462769de68fac05fae60413e3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1683,7 +1682,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1691,55 +1690,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        , <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        , <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        , <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        , <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed>
+        <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6b0d1b04-66e5-4896-baf4-c2515d79875e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"bfa71cad-56bf-4e92-9e83-5dbddb402e8e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.567Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.751Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.617Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.814Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf
     body:
       encoding: US-ASCII
       string: ''
@@ -1756,9 +1755,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9cc09db57057d36a882122090d1093e8dd5bcae1"'
+      - '"e6c179fd367c36ea93fd42ee4f1b0e3f28f0f7c7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1771,7 +1770,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6639'
+      - '6702'
       Content-Type:
       - application/x-turtle
     body:
@@ -1779,76 +1778,75 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#item1>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8c69946a-8fdf-4441-be5a-1cf4c9cbe2e0\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://text.transcriptions.com> ;\n\tfcrepo:mixinTypes
-        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#default>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Sound , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"777964fe-4541-4e06-812d-9bf213b931c9\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"944199c4-a1a4-42cc-a1e6-2d85a4793378\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:mixinTypes
         \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#item1>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ac8a2626-7ea9-4dec-ac38-3cef41afdcbe\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://text.transcriptions.com> ;\n\tfcrepo:mixinTypes
+        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"7ca1bfde-2fe2-4999-98a5-a7a4abf4e76f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"6eda60a0-0f31-4c77-96bb-c7f1feddfad2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.604Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:25.797Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/b/cac28392-2a08-4445-8a6d-01807004bf89#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/b/98debd41-92f6-4ef4-9e3e-c975edd90baf#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a
+    uri: http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543
     body:
       encoding: US-ASCII
       string: ''
@@ -1865,9 +1863,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"764603331be6e7bfc3817a538f6046480ee06fe0"'
+      - '"6b5ebbda48c329231fd8ed4887a537c1047d842c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:57 GMT
+      - Wed, 04 Mar 2015 19:26:25 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1880,7 +1878,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1888,41 +1886,41 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b5407d74-ecd7-4e1a-9628-038bba17b0ed/t/6cc4e616-9d3a-4698-b459-db5657e6421a>
+        .\n\n<http://localhost:8983/fedora/rest/anno/c1d32dc1-43cf-4880-983c-ffa0268c866d/t/c9df1291-70e6-40d7-b360-23cc96a79543>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0ccd5a9e-bb51-4254-8877-f764c4dd742a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"3cb429e2-fdf2-4835-af7e-a577bcb28152\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:57.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:57.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:25.831Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:25.831Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b22b4b9af9e86807c1f2b349dbc6df03c95e9aaa"'
+      - '"21116bbc54c751955a5756ad43d9ecdc25221390"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+      - http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+      string: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2c2406029fb42a024a9d9fe67848f510fae20254"'
+      - '"196a97c7979b2c22ae7135b7b77c43f25e96c206"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b
+      - http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b
+      string: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"96767da0bbf3d64d743455dbfda01930d08106f4"'
+      - '"e247604af62a6a4c3e04f337685836dc34aea502"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed
+      - http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed
+      string: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1dc66deadadf4b12df5a19a4e8d7c7d41cd181b3"'
+      - '"93ded5a116e5c4dff2a2f8600ca46516bb7b5527"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t
+      - http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t
+      string: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t
     body:
       encoding: UTF-8
       string: |
@@ -200,23 +200,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4a4002ed630b473672e7bd8b1be6b371adb41a87"'
+      - '"30506507577c01b0deaf3748311e6aedc1bd8f46"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc
+      - http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc
+      string: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
     body:
       encoding: US-ASCII
       string: ''
@@ -233,9 +233,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"da19d72f88a9904e609cbb8b4ef93c573fc14dbb"'
+      - '"c535711eb70f9c37f441fb960966da0ee8e2b0bf"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -248,7 +248,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4462'
       Content-Type:
       - application/x-turtle
     body:
@@ -256,54 +256,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        , <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        , <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        , <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        , <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"a6e7dd63-3ccd-431a-8278-dcb4c1ad3460\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b9007665-ccc4-422c-8d84-b94ccff1310d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.673Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:26 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53
     body:
       encoding: US-ASCII
       string: ''
@@ -320,9 +320,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"96767da0bbf3d64d743455dbfda01930d08106f4"'
+      - '"e247604af62a6a4c3e04f337685836dc34aea502"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -335,7 +335,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -343,46 +343,45 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"53ffa36e-0ccd-4be6-a35f-0fbbeab56b41\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e751cc47-0c9b-454c-8971-059d0a92ad38\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.824Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:26.824Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220
     body:
       encoding: US-ASCII
       string: ''
@@ -399,9 +398,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4a4002ed630b473672e7bd8b1be6b371adb41a87"'
+      - '"30506507577c01b0deaf3748311e6aedc1bd8f46"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -414,7 +413,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6409'
+      - '6361'
       Content-Type:
       - application/x-turtle
     body:
@@ -422,71 +421,71 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#item1>
+        <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#item1>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eeb3c097-bdac-414e-a0dc-635e4b865393\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a2886880-9443-4df7-a2f3-59dc8dd20e42\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://some.external.ref/item> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#default>
+        \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5359190c-a337-4eef-9b83-643770f53911\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"4229dce3-8588-419c-ba53-ede3e3ff09ae\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://some.external.ref/default> ;\n\tfcrepo:mixinTypes
         \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"91e6201e-0a84-48c6-bd4a-b2b7d6e61fa2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"39450490-c3c3-4f97-bf45-a1b7aaf226a5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:58 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -510,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -524,7 +523,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:58 GMT
+      - Thu, 05 Mar 2015 01:26:27 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1640,10 +1639,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2
     body:
       encoding: US-ASCII
       string: ''
@@ -1660,9 +1659,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"da19d72f88a9904e609cbb8b4ef93c573fc14dbb"'
+      - '"c535711eb70f9c37f441fb960966da0ee8e2b0bf"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1675,7 +1674,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4462'
       Content-Type:
       - application/x-turtle
     body:
@@ -1683,54 +1682,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        , <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        , <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        , <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        , <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"a6e7dd63-3ccd-431a-8278-dcb4c1ad3460\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"b9007665-ccc4-422c-8d84-b94ccff1310d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.673Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.728Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.839Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53
     body:
       encoding: US-ASCII
       string: ''
@@ -1747,9 +1746,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"96767da0bbf3d64d743455dbfda01930d08106f4"'
+      - '"e247604af62a6a4c3e04f337685836dc34aea502"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1762,7 +1761,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1770,46 +1769,45 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/b/5e704c02-407e-4763-a9a0-1f90009021ed>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/b/6c67e2a6-7c1c-451c-82f6-0dfa0a43fb53>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"53ffa36e-0ccd-4be6-a35f-0fbbeab56b41\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e751cc47-0c9b-454c-8971-059d0a92ad38\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.824Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:58.706Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:26.824Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc
+    uri: http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220
     body:
       encoding: US-ASCII
       string: ''
@@ -1826,9 +1824,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4a4002ed630b473672e7bd8b1be6b371adb41a87"'
+      - '"30506507577c01b0deaf3748311e6aedc1bd8f46"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:58 GMT
+      - Wed, 04 Mar 2015 19:26:26 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1841,7 +1839,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6409'
+      - '6361'
       Content-Type:
       - application/x-turtle
     body:
@@ -1849,69 +1847,69 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#item1>
+        <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#item1>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eeb3c097-bdac-414e-a0dc-635e4b865393\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a2886880-9443-4df7-a2f3-59dc8dd20e42\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://some.external.ref/item> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#default>
+        \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5359190c-a337-4eef-9b83-643770f53911\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"4229dce3-8588-419c-ba53-ede3e3ff09ae\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://some.external.ref/default> ;\n\tfcrepo:mixinTypes
         \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc>
+        <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"91e6201e-0a84-48c6-bd4a-b2b7d6e61fa2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"39450490-c3c3-4f97-bf45-a1b7aaf226a5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:26.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:58.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/9490e9e9-e009-438c-aff1-b3d577f8c96e/t/fde53ca8-4d58-4b60-97a3-a803f2f088fc#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/82e471c2-cb62-422d-8863-6b21c4c36ca2/t/ef3b6b20-661b-467e-9dd7-5dd88f351220#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a2cdb8f781cbb36691cc796d0942d7f7e7dbacbe"'
+      - '"58b61feacc9fea75c62d734e86abddc9d86a586a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+      - http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+      string: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"59153c5cbcb904b994b53990afc045616cbba36c"'
+      - '"47a2649fbb8cf68f371c8e5ebf5430e51db70d32"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b
+      - http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b
+      string: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"370c2eea08cd58a9ac9edec2e2dbe33032160366"'
+      - '"abf1ba9e7cb11cc71f6d015b1aae01ee02d076c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95
+      - http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95
+      string: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"24177cecb0914219184870dd73a4005896655ee8"'
+      - '"98e71aac6be702efea399e7e71cec43464bcd1b6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t
+      - http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t
+      string: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t
     body:
       encoding: UTF-8
       string: |
@@ -205,23 +205,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"982941c0295ff22e660a0de062182e9cdc391739"'
+      - '"60d284abe895cbb2ea0aea1c483028395b2cd88b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6
+      - http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6
+      string: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
     body:
       encoding: US-ASCII
       string: ''
@@ -238,9 +238,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9411a78204eef230441ff0effeb2b50367df9aa3"'
+      - '"9a42a44e79aaa0d15421e8ec2132eae851590db4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -253,7 +253,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4541'
       Content-Type:
       - application/x-turtle
     body:
@@ -261,55 +261,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6910bba4-edde-4cfd-85b6-bdf08aa4c0c6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"dcdab175-b63e-4f7a-947a-24a2681860fd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.869Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.874Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.923Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:27 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9
     body:
       encoding: US-ASCII
       string: ''
@@ -326,9 +326,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"370c2eea08cd58a9ac9edec2e2dbe33032160366"'
+      - '"abf1ba9e7cb11cc71f6d015b1aae01ee02d076c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -341,7 +341,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -349,46 +349,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
+        <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"d7c506d6-bbee-4b0b-a530-5f59a30ea02e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"2d34aa13-8be2-4eb4-95a0-46152e58edda\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.907Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:59.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:27.907Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:59 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4
     body:
       encoding: US-ASCII
       string: ''
@@ -405,9 +405,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"982941c0295ff22e660a0de062182e9cdc391739"'
+      - '"60d284abe895cbb2ea0aea1c483028395b2cd88b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -420,7 +420,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '7949'
+      - '7776'
       Content-Type:
       - application/x-turtle
     body:
@@ -428,85 +428,84 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item1>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item1>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3631d6ae-8f46-4d69-a809-ce0c51dcd25f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3a2f6958-455e-4930-8956-2128c1a293ea\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/large> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item2>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4c415b45-83ca-413d-bbe3-620da237df8e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1235e823-8ede-4edd-9a1e-448d2e8b3a6d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://images.com/huge> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#default>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8a16b30e-dbac-4777-ba10-819ccaa61b87\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/small> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item2>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"83032c84-044d-411a-a82e-48b987065fbb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://images.com/huge> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"701f6b61-99ef-43a4-9781-d97408113163\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"52e124cc-8120-466b-978a-e44727d86728\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item2>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item2>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -530,7 +529,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:00 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -544,7 +543,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:00 GMT
+      - Thu, 05 Mar 2015 01:26:28 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1660,10 +1659,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18
     body:
       encoding: US-ASCII
       string: ''
@@ -1680,9 +1679,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9411a78204eef230441ff0effeb2b50367df9aa3"'
+      - '"9a42a44e79aaa0d15421e8ec2132eae851590db4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1695,7 +1694,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4541'
       Content-Type:
       - application/x-turtle
     body:
@@ -1703,55 +1702,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6910bba4-edde-4cfd-85b6-bdf08aa4c0c6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"dcdab175-b63e-4f7a-947a-24a2681860fd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.869Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.874Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.923Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9
     body:
       encoding: US-ASCII
       string: ''
@@ -1768,9 +1767,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"370c2eea08cd58a9ac9edec2e2dbe33032160366"'
+      - '"abf1ba9e7cb11cc71f6d015b1aae01ee02d076c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1783,7 +1782,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1791,46 +1790,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b>
+        <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/b/fdb27733-c524-451e-924f-6902ad17ce95>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/b/4f13d047-47c5-4a46-a0a9-be15e95d66f9>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"d7c506d6-bbee-4b0b-a530-5f59a30ea02e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"2d34aa13-8be2-4eb4-95a0-46152e58edda\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.907Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:59.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:27.907Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6
+    uri: http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4
     body:
       encoding: US-ASCII
       string: ''
@@ -1847,9 +1846,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"982941c0295ff22e660a0de062182e9cdc391739"'
+      - '"60d284abe895cbb2ea0aea1c483028395b2cd88b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:59 GMT
+      - Wed, 04 Mar 2015 19:26:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1862,7 +1861,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '7949'
+      - '7776'
       Content-Type:
       - application/x-turtle
     body:
@@ -1870,83 +1869,82 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item1>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item1>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3631d6ae-8f46-4d69-a809-ce0c51dcd25f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3a2f6958-455e-4930-8956-2128c1a293ea\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/large> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item2>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4c415b45-83ca-413d-bbe3-620da237df8e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1235e823-8ede-4edd-9a1e-448d2e8b3a6d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://images.com/huge> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#default>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8a16b30e-dbac-4777-ba10-819ccaa61b87\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/small> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item2>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"83032c84-044d-411a-a82e-48b987065fbb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://images.com/huge> ;\n\tfcrepo:mixinTypes
+        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Choice , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"701f6b61-99ef-43a4-9781-d97408113163\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"52e124cc-8120-466b-978a-e44727d86728\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:59.905Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:27.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item2>
-        , <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#item1>
-        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/ec504ea3-2cef-4eea-8173-451326e1d7fa/t/af9307d2-31a4-4c58-85a3-c6f39991f4a6#default>
+        ;\n\topenannotation:item <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item2>
+        , <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#item1>
+        ;\n\topenannotation:default <http://localhost:8983/fedora/rest/anno/15735c54-ba11-477f-af7d-8a7747835c18/t/ab779624-5d9c-4207-a7bd-fe104dc99fb4#default>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:00 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"856770fdfe62d7c050c14bfad8af22b6796a380a"'
+      - '"c824daa5f4d02b4330e57b8c19d9f363e0f4eeda"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+      - http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+      string: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fb269427974b313cb1eeeb0a25321ea9dc167623"'
+      - '"b4fde00e1710fce8dcfcc66bdc4d6615972290a4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b
+      - http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b
+      string: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0432555af772eb3d98cdd31377efcac61a83c049"'
+      - '"fff64d40f09af26d594f60c5a777b25d22f0b5e7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e
+      - http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e
+      string: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6ec2d85eb332329c95aa28be9ff408c482d93c3d"'
+      - '"70bd8ec939f828e46b9fad1ebe0c0b19ec22c05a"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t
+      - http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t
+      string: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"01c10c9d63c9b30e344305e7b71e0fb1ff17f011"'
+      - '"b254a8d367d0786904f32feff5c1dc300f8a62e7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97
+      - http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97
+      string: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"830ef3174abbcf8b22d170cdf4e876fd0b1135a4"'
+      - '"4fdd2f0c447dce5c172767ca365c679f998c5763"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4541'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,55 +251,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b>
-        , <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b>
-        , <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b>
+        , <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b>
+        , <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"7b62d5a2-f38e-4c23-a145-32097eba3d9a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"546502ad-a736-49e4-afd6-622cd785ed8a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:18.548Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:38.451Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:18.599Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:38.502Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d
     body:
       encoding: US-ASCII
       string: ''
@@ -316,9 +316,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0432555af772eb3d98cdd31377efcac61a83c049"'
+      - '"fff64d40f09af26d594f60c5a777b25d22f0b5e7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -331,7 +331,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3871'
+      - '3823'
       Content-Type:
       - application/x-turtle
     body:
@@ -339,47 +339,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/b/f114ee7b-c474-4a76-a387-f01efb79d44e>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/b/e9e6377d-06c1-4ca4-9654-9884df15453d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c4ed422f-5385-41f2-8236-6f5abed07800\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"20e370d7-fb2e-4dc1-b240-a8bd7eacef69\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:18.577Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:18.577Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:38.487Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:38.487Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"Solr integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d
     body:
       encoding: US-ASCII
       string: ''
@@ -396,9 +396,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"01c10c9d63c9b30e344305e7b71e0fb1ff17f011"'
+      - '"b254a8d367d0786904f32feff5c1dc300f8a62e7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:18 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -411,7 +411,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3573'
+      - '3642'
       Content-Type:
       - application/x-turtle
     body:
@@ -419,42 +419,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71/t/c2deadc3-ff28-4742-b428-bc63dafd9e97>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc/t/3fb43c40-c147-4004-8c55-c6297982f07d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"2986e51a-a9b0-4d06-851b-5a0c726603e9\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6dc2d87a-f3a9-4b35-b6c4-8772c75f9815\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:18.613Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:38.516Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:18.613Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:38.516Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -478,7 +479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:12:19 GMT
+      - Wed, 04 Mar 2015 19:26:39 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -492,7 +493,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:12:19 GMT
+      - Thu, 05 Mar 2015 01:26:39 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1608,18 +1609,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">c3b51478-9246-4dce-95a0-a72c91fe1e71</field><field name="motivation">commenting</field><field
+        name="id">53971460-8a06-4e56-b12a-ca09d9f582fc</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291547858400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/c3b51478-9246-4dce-95a0-a72c91fe1e71","@type":"oa:Annotation","hasBody":"_:g70291547858400","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121627498120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/53971460-8a06-4e56-b12a-ca09d9f582fc","@type":"oa:Annotation","hasBody":"_:g70121627498120","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1635,12 +1636,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:39 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=c3b51478-9246-4dce-95a0-a72c91fe1e71&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=53971460-8a06-4e56-b12a-ca09d9f582fc&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -1651,9 +1652,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:20 GMT
+      - Wed, 04 Mar 2015 19:26:39 GMT
       Etag:
-      - '"NmE4MDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"NGIwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -1664,27 +1665,27 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>1,
+            'QTime'=>4,
             'params'=>{
-              'id'=>'c3b51478-9246-4dce-95a0-a72c91fe1e71',
+              'id'=>'53971460-8a06-4e56-b12a-ca09d9f582fc',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'c3b51478-9246-4dce-95a0-a72c91fe1e71',
+                'id'=>'53971460-8a06-4e56-b12a-ca09d9f582fc',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291547858400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/c3b51478-9246-4dce-95a0-a72c91fe1e71","@type":"oa:Annotation","hasBody":"_:g70291547858400","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1492132812109643776,
-                'timestamp'=>'2015-02-04T00:12:19.575Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121627498120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/53971460-8a06-4e56-b12a-ca09d9f582fc","@type":"oa:Annotation","hasBody":"_:g70121627498120","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1494742151066550272,
+                'timestamp'=>'2015-03-04T19:26:39.122Z'}]
           }}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:24 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:40 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/c3b51478-9246-4dce-95a0-a72c91fe1e71
+    uri: http://localhost:8983/fedora/rest/anno/53971460-8a06-4e56-b12a-ca09d9f582fc
     body:
       encoding: US-ASCII
       string: ''
@@ -1704,13 +1705,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:24 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>c3b51478-9246-4dce-95a0-a72c91fe1e71</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>53971460-8a06-4e56-b12a-ca09d9f582fc</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -1728,7 +1729,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:24 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -1750,12 +1751,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>11}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:24 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=c3b51478-9246-4dce-95a0-a72c91fe1e71&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=53971460-8a06-4e56-b12a-ca09d9f582fc&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -1766,9 +1767,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:24 GMT
+      - Wed, 04 Mar 2015 19:26:40 GMT
       Etag:
-      - '"MWE4MDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MmIwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -1779,12 +1780,12 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>0,
+            'QTime'=>1,
             'params'=>{
-              'id'=>'c3b51478-9246-4dce-95a0-a72c91fe1e71',
+              'id'=>'53971460-8a06-4e56-b12a-ca09d9f582fc',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]
           }}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:26 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:12:26 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -37,7 +37,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:12:26 GMT
+      - Thu, 05 Mar 2015 01:26:41 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1153,7 +1153,7 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -1180,23 +1180,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"460907cd81b139d6783bfb2f33be3b5e96ea0d8f"'
+      - '"64f449197d0caa55865d496f49570eb3f95140a9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2
+      - http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2
+      string: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed
     body:
       encoding: UTF-8
       string: |
@@ -1206,7 +1206,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -1224,23 +1224,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"409dfad7e7f942126db1ec6d6ef2e26b1a7e9489"'
+      - '"c1eb8781e951c7ef23226b325e2690613f29f036"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b
+      - http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b
+      string: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b
     body:
       encoding: UTF-8
       string: |
@@ -1267,23 +1267,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2cd19216895e512d65fbbdb2c363bd3eaa3ec882"'
+      - '"0dc4f8008ecb464f73df69f369852019a3397e57"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a
+      - http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a
+      string: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed
     body:
       encoding: UTF-8
       string: |
@@ -1293,7 +1293,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -1311,23 +1311,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"42b332cdc89c2262131ea45c2b63330b45a582b5"'
+      - '"ceafebeb0d5f762ea5e5ccb11bca7a1915ade13c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t
+      - http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t
+      string: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t
     body:
       encoding: UTF-8
       string: |
@@ -1349,23 +1349,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"18497ee9ba3ae61ed67fd5a8f891f40c1d63a618"'
+      - '"117fa797e50aa9b06140c4d2e27f2904da1bd6fc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8
+      - http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8
+      string: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed
     body:
       encoding: US-ASCII
       string: ''
@@ -1382,9 +1382,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5d084c28fd507a68425c4f7655d923b8ebcb7e40"'
+      - '"baae195fb7ba3b064d4ed456bfc67a384ab91ccb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1397,7 +1397,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1405,55 +1405,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b>
-        , <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b>
-        , <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
-        .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
-        .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b>
+        , <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b>
+        , <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"dbe27f23-6505-46ee-9a84-c32708743544\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"365ba9fb-82b4-4d3f-ad75-b5c5ca25e5b2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:27.216Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:41.615Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:27.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:41.673Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff
     body:
       encoding: US-ASCII
       string: ''
@@ -1470,9 +1469,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2cd19216895e512d65fbbdb2c363bd3eaa3ec882"'
+      - '"0dc4f8008ecb464f73df69f369852019a3397e57"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1485,7 +1484,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3754'
+      - '3706'
       Content-Type:
       - application/x-turtle
     body:
@@ -1493,46 +1492,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b>
+        <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/b/b7156b66-20be-4a3b-a736-bebf23d2ed7a>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/b/6f6f0d3d-4cd6-4ce6-af0d-3329089502ff>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"65524e3b-bb4e-4cb5-ae8d-51a0e4c53ffd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ff29c1a3-2827-41e5-91f4-78f52431f89e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:27.258Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:27.258Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:41.658Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
-        \"Solr integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:41.658Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tcontent:chars \"Solr integration test\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8
+    uri: http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87
     body:
       encoding: US-ASCII
       string: ''
@@ -1549,9 +1549,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"18497ee9ba3ae61ed67fd5a8f891f40c1d63a618"'
+      - '"117fa797e50aa9b06140c4d2e27f2904da1bd6fc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1564,7 +1564,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3573'
+      - '3525'
       Content-Type:
       - application/x-turtle
     body:
@@ -1572,42 +1572,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/2baa8af1-3ac4-4608-8cbf-afc74ada01d2/t/9f00073a-a0fd-4c3c-abc2-856729e41ca8>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/6a17642e-ebed-4c6d-b845-67e2803a22ed/t/4565c87d-9d55-411e-b60a-e1ab1a8a9e87/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"1aace569-b9c0-4898-89d3-46346765c8ec\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6c455374-c402-423c-a9f0-248bb446807f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:27.296Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:41.687Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:27.296Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:41.687Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:42 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -1631,7 +1631,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:12:27 GMT
+      - Wed, 04 Mar 2015 19:26:42 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -1645,7 +1645,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:12:27 GMT
+      - Thu, 05 Mar 2015 01:26:42 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -2761,18 +2761,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:42 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">2baa8af1-3ac4-4608-8cbf-afc74ada01d2</field><field name="motivation">commenting</field><field
+        name="id">6a17642e-ebed-4c6d-b845-67e2803a22ed</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291546165180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/2baa8af1-3ac4-4608-8cbf-afc74ada01d2","@type":"oa:Annotation","hasBody":"_:g70291546165180","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121679257840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/6a17642e-ebed-4c6d-b845-67e2803a22ed","@type":"oa:Annotation","hasBody":"_:g70121679257840","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -2788,12 +2788,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:27 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=2baa8af1-3ac4-4608-8cbf-afc74ada01d2&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=6a17642e-ebed-4c6d-b845-67e2803a22ed&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -2804,9 +2804,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:28 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Etag:
-      - '"NWE4MDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"NmIwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -2817,22 +2817,22 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>1,
+            'QTime'=>0,
             'params'=>{
-              'id'=>'2baa8af1-3ac4-4608-8cbf-afc74ada01d2',
+              'id'=>'6a17642e-ebed-4c6d-b845-67e2803a22ed',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'2baa8af1-3ac4-4608-8cbf-afc74ada01d2',
+                'id'=>'6a17642e-ebed-4c6d-b845-67e2803a22ed',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291546165180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/2baa8af1-3ac4-4608-8cbf-afc74ada01d2","@type":"oa:Annotation","hasBody":"_:g70291546165180","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1492132820878884864,
-                'timestamp'=>'2015-02-04T00:12:27.938Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121679257840","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/6a17642e-ebed-4c6d-b845-67e2803a22ed","@type":"oa:Annotation","hasBody":"_:g70121679257840","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1494742154602348544,
+                'timestamp'=>'2015-03-04T19:26:42.494Z'}]
           }}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:32 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2d833ea586399ab6c2620dd36c2d8c9d0998d2de"'
+      - '"09590b1bd41b99e73e3802c5528c31f2d705cfbb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:32 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc
+      - http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc
+      string: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:32 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"04a290ad14a37de7f3703fc90d37bc90ff87c295"'
+      - '"5d6a91c7ef2cf4d5996badb78814074c131c0e78"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b
+      - http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b
+      string: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ac9c6540caa10ea8cfbb391de466f01fa66bbd6e"'
+      - '"ce65ce4fa5b6f2fc70c1fd51dad6d9f611796c99"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918
+      - http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918
+      string: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7101c226b26aa0900dc980d869de2c75164d1b27"'
+      - '"36c08207bb708454804cc13059d992be6c07298e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t
+      - http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t
+      string: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bb1ba0fae8d42146a18fc954422b805a30aa596b"'
+      - '"4ee2f5f50da066ee86a94d3e6a944e1d0dfa9b83"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115
+      - http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115
+      string: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"dda4250f0787e7efb29bfece74a15117863458fb"'
+      - '"a02e4b94f62cdbb90568deacfedcdcfbfeee3254"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,54 +251,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b>
-        , <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b>
-        , <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b>
+        , <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b>
+        , <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"03f13f0b-889d-4546-bdf0-be1c17e77545\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"16843f3d-3348-460a-8a20-8023935ed90e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:32.994Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:43.547Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T00:12:33.037Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:43.605Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32
     body:
       encoding: US-ASCII
       string: ''
@@ -315,9 +315,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ac9c6540caa10ea8cfbb391de466f01fa66bbd6e"'
+      - '"ce65ce4fa5b6f2fc70c1fd51dad6d9f611796c99"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -330,7 +330,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3871'
+      - '3823'
       Content-Type:
       - application/x-turtle
     body:
@@ -338,48 +338,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/b/b2b88b59-1cb1-4b6c-a993-f57535ba0918>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/b/5d298366-573e-4ab7-9d81-4c9f35e7ce32>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"bda7dd92-2b72-46cd-87bd-1e6363e95c8e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"eddc35a8-c70e-4a5e-936f-3089f9533937\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:33.024Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:43.589Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:43.589Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:12:33.024Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tcontent:chars \"Solr integration test\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
+        \"Solr integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115
+    uri: http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1
     body:
       encoding: US-ASCII
       string: ''
@@ -396,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bb1ba0fae8d42146a18fc954422b805a30aa596b"'
+      - '"4ee2f5f50da066ee86a94d3e6a944e1d0dfa9b83"'
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -411,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3573'
+      - '3640'
       Content-Type:
       - application/x-turtle
     body:
@@ -419,43 +418,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t>
+        <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/343c453d-e545-45d3-b9fa-cb60231d20bc/t/4924bbf9-d850-4470-80c7-38d33c663115/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/0f7977a4-264f-499f-8e42-c993417430a0/t/addf8fe1-c73e-4afd-94f8-5cc9ab0e41b1>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"aea26a8b-6dc7-48cd-9c34-49e234f3e5a7\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"28f63c8a-18f9-4770-936d-cb5142c3e389\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T00:12:33.049Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:43.62Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:43.62Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T00:12:33.049Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:43 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -479,7 +478,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 00:12:33 GMT
+      - Wed, 04 Mar 2015 19:26:44 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -493,7 +492,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 06:12:33 GMT
+      - Thu, 05 Mar 2015 01:26:44 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1609,18 +1608,18 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">343c453d-e545-45d3-b9fa-cb60231d20bc</field><field name="motivation">commenting</field><field
+        name="id">0f7977a4-264f-499f-8e42-c993417430a0</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291555704260","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/343c453d-e545-45d3-b9fa-cb60231d20bc","@type":"oa:Annotation","hasBody":"_:g70291555704260","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121685483340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/0f7977a4-264f-499f-8e42-c993417430a0","@type":"oa:Annotation","hasBody":"_:g70121685483340","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -1636,12 +1635,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:33 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=343c453d-e545-45d3-b9fa-cb60231d20bc&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=0f7977a4-264f-499f-8e42-c993417430a0&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -1652,9 +1651,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Feb 2015 00:12:34 GMT
+      - Wed, 04 Mar 2015 19:26:44 GMT
       Etag:
-      - '"M2E4MDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MWIwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -1667,20 +1666,20 @@ http_interactions:
             'status'=>0,
             'QTime'=>1,
             'params'=>{
-              'id'=>'343c453d-e545-45d3-b9fa-cb60231d20bc',
+              'id'=>'0f7977a4-264f-499f-8e42-c993417430a0',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'343c453d-e545-45d3-b9fa-cb60231d20bc',
+                'id'=>'0f7977a4-264f-499f-8e42-c993417430a0',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70291555704260","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/343c453d-e545-45d3-b9fa-cb60231d20bc","@type":"oa:Annotation","hasBody":"_:g70291555704260","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1492132827047657472,
-                'timestamp'=>'2015-02-04T00:12:33.822Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa.jsonld","@graph":[{"@id":"_:g70121685483340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/0f7977a4-264f-499f-8e42-c993417430a0","@type":"oa:Annotation","hasBody":"_:g70121685483340","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1494742156420579328,
+                'timestamp'=>'2015-03-04T19:26:44.227Z'}]
           }}
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 00:12:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5ef6b593c3e9431c2d6043431ccbaa5c1200b890"'
+      - '"a1386a4d3b2869870be7b2496d3b97b634cab772"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:13 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+      - http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+      string: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a2dac6267c17ae82c7a3509f904941ed60940a9e"'
+      - '"b6894a42243fc520a086c6946355d29f63b227a4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:13 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b
+      - http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b
+      string: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b
     body:
       encoding: UTF-8
       string: |
@@ -120,23 +120,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3f3fd6d4e395acb48772a442be5568f1b5b01406"'
+      - '"044599c98dee9fd886150ef5613e99d79c7ee64d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268
+      - http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268
+      string: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
     body:
       encoding: UTF-8
       string: |
@@ -146,7 +146,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -164,23 +164,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d898c17780ce552cae425bd830546c8ea7b9d50d"'
+      - '"289abaa2296b2f7c38516b2f6c2778f04aef4691"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t
+      - http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t
+      string: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t
     body:
       encoding: UTF-8
       string: |
@@ -202,23 +202,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"263c4f8cbefd0a4d96b615527b75f8f0cf5c81d5"'
+      - '"ef7f3fb76f3e798c040be9109451149c68a62069"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008
+      - http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008
+      string: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
     body:
       encoding: US-ASCII
       string: ''
@@ -235,9 +235,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f445c775d5d0ca2a43eea503eac6d3dca00dcc10"'
+      - '"85a25c5d14dfe8eb2679194fc27c64647939b9aa"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -250,7 +250,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4510'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -269,44 +269,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        , <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        , <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        , <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        , <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"dbd86fad-ed25-48bb-ad33-37b16e696f9f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"23a3e405-ad49-4bb5-ae38-d0b7688a7ccc\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:13.951Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.292Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.02Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.345Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c
     body:
       encoding: US-ASCII
       string: ''
@@ -323,9 +323,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3f3fd6d4e395acb48772a442be5568f1b5b01406"'
+      - '"044599c98dee9fd886150ef5613e99d79c7ee64d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -338,7 +338,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6076'
+      - '6072'
       Content-Type:
       - application/x-turtle
     body:
@@ -357,59 +357,59 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e0c48ac7-79c5-462c-b911-ce8adb201b7d>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/64f42374-221b-49e9-963f-acb3a3780bd0>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"10aeed9d-3660-4463-8148-b03a689f9b1e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3996dd3e-2159-48d0-b0d0-6afb340e9140\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"024699dd-64ab-46b6-b664-120b05021d6c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"45324a0c-e961-40e7-9eed-91ef8f5c5c0c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e0c48ac7-79c5-462c-b911-ce8adb201b7d>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/64f42374-221b-49e9-963f-acb3a3780bd0>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c87c5c4c-9f2f-44a5-b988-81fdef053b77\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"58d88cca-6292-4a8e-a50c-6d582e4bb05f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268#source>
+        <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"263c4f8cbefd0a4d96b615527b75f8f0cf5c81d5"'
+      - '"ef7f3fb76f3e798c040be9109451149c68a62069"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -441,7 +441,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -460,32 +460,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"b68e33b6-e45e-47a7-90ea-ca972c151875\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"0f4e12da-fef1-4eb5-a296-0e225fc3d19f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.033Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:14.033Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:46.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -509,7 +508,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -523,7 +522,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:14 GMT
+      - Thu, 05 Mar 2015 01:26:46 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1639,10 +1638,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143
     body:
       encoding: US-ASCII
       string: ''
@@ -1659,9 +1658,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f445c775d5d0ca2a43eea503eac6d3dca00dcc10"'
+      - '"85a25c5d14dfe8eb2679194fc27c64647939b9aa"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1674,7 +1673,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4510'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -1693,44 +1692,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        , <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        , <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        , <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        , <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"dbd86fad-ed25-48bb-ad33-37b16e696f9f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"23a3e405-ad49-4bb5-ae38-d0b7688a7ccc\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:13.951Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.292Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.02Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.345Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c
     body:
       encoding: US-ASCII
       string: ''
@@ -1747,9 +1746,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3f3fd6d4e395acb48772a442be5568f1b5b01406"'
+      - '"044599c98dee9fd886150ef5613e99d79c7ee64d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1762,7 +1761,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6076'
+      - '6072'
       Content-Type:
       - application/x-turtle
     body:
@@ -1781,59 +1780,59 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e0c48ac7-79c5-462c-b911-ce8adb201b7d>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/64f42374-221b-49e9-963f-acb3a3780bd0>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"10aeed9d-3660-4463-8148-b03a689f9b1e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3996dd3e-2159-48d0-b0d0-6afb340e9140\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"024699dd-64ab-46b6-b664-120b05021d6c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"45324a0c-e961-40e7-9eed-91ef8f5c5c0c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e0c48ac7-79c5-462c-b911-ce8adb201b7d>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/64f42374-221b-49e9-963f-acb3a3780bd0>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c87c5c4c-9f2f-44a5-b988-81fdef053b77\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"58d88cca-6292-4a8e-a50c-6d582e4bb05f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:14.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:46.33Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/b/fccb15e7-0dec-4e99-9c14-aba59f8d5268#source>
+        <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/b/88d7cad9-5146-4a4b-9e49-630bc9939d8c#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008
+    uri: http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23
     body:
       encoding: US-ASCII
       string: ''
@@ -1850,9 +1849,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"263c4f8cbefd0a4d96b615527b75f8f0cf5c81d5"'
+      - '"ef7f3fb76f3e798c040be9109451149c68a62069"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:14 GMT
+      - Wed, 04 Mar 2015 19:26:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1865,7 +1864,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3569'
       Content-Type:
       - application/x-turtle
     body:
@@ -1884,30 +1883,29 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/768193a3-21ad-4041-89e8-ac48664cbdfc/t/8ba6e797-a36b-42bd-83eb-78342da33008>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/2be5e349-0954-4750-a53f-0b59066b0143/t/dd818752-73f9-427d-8b42-22661912ba23/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"b68e33b6-e45e-47a7-90ea-ca972c151875\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"0f4e12da-fef1-4eb5-a296-0e225fc3d19f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:14.033Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:46.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:14.033Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:46.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"641809076ccddf176a57826b67e5e9db6eab2153"'
+      - '"1be4191f6f1d143cc4b30ea3ea632f7cf342b44c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+      - http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+      string: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b4fa71a5c51b819211baf69472e8f5e3087b1708"'
+      - '"826d3669f03557f38b879333c8613ac65e55ef41"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b
+      - http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b
+      string: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b
     body:
       encoding: UTF-8
       string: |
@@ -119,23 +119,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1f66cc3e8b64a12d74822b8bb7a85a85a7b9768e"'
+      - '"828f96a2e2c3f40c87697aef2f34ea9885a2002c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f
+      - http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f
+      string: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
     body:
       encoding: UTF-8
       string: |
@@ -145,7 +145,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -163,23 +163,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"307c86f7b473a5e32cff4058587030e44e437f9d"'
+      - '"830401aae7b81aa807ce10ef442488c51ab62201"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t
+      - http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t
+      string: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3ab0d787c8572851db99adbcc1ad7e95c6f858b5"'
+      - '"348228448e276fbfbe5d1e492d9bca2f2636541d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6
+      - http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6
+      string: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
     body:
       encoding: US-ASCII
       string: ''
@@ -234,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f5233ebd0984b8e269324c56233f72cb683b82e5"'
+      - '"78ad8bc944a884e899e3cae1f60971f0bad84938"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -249,7 +249,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -268,44 +268,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        , <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        , <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        , <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        , <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"836c0286-5ce9-4d65-863e-c4d2dda891d4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"8d1b187f-ba3e-425f-b357-a79ae0fcb9f4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.402Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.234Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.459Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.287Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5
     body:
       encoding: US-ASCII
       string: ''
@@ -322,9 +322,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1f66cc3e8b64a12d74822b8bb7a85a85a7b9768e"'
+      - '"828f96a2e2c3f40c87697aef2f34ea9885a2002c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -337,7 +337,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6093'
+      - '5976'
       Content-Type:
       - application/x-turtle
     body:
@@ -356,59 +356,59 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e8ab2b9d-b09c-430f-b9d9-4246d5d3909f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7d6ce904-1c5e-4571-9c62-8257da19fe5a>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"ad850b06-fa0b-47de-9e21-3cd1b590bc1c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e777025c-11b3-465e-874e-8984b31620d1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:end \"66\"^^<http://www.w3.org/2001/XMLSchema#long> ;\n\topenannotation:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f#source>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8dcd420c-983d-4c69-9529-556cbe350208\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ee1f0829-b2bc-46a9-95e7-da769ecd2988\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e8ab2b9d-b09c-430f-b9d9-4246d5d3909f>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7d6ce904-1c5e-4571-9c62-8257da19fe5a>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"15db5778-466a-4f06-93e1-97fab7702ced\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"eb0ab0fd-58a5-418d-a20d-67263c7e7539\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f#source>
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66
     body:
       encoding: US-ASCII
       string: ''
@@ -425,9 +425,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ab0d787c8572851db99adbcc1ad7e95c6f858b5"'
+      - '"348228448e276fbfbe5d1e492d9bca2f2636541d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -459,31 +459,31 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"bd5fdcd4-bfe7-480e-a759-c82834c337a2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"4dc93ccf-a394-4576-a547-ed34c89976a9\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.472Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.472Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:48.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -507,7 +507,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -521,7 +521,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:16 GMT
+      - Thu, 05 Mar 2015 01:26:48 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1637,10 +1637,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb
     body:
       encoding: US-ASCII
       string: ''
@@ -1657,9 +1657,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f5233ebd0984b8e269324c56233f72cb683b82e5"'
+      - '"78ad8bc944a884e899e3cae1f60971f0bad84938"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1672,7 +1672,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -1691,44 +1691,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        , <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        , <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d>
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        , <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        , <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"836c0286-5ce9-4d65-863e-c4d2dda891d4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"8d1b187f-ba3e-425f-b357-a79ae0fcb9f4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.402Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.234Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.459Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.287Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5
     body:
       encoding: US-ASCII
       string: ''
@@ -1745,9 +1745,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1f66cc3e8b64a12d74822b8bb7a85a85a7b9768e"'
+      - '"828f96a2e2c3f40c87697aef2f34ea9885a2002c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1760,7 +1760,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6093'
+      - '5976'
       Content-Type:
       - application/x-turtle
     body:
@@ -1779,59 +1779,59 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e8ab2b9d-b09c-430f-b9d9-4246d5d3909f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7d6ce904-1c5e-4571-9c62-8257da19fe5a>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"ad850b06-fa0b-47de-9e21-3cd1b590bc1c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e777025c-11b3-465e-874e-8984b31620d1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:end \"66\"^^<http://www.w3.org/2001/XMLSchema#long> ;\n\topenannotation:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f#source>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8dcd420c-983d-4c69-9529-556cbe350208\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ee1f0829-b2bc-46a9-95e7-da769ecd2988\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e8ab2b9d-b09c-430f-b9d9-4246d5d3909f>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7d6ce904-1c5e-4571-9c62-8257da19fe5a>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"15db5778-466a-4f06-93e1-97fab7702ced\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"eb0ab0fd-58a5-418d-a20d-67263c7e7539\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.444Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:48.272Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/b/9e69cbb3-8033-4ed6-8375-fa522fe85c8f#source>
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/b/c3e6771a-f648-4193-8b3c-19236e8a1ba5#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6
+    uri: http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66
     body:
       encoding: US-ASCII
       string: ''
@@ -1848,9 +1848,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ab0d787c8572851db99adbcc1ad7e95c6f858b5"'
+      - '"348228448e276fbfbe5d1e492d9bca2f2636541d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:16 GMT
+      - Wed, 04 Mar 2015 19:26:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1882,29 +1882,29 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/896da946-b5a1-4478-a09f-b456f5c6ee6d/t/0610c61f-952a-4bf1-9b45-346de44b92c6>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/af45f847-733d-4eec-8ef7-7c7e46a48ecb/t/702cafb8-6490-4d59-9074-f90b96f02d66/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"bd5fdcd4-bfe7-480e-a759-c82834c337a2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"4dc93ccf-a394-4576-a547-ed34c89976a9\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:16.472Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:16.472Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:48.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:48.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"aef2412390e8af81afbc72d6d82f79454b27f7fa"'
+      - '"bb24187d5d758bd184130c544a46dcf56ac65ebd"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+      - http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+      string: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e8c40f7e920cbdc1e61e5dfcc7b22a3e944c000d"'
+      - '"50854c3e6b108efb0da537bda6060704cd426716"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b
+      - http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b
+      string: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b
     body:
       encoding: UTF-8
       string: |
@@ -120,23 +120,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5529857b8a17809f5bdc5937fae7ec6e859f484e"'
+      - '"8495f6b9aede8a57423d9ede63a1fcdb379437d5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901
+      - http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901
+      string: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
     body:
       encoding: UTF-8
       string: |
@@ -146,7 +146,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -164,23 +164,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4c55dbc2d181287ec923a1b380700b035cf1d2ec"'
+      - '"d684d51b14e36c73566476e14ccd71a8ee73bd5b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t
+      - http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t
+      string: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t
     body:
       encoding: UTF-8
       string: |
@@ -202,23 +202,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7bafc1fc4f077a43ef244237369f85979674f6b8"'
+      - '"046601fc34f4270b2299d5688e902d0ebebc47a9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368
+      - http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368
+      string: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
     body:
       encoding: US-ASCII
       string: ''
@@ -235,9 +235,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c7b9d9d6979a85b53f801ccee4ad1d078fb6204c"'
+      - '"a35094cd26f0ae96efa7118b113e954c05e8f578"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -269,43 +269,43 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        , <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        , <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        , <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        , <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"05cc0142-d29c-42ae-81e5-142b67f9b71f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"52befe7f-9be7-4051-a96a-70db7e489b3d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.873Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.174Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.922Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.318Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef
     body:
       encoding: US-ASCII
       string: ''
@@ -322,9 +322,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5529857b8a17809f5bdc5937fae7ec6e859f484e"'
+      - '"8495f6b9aede8a57423d9ede63a1fcdb379437d5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -356,60 +356,60 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7989d57d-5d40-4538-9e5d-5c0124d68f7b>
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/a4b2361f-7d13-45d9-83fe-cbfbadb05177>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextQuoteSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"8eae6796-caf2-4762-b885-0f2103fca3b0\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"30b30400-e73d-49c3-bc5a-9dabd8719a88\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextQuoteSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"e98b9836-a0cc-4d32-b6c4-321d7f6bc882\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a3defdd7-61aa-46e3-a910-2ecd3c2f9ec6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7989d57d-5d40-4538-9e5d-5c0124d68f7b>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/a4b2361f-7d13-45d9-83fe-cbfbadb05177>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eb9532d1-7110-4791-ac46-be15366c22bb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"aecf4716-bf77-4ccd-b597-d76496234984\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:hasSource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7bafc1fc4f077a43ef244237369f85979674f6b8"'
+      - '"046601fc34f4270b2299d5688e902d0ebebc47a9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -460,32 +460,32 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ffaabb2a-b724-41e5-ab22-ef276ad1653a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"0f40f480-ed09-460d-b5cf-aa26b8959a8a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.935Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.935Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.339Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:50.339Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -509,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -523,7 +523,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:18 GMT
+      - Thu, 05 Mar 2015 01:26:50 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1639,10 +1639,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b
     body:
       encoding: US-ASCII
       string: ''
@@ -1659,9 +1659,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c7b9d9d6979a85b53f801ccee4ad1d078fb6204c"'
+      - '"a35094cd26f0ae96efa7118b113e954c05e8f578"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1693,43 +1693,43 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        , <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        , <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        , <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        , <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"05cc0142-d29c-42ae-81e5-142b67f9b71f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"52befe7f-9be7-4051-a96a-70db7e489b3d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.873Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.174Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.922Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.318Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef
     body:
       encoding: US-ASCII
       string: ''
@@ -1746,9 +1746,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5529857b8a17809f5bdc5937fae7ec6e859f484e"'
+      - '"8495f6b9aede8a57423d9ede63a1fcdb379437d5"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1780,60 +1780,60 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7989d57d-5d40-4538-9e5d-5c0124d68f7b>
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/a4b2361f-7d13-45d9-83fe-cbfbadb05177>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextQuoteSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"8eae6796-caf2-4762-b885-0f2103fca3b0\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"30b30400-e73d-49c3-bc5a-9dabd8719a88\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextQuoteSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"e98b9836-a0cc-4d32-b6c4-321d7f6bc882\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a3defdd7-61aa-46e3-a910-2ecd3c2f9ec6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7989d57d-5d40-4538-9e5d-5c0124d68f7b>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/a4b2361f-7d13-45d9-83fe-cbfbadb05177>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eb9532d1-7110-4791-ac46-be15366c22bb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"aecf4716-bf77-4ccd-b597-d76496234984\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:50.301Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:18.908Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:hasSource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/b/fa564f99-5f9f-4a8e-8f43-44ad584e5901#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/b/0f0e757f-4a57-4a3f-a819-92b0d64a47ef#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368
+    uri: http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c
     body:
       encoding: US-ASCII
       string: ''
@@ -1850,9 +1850,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7bafc1fc4f077a43ef244237369f85979674f6b8"'
+      - '"046601fc34f4270b2299d5688e902d0ebebc47a9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:18 GMT
+      - Wed, 04 Mar 2015 19:26:50 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1884,30 +1884,30 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f46a3830-5759-44d5-827b-99d6e9ff668b/t/515fbdbc-5a1a-4f1f-ae35-91f44ac40368>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f6e5d6c7-87a7-49bf-9da4-f001ff635c9b/t/a1ac8e0c-7853-43dc-bae5-35f49160795c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ffaabb2a-b724-41e5-ab22-ef276ad1653a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"0f40f480-ed09-460d-b5cf-aa26b8959a8a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:18.935Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:18.935Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:50.339Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:50.339Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:19 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f014aedc0956699f150c27a3c508a7c7cfb2fa4c"'
+      - '"2c9373a506b060b385c17f89b555eea4d2710d03"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+      - http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+      string: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a9d4d68d3cd13f3ba2415783bf65e55087135a14"'
+      - '"bb0372329b227670f3f4fd927574184b09dba0c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b
+      - http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b
+      string: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6d4415816360ea8cc1fbb1b0c0e789833fd430aa"'
+      - '"50c5de47d660931010671a635e17aba0dbc0a626"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff
+      - http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff
+      string: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b1477a2634bee99a4e59bb9c04e823cf5263f0ff"'
+      - '"b618d28af13a267a4e53b7f56be94d83a9d9cdc7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t
+      - http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t
+      string: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t
     body:
       encoding: UTF-8
       string: |
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"42d36a8b6b66e621f4846982987cde66d91ca667"'
+      - '"ce6d595c16116a4ab0bcc2855e6072c31237479d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd
+      - http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd
+      string: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
     body:
       encoding: US-ASCII
       string: ''
@@ -237,9 +237,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e8d70c2803c26ca491d5d11c19818c04edf1c636"'
+      - '"c28637892ca9755f6f93486179c64f5958aa48a4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -252,7 +252,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -271,44 +271,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        , <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        , <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        , <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        , <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eb0606ce-4223-4400-9bef-c380ebb4f010\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"605d1329-9d90-4ebd-a8a1-84bf5fb89660\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.077Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:20.121Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:51.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed
     body:
       encoding: US-ASCII
       string: ''
@@ -325,9 +325,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6d4415816360ea8cc1fbb1b0c0e789833fd430aa"'
+      - '"50c5de47d660931010671a635e17aba0dbc0a626"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -359,34 +359,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"6548b18a-f13b-4e02-a954-2ba83bb8650e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"cef2a481-750d-4260-b55d-e1bdbab115e3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.108Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:20.108Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.342Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:51.342Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d
     body:
       encoding: US-ASCII
       string: ''
@@ -403,9 +403,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"42d36a8b6b66e621f4846982987cde66d91ca667"'
+      - '"ce6d595c16116a4ab0bcc2855e6072c31237479d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -418,7 +418,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6151'
+      - '6038'
       Content-Type:
       - application/x-turtle
     body:
@@ -437,56 +437,56 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/5d317ccf-491d-4be8-9f35-7fbbc743791e>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/cd2fb348-48ac-491b-aaac-36d72594f5b6>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2c2e1560-b82d-4e19-8bca-7833f5ef59ee\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"04e145c8-26b4-4ef3-89a4-a8299dedb5c9\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"828acbdd-9b7d-4a1a-a08a-d192ff170888\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4e4c8ae-2777-49ea-9e61-e21d5d0b0691\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/5d317ccf-491d-4be8-9f35-7fbbc743791e>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/cd2fb348-48ac-491b-aaac-36d72594f5b6>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"46690cda-3dad-4cd7-91d7-a577f7ab3721\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"118c6abb-a599-429e-b0fb-eecb290df931\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:51 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -510,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -524,7 +524,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:20 GMT
+      - Thu, 05 Mar 2015 01:26:51 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1640,10 +1640,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099
     body:
       encoding: US-ASCII
       string: ''
@@ -1660,9 +1660,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e8d70c2803c26ca491d5d11c19818c04edf1c636"'
+      - '"c28637892ca9755f6f93486179c64f5958aa48a4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1675,7 +1675,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -1694,44 +1694,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        , <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        , <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        , <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        , <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"eb0606ce-4223-4400-9bef-c380ebb4f010\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"605d1329-9d90-4ebd-a8a1-84bf5fb89660\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.077Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:20.121Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:51.357Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed
     body:
       encoding: US-ASCII
       string: ''
@@ -1748,9 +1748,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6d4415816360ea8cc1fbb1b0c0e789833fd430aa"'
+      - '"50c5de47d660931010671a635e17aba0dbc0a626"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1782,34 +1782,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b>
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/b/98255a47-49a9-45c8-821a-378a228012ff/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/b/37c0a2aa-08b4-4f6e-bc7c-68618e1c83ed/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"6548b18a-f13b-4e02-a954-2ba83bb8650e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"cef2a481-750d-4260-b55d-e1bdbab115e3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.108Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:20.108Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.342Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:51.342Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:20 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd
+    uri: http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d
     body:
       encoding: US-ASCII
       string: ''
@@ -1826,9 +1826,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"42d36a8b6b66e621f4846982987cde66d91ca667"'
+      - '"ce6d595c16116a4ab0bcc2855e6072c31237479d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:20 GMT
+      - Wed, 04 Mar 2015 19:26:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1841,7 +1841,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6151'
+      - '6038'
       Content-Type:
       - application/x-turtle
     body:
@@ -1860,54 +1860,54 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/5d317ccf-491d-4be8-9f35-7fbbc743791e>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/cd2fb348-48ac-491b-aaac-36d72594f5b6>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2c2e1560-b82d-4e19-8bca-7833f5ef59ee\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"04e145c8-26b4-4ef3-89a4-a8299dedb5c9\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , dcmitype:Image , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"828acbdd-9b7d-4a1a-a08a-d192ff170888\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4e4c8ae-2777-49ea-9e61-e21d5d0b0691\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/5d317ccf-491d-4be8-9f35-7fbbc743791e>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/cd2fb348-48ac-491b-aaac-36d72594f5b6>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"46690cda-3dad-4cd7-91d7-a577f7ab3721\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"118c6abb-a599-429e-b0fb-eecb290df931\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:51.376Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:20.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/dc279650-2b87-427d-8a79-938d5682f3f9/t/3eef5575-bb77-49cf-a9f6-cba56c238ebd#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/3f9b72a9-057e-4b69-bac0-4e9c59bef099/t/67a64379-3db7-4b87-8d8d-8f4295abdb3d#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:21 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:52 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e91cca932ef63ccac888cfa0880f14454f35e8d5"'
+      - '"99572028160562b267a91e7c080c027a464c1b5d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+      - http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+      string: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"27bd9a1d341860a5e6e26723d5bd2274444ba632"'
+      - '"746af695c4dd5bccbeefa5c9a583a62174656d42"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b
+      - http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b
+      string: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0d63ff120456405974515e685496a8fa3c80da87"'
+      - '"17dddd532dfd6d76cef81572342e7d17b42527c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5
+      - http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5
+      string: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cc656068a453b8fc97c7c8c513219e9472548956"'
+      - '"c5ecf8f9cd12e81986870e72954738940bc37e37"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t
+      - http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t
+      string: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t
     body:
       encoding: UTF-8
       string: |
@@ -202,23 +202,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6cb1ea5d2f703d229621cf7b1656777a921d7553"'
+      - '"38ed3ed00e378175f04851f90969155936adb3f4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3
+      - http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3
+      string: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
     body:
       encoding: US-ASCII
       string: ''
@@ -235,9 +235,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6b3b405e3a0a4dc21017eb0b2b0a24d3290dd095"'
+      - '"961b9fcfaa3623a9db67c7a27c925c98a285682c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -269,44 +269,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        , <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        , <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        , <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        , <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"f285ceec-180c-41a7-8a2a-0d25cf42797a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"48bcbea3-dc0f-4691-8b73-18074ac7e41e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.872Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.278Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.913Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043
     body:
       encoding: US-ASCII
       string: ''
@@ -323,9 +323,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d63ff120456405974515e685496a8fa3c80da87"'
+      - '"17dddd532dfd6d76cef81572342e7d17b42527c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -338,7 +338,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3686'
       Content-Type:
       - application/x-turtle
     body:
@@ -357,34 +357,35 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"17523360-e5e0-471c-ba6f-d82948396f66\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"4f79d90e-946b-4760-9636-d7c5681ada0c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.901Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.901Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:45.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2
     body:
       encoding: US-ASCII
       string: ''
@@ -401,9 +402,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6cb1ea5d2f703d229621cf7b1656777a921d7553"'
+      - '"38ed3ed00e378175f04851f90969155936adb3f4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -416,7 +417,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '5955'
+      - '5959'
       Content-Type:
       - application/x-turtle
     body:
@@ -435,56 +436,56 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/d7e27194-89b7-4978-b6e9-ef0d97479b5f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6606bcc0-fb33-459a-a1b3-13ff6c539b41>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3dd0a82d-58e7-4016-adc6-7ba9ccdf8625\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2792a0fa-0de8-4f90-8d0b-3fe7edecc99d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2f7a1688-2c1d-4291-a45b-8e41aa93fd45\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"37610c38-0b4a-4174-a321-8c6df181afc3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/d7e27194-89b7-4978-b6e9-ef0d97479b5f>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/6606bcc0-fb33-459a-a1b3-13ff6c539b41>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2b039d0d-558f-45f0-9fe3-bcc92b954821\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ecce3391-7359-4494-a931-485eca77cfde\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -508,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -522,7 +523,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:12 GMT
+      - Thu, 05 Mar 2015 01:26:45 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1638,10 +1639,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4
     body:
       encoding: US-ASCII
       string: ''
@@ -1658,9 +1659,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6b3b405e3a0a4dc21017eb0b2b0a24d3290dd095"'
+      - '"961b9fcfaa3623a9db67c7a27c925c98a285682c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1692,44 +1693,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        , <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        , <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/fcr:export?format=jcr/xml>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        , <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        , <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"f285ceec-180c-41a7-8a2a-0d25cf42797a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"48bcbea3-dc0f-4691-8b73-18074ac7e41e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.872Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.278Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.913Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043
     body:
       encoding: US-ASCII
       string: ''
@@ -1746,9 +1747,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d63ff120456405974515e685496a8fa3c80da87"'
+      - '"17dddd532dfd6d76cef81572342e7d17b42527c9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1761,7 +1762,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3686'
       Content-Type:
       - application/x-turtle
     body:
@@ -1780,34 +1781,35 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b>
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/b/932371be-dfae-4b5f-acb7-62e28213b6d5/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/b/156ac9b7-cf5e-457b-838b-b4bb49dc9043>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"17523360-e5e0-471c-ba6f-d82948396f66\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"4f79d90e-946b-4760-9636-d7c5681ada0c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.901Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.901Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:45.311Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3
+    uri: http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2
     body:
       encoding: US-ASCII
       string: ''
@@ -1824,9 +1826,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6cb1ea5d2f703d229621cf7b1656777a921d7553"'
+      - '"38ed3ed00e378175f04851f90969155936adb3f4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:12 GMT
+      - Wed, 04 Mar 2015 19:26:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1839,7 +1841,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '5955'
+      - '5959'
       Content-Type:
       - application/x-turtle
     body:
@@ -1858,54 +1860,54 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/d7e27194-89b7-4978-b6e9-ef0d97479b5f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6606bcc0-fb33-459a-a1b3-13ff6c539b41>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , openannotation:FragmentSelector , fedora:blanknode , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3dd0a82d-58e7-4016-adc6-7ba9ccdf8625\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2792a0fa-0de8-4f90-8d0b-3fe7edecc99d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"openannotation:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3#source>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2f7a1688-2c1d-4291-a45b-8e41aa93fd45\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"37610c38-0b4a-4174-a321-8c6df181afc3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/d7e27194-89b7-4978-b6e9-ef0d97479b5f>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/6606bcc0-fb33-459a-a1b3-13ff6c539b41>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"2b039d0d-558f-45f0-9fe3-bcc92b954821\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"ecce3391-7359-4494-a931-485eca77cfde\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:45.359Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:12.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/658b53c4-9907-41f4-837d-152e6d8abcaf/t/9a219944-34a4-47b5-bc8a-951471d7ecd3#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/121a638b-c3ea-4986-9ed6-bf4c12e302a4/t/0fa19ada-b62a-4149-9745-78407f14d3c2#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b7eb088078fea184a272ec01ae9f323124e44b40"'
+      - '"e9f5a5186c77025158c13def6a013bd4e73203fb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+      - http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+      string: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5e4319cfce1922044044c549dc1ee097144fffe5"'
+      - '"0c0214095968d5f77cb3ffd11c7a6840139d1069"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b
+      - http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b
+      string: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fc4683703aa86894aaac099ee3a98179f68acf5e"'
+      - '"da1a20f3b1cd9767b60feaab8b782214d7807e2e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9
+      - http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9
+      string: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"add6c608b228dfabb7fe7f7b932060488ec11d35"'
+      - '"37850e90e9d378433a78b0995836f388dc38d6bc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t
+      - http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t
+      string: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"58cbab75bc4e4752ce2b28f736a56daff50b227b"'
+      - '"9224d7fabe2e068ea313632df2b24517a295ae31"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088
+      - http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088
+      string: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
     body:
       encoding: US-ASCII
       string: ''
@@ -234,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e8c2baa4fe4981bcca8f06da54cb5b0ee02e5482"'
+      - '"c767fcdee52d0ddf81e89c401f7f56d2eef63daa"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -249,7 +249,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -268,43 +268,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        , <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        , <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        , <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        , <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c6bf532d-fe1b-4e30-b362-18666f5c3ee7\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d05fb084-cae1-4eb9-9443-01656ea6f26d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.233Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:15.288Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.322Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f
     body:
       encoding: US-ASCII
       string: ''
@@ -321,9 +322,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fc4683703aa86894aaac099ee3a98179f68acf5e"'
+      - '"da1a20f3b1cd9767b60feaab8b782214d7807e2e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -355,34 +356,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"e74cc0c1-f2f5-408c-8f6a-985ee2ae1f8e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"dd6210a9-1897-43a7-a706-b1b7e7018e38\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.274Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:15.274Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:47.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf
     body:
       encoding: US-ASCII
       string: ''
@@ -399,9 +400,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"58cbab75bc4e4752ce2b28f736a56daff50b227b"'
+      - '"9224d7fabe2e068ea313632df2b24517a295ae31"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -433,56 +434,55 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/4aaee62e-eb93-4274-9f14-3cfdfdef8688>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e50ad670-de30-4eea-bb90-e1c746d7407c>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"a6b1fa9b-6ea3-497b-83cf-5be346623611\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2792a03d-228a-4adc-82a9-dcbab1526fbe\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:end \"66\"^^<http://www.w3.org/2001/XMLSchema#long> ;\n\topenannotation:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088#source>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5bd27041-e4e4-4c3a-b620-c183d6bdc7cb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e4de9179-b0cd-47a2-b553-e6304b14db8d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/4aaee62e-eb93-4274-9f14-3cfdfdef8688>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e50ad670-de30-4eea-bb90-e1c746d7407c>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4bda6be2-1555-44ee-8917-a489a55040ca\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"cae57f2f-61bd-4d70-893d-ba2df8b03ea2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:hasSource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -520,7 +520,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:15 GMT
+      - Thu, 05 Mar 2015 01:26:47 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1636,10 +1636,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c
     body:
       encoding: US-ASCII
       string: ''
@@ -1656,9 +1656,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e8c2baa4fe4981bcca8f06da54cb5b0ee02e5482"'
+      - '"c767fcdee52d0ddf81e89c401f7f56d2eef63daa"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1671,7 +1671,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -1690,43 +1690,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        , <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        , <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        , <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        , <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"c6bf532d-fe1b-4e30-b362-18666f5c3ee7\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d05fb084-cae1-4eb9-9443-01656ea6f26d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.233Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.277Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:15.288Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.322Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f
     body:
       encoding: US-ASCII
       string: ''
@@ -1743,9 +1744,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fc4683703aa86894aaac099ee3a98179f68acf5e"'
+      - '"da1a20f3b1cd9767b60feaab8b782214d7807e2e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1777,34 +1778,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/b/a54aa9e7-5e15-4226-84ec-84b904363da9>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/b/8cf1693a-c1ba-4a91-aea5-eaf7076c7f9f/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"e74cc0c1-f2f5-408c-8f6a-985ee2ae1f8e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"dd6210a9-1897-43a7-a706-b1b7e7018e38\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.274Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:15.274Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:47.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088
+    uri: http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf
     body:
       encoding: US-ASCII
       string: ''
@@ -1821,9 +1822,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"58cbab75bc4e4752ce2b28f736a56daff50b227b"'
+      - '"9224d7fabe2e068ea313632df2b24517a295ae31"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:15 GMT
+      - Wed, 04 Mar 2015 19:26:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1855,54 +1856,53 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/4aaee62e-eb93-4274-9f14-3cfdfdef8688>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e50ad670-de30-4eea-bb90-e1c746d7407c>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"a6b1fa9b-6ea3-497b-83cf-5be346623611\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2792a03d-228a-4adc-82a9-dcbab1526fbe\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:end \"66\"^^<http://www.w3.org/2001/XMLSchema#long> ;\n\topenannotation:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088#source>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5bd27041-e4e4-4c3a-b620-c183d6bdc7cb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e4de9179-b0cd-47a2-b553-e6304b14db8d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088/fcr:export?format=jcr/xml>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/4aaee62e-eb93-4274-9f14-3cfdfdef8688>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e50ad670-de30-4eea-bb90-e1c746d7407c>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"4bda6be2-1555-44ee-8917-a489a55040ca\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"cae57f2f-61bd-4d70-893d-ba2df8b03ea2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:47.343Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:15.307Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\topenannotation:hasSource <http://localhost:8983/fedora/rest/anno/09c56d57-afdd-49f8-9102-b942fb7f6191/t/8ed8468d-b87f-4a79-a7fb-7bc59db43088#source>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
+        <http://localhost:8983/fedora/rest/anno/4cc85bbf-6e5d-4542-b49c-b5035ef66f4c/t/abe1f81d-48d1-4321-af81-e77c1ca6b5cf#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:16 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"267c8cfc3fda932223d0eb28eca5b6f193aa1b50"'
+      - '"a49b2cc35dd5ea13fd79cdfcbfab06761ae3688b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+      - http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+      string: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b0cb8baf30bb57f6abcf89ec6d397da0c17e4981"'
+      - '"ee797b97268bb6c8c60e12efb4843541b4053348"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b
+      - http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b
+      string: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"22ab4d264667ea05c578da2b492abedbe3f6e0db"'
+      - '"5d6e8a5746b29d5be65311bc40339407e72bde56"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace
+      - http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace
+      string: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cbd874c6ef9576f62d93c2a5061834d6a09194be"'
+      - '"de2c864d267c4b09a51d7ed6bf63c0f6ca9127f4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t
+      - http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t
+      string: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t
     body:
       encoding: UTF-8
       string: |
@@ -202,23 +202,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"521e6fa6c36167f1c1d50c5b780432770bdd30e1"'
+      - '"348f0cce38f93a4b0b4d3a724305759c666a54b1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a
+      - http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a
+      string: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
     body:
       encoding: US-ASCII
       string: ''
@@ -235,9 +235,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34c6647071ca97ad5c5fba9e8ccc036e1a209532"'
+      - '"75e5568c15c908b1e7e67d7679f8c9b0292fce72"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -250,7 +250,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -269,44 +269,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        , <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        , <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        , <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        , <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"a8a96155-0afb-4368-8b4f-2fc389943892\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"054f20a3-0b25-4aed-bdda-76715860f627\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.596Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.183Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.643Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.227Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c
     body:
       encoding: US-ASCII
       string: ''
@@ -323,9 +323,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"22ab4d264667ea05c578da2b492abedbe3f6e0db"'
+      - '"5d6e8a5746b29d5be65311bc40339407e72bde56"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -357,34 +357,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0cdab938-fbf6-4c51-a425-cc292f9c8d6a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"3ff4aae3-662b-4a1b-b295-26bfc402d29b\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.213Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:17.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:49.213Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b
     body:
       encoding: US-ASCII
       string: ''
@@ -401,9 +401,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"521e6fa6c36167f1c1d50c5b780432770bdd30e1"'
+      - '"348f0cce38f93a4b0b4d3a724305759c666a54b1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -416,7 +416,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6124'
+      - '6128'
       Content-Type:
       - application/x-turtle
     body:
@@ -435,58 +435,58 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0c0cf03e-3371-4073-a9b9-a8bbf740e118>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/34bf606b-f2a8-48df-96e2-5f6b2eb70e8e>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextQuoteSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"ab8809f8-5011-4455-be9d-7df42cce59a5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"aec2b0f5-57b5-438e-af8a-d3eacd500959\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextQuoteSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"d863d543-9c1b-4760-843e-1b0f80d8d363\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e3c40b94-4c7f-4ae0-8c89-1afd63f339ff\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0c0cf03e-3371-4073-a9b9-a8bbf740e118>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/34bf606b-f2a8-48df-96e2-5f6b2eb70e8e>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"21062c6d-499d-4dab-bb8d-236cc3aa90bc\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3d600789-a9a0-4eb5-a28f-51a734c8d424\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a#source>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:17 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -510,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -524,7 +524,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:17 GMT
+      - Thu, 05 Mar 2015 01:26:49 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1640,10 +1640,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892
     body:
       encoding: US-ASCII
       string: ''
@@ -1660,9 +1660,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34c6647071ca97ad5c5fba9e8ccc036e1a209532"'
+      - '"75e5568c15c908b1e7e67d7679f8c9b0292fce72"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1675,7 +1675,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4589'
       Content-Type:
       - application/x-turtle
     body:
@@ -1694,44 +1694,44 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        , <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        , <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        , <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        , <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"a8a96155-0afb-4368-8b4f-2fc389943892\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"054f20a3-0b25-4aed-bdda-76715860f627\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.596Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.183Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.643Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.227Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c
     body:
       encoding: US-ASCII
       string: ''
@@ -1748,9 +1748,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"22ab4d264667ea05c578da2b492abedbe3f6e0db"'
+      - '"5d6e8a5746b29d5be65311bc40339407e72bde56"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1782,34 +1782,34 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/b/dfa03b2a-0f2f-4661-a254-856dfa078ace>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c/fcr:export?format=jcr/xml>
+        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/b/fdcaaa28-adf4-451b-b40a-d717f93ec60c/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0cdab938-fbf6-4c51-a425-cc292f9c8d6a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"3ff4aae3-662b-4a1b-b295-26bfc402d29b\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.213Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:17.629Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:49.213Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a
+    uri: http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b
     body:
       encoding: US-ASCII
       string: ''
@@ -1826,9 +1826,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"521e6fa6c36167f1c1d50c5b780432770bdd30e1"'
+      - '"348f0cce38f93a4b0b4d3a724305759c666a54b1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:17 GMT
+      - Wed, 04 Mar 2015 19:26:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1841,7 +1841,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '6124'
+      - '6128'
       Content-Type:
       - application/x-turtle
     body:
@@ -1860,56 +1860,56 @@ http_interactions:
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0c0cf03e-3371-4073-a9b9-a8bbf740e118>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/34bf606b-f2a8-48df-96e2-5f6b2eb70e8e>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:blanknode , openannotation:TextQuoteSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfcrepo:uuid \"ab8809f8-5011-4455-be9d-7df42cce59a5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"aec2b0f5-57b5-438e-af8a-d3eacd500959\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:mixinTypes \"fedora:blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:TextQuoteSelector\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\topenannotation:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"d863d543-9c1b-4760-843e-1b0f80d8d363\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"e3c40b94-4c7f-4ae0-8c89-1afd63f339ff\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b/fcr:export?format=jcr/xml>
         ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SpecificResource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0c0cf03e-3371-4073-a9b9-a8bbf740e118>
+        , fedora:resource , ldp:Container ;\n\topenannotation:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/34bf606b-f2a8-48df-96e2-5f6b2eb70e8e>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"21062c6d-499d-4dab-bb8d-236cc3aa90bc\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"3d600789-a9a0-4eb5-a28f-51a734c8d424\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:17.66Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:49.248Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"openannotation:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\topenannotation:hasSource
-        <http://localhost:8983/fedora/rest/anno/9457e716-62b2-4025-832f-ccd56427590c/t/eb140fa9-c0cd-4be1-a054-32eb95357c3a#source>
+        <http://localhost:8983/fedora/rest/anno/bceb9bd6-8955-45bb-abf3-441ce05bd892/t/a624cded-9d17-4036-9f75-25bd4ce2566b#source>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:18 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bc37ae005a679b915ff280db644c1cf48eae41f8"'
+      - '"91cd149028d8db89172bd6ce052d7283b2bbba63"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+      - http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+      string: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1f2825af06984b084b48ae6976a50cbd84d6b42d"'
+      - '"69f8bfba1d673f654c954474959df692ed1d9f14"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b
+      - http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b
+      string: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"422412368a55a017c681d40834910b517a6e897d"'
+      - '"614adbe59b8e1e8daec9267a78cc9a66193f6236"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9
+      - http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9
+      string: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
     body:
       encoding: UTF-8
       string: |
@@ -139,7 +139,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"16689e14e6290d2b7cae10100fa2a396a8d76267"'
+      - '"9b7ea922d11417dc6144ed12654f6a388f9e30fd"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t
+      - http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t
+      string: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:28 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t
     body:
       encoding: UTF-8
       string: |
@@ -195,23 +195,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f860ca1d4effcc0a62d6f36be879fd10a7a9ccf9"'
+      - '"5cbee9f0c495c6375699414ba2e5667e823ac9b2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9
+      - http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9
+      string: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
     body:
       encoding: US-ASCII
       string: ''
@@ -228,9 +228,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5008517b7995632ba640483e2781bede04b9732"'
+      - '"60c88d50a0c65ecbb1db6b472541b1266e89585f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -243,7 +243,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -251,55 +251,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        , <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        , <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        , <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        , <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"83034eae-62f4-4e34-be3f-6cd0ba7757bd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2fbadbab-7f41-4ac6-a24c-514c96623f48\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.097Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.941Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:01.149Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:28.985Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e
     body:
       encoding: US-ASCII
       string: ''
@@ -316,9 +315,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"422412368a55a017c681d40834910b517a6e897d"'
+      - '"614adbe59b8e1e8daec9267a78cc9a66193f6236"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -331,7 +330,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3745'
+      - '3814'
       Content-Type:
       - application/x-turtle
     body:
@@ -339,47 +338,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8e55389c-581a-4818-a62b-c29b2f381236\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"693b5420-3bb2-4406-9c11-cd9eb0fec842\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.129Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.972Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:28.972Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:01.129Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tcontent:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
+        \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce
     body:
       encoding: US-ASCII
       string: ''
@@ -396,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f860ca1d4effcc0a62d6f36be879fd10a7a9ccf9"'
+      - '"5cbee9f0c495c6375699414ba2e5667e823ac9b2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -411,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -419,42 +418,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
+        <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"192a8d99-69f5-4d21-9e67-a43e9569f312\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"99b7d72c-e650-431c-acf1-927eeff8f038\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.163Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:01.163Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.999Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:28.999Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -478,7 +478,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -492,7 +492,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:01 GMT
+      - Thu, 05 Mar 2015 01:26:29 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1608,10 +1608,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062
     body:
       encoding: US-ASCII
       string: ''
@@ -1628,9 +1628,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5008517b7995632ba640483e2781bede04b9732"'
+      - '"60c88d50a0c65ecbb1db6b472541b1266e89585f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1643,7 +1643,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1651,55 +1651,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        , <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        , <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        , <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        , <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"83034eae-62f4-4e34-be3f-6cd0ba7757bd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2fbadbab-7f41-4ac6-a24c-514c96623f48\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.097Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.941Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:01.149Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:28.985Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e
     body:
       encoding: US-ASCII
       string: ''
@@ -1716,9 +1715,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"422412368a55a017c681d40834910b517a6e897d"'
+      - '"614adbe59b8e1e8daec9267a78cc9a66193f6236"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1731,7 +1730,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3745'
+      - '3814'
       Content-Type:
       - application/x-turtle
     body:
@@ -1739,47 +1738,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/b/1829345f-e94f-4462-8ecc-c5686b6055f9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/b/fae1d5a0-c8e4-4678-bc53-68525331a91e>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"8e55389c-581a-4818-a62b-c29b2f381236\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"693b5420-3bb2-4406-9c11-cd9eb0fec842\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.129Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.972Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:28.972Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:01.129Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tcontent:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
+        \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:01 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9
+    uri: http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce
     body:
       encoding: US-ASCII
       string: ''
@@ -1796,9 +1795,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f860ca1d4effcc0a62d6f36be879fd10a7a9ccf9"'
+      - '"5cbee9f0c495c6375699414ba2e5667e823ac9b2"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:01 GMT
+      - Wed, 04 Mar 2015 19:26:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1811,7 +1810,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1819,40 +1818,41 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t>
+        <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/0f979293-65b7-4325-bfde-8e7e6edd2504/t/809ace28-9bab-497e-b53b-4b3ae6cfa3a9>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/10b75957-02e5-4dd8-b9bb-29ba0cbb2062/t/aaaccffc-89b5-40dd-8ccf-ce4972a1b6ce>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"192a8d99-69f5-4d21-9e67-a43e9569f312\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"99b7d72c-e650-431c-acf1-927eeff8f038\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:01.163Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:01.163Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:28.999Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:28.999Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"659d6c8f6660b85f157051af4a29ab3844ad3da3"'
+      - '"9cdff619e086f40d11d10cd3e8b4529c6f1cbeab"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+      - http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+      string: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ab132fdef1376bdcdbfa72ed49cce0364804b0a4"'
+      - '"18cebac0fc036b0a991583103e04f9b6b9050566"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b
+      - http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b
+      string: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b
     body:
       encoding: UTF-8
       string: |
@@ -116,23 +116,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"78a0e4c1d86b1db06ea808233cbb853094922795"'
+      - '"047c1bd3ddfa3755be4ce12ba7cb8e68a0e37d8d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4
+      - http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4
+      string: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
     body:
       encoding: UTF-8
       string: |
@@ -142,7 +142,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -160,23 +160,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"71bbeb7239b7f9b1e40ba037311774bf21b2fa32"'
+      - '"cc0e052b968af4b69a615d1f08a06d0b4f72921b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t
+      - http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t
+      string: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t
     body:
       encoding: UTF-8
       string: |
@@ -198,23 +198,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c567e12b0f7eb92aab50bff8dc5318e519b1083b"'
+      - '"98a3b2d9102afa4002f4796c3f2d310eaaefc48c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43
+      - http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43
+      string: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
     body:
       encoding: US-ASCII
       string: ''
@@ -231,9 +231,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"61dc94be89bcda4a4ca68e70367d7da1f0c897ad"'
+      - '"51ec7b9bddca1057492fd0c54d5faa16e1276966"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -246,7 +246,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -254,55 +254,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        , <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        , <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        , <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        , <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"dddc9bd5-3a77-41ef-8145-64b1db5dc0c6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"bbe9e156-5a35-4dbb-9a80-6fdf655638cb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.121Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.847Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:02.185Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:29.898Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +319,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"78a0e4c1d86b1db06ea808233cbb853094922795"'
+      - '"047c1bd3ddfa3755be4ce12ba7cb8e68a0e37d8d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -334,7 +334,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4000'
+      - '3829'
       Content-Type:
       - application/x-turtle
     body:
@@ -342,49 +342,48 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\tns001:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , fedora:resource , ldp:Container ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"f56ee355-5073-494b-84e1-affb480bada1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"8140bbcf-a627-41fe-b1e9-209471f856c4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:02.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:29.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tns001:format
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format
         \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:29 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8
     body:
       encoding: US-ASCII
       string: ''
@@ -401,9 +400,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c567e12b0f7eb92aab50bff8dc5318e519b1083b"'
+      - '"98a3b2d9102afa4002f4796c3f2d310eaaefc48c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -416,7 +415,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -424,43 +423,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4c6cc6ab-deaf-4a5e-8b37-1e83edf29140\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"72744bde-f601-4d07-8366-603597ef4ddd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.206Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.911Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:02.206Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:29.911Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -484,7 +482,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -498,7 +496,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:02 GMT
+      - Thu, 05 Mar 2015 01:26:30 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1614,10 +1612,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80
     body:
       encoding: US-ASCII
       string: ''
@@ -1634,9 +1632,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"61dc94be89bcda4a4ca68e70367d7da1f0c897ad"'
+      - '"51ec7b9bddca1057492fd0c54d5faa16e1276966"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1649,7 +1647,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4589'
+      - '4463'
       Content-Type:
       - application/x-turtle
     body:
@@ -1657,55 +1655,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        , <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        , <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b>
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        , <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        , <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"dddc9bd5-3a77-41ef-8145-64b1db5dc0c6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"bbe9e156-5a35-4dbb-9a80-6fdf655638cb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.121Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.847Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:02.185Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:29.898Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783
     body:
       encoding: US-ASCII
       string: ''
@@ -1722,9 +1720,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"78a0e4c1d86b1db06ea808233cbb853094922795"'
+      - '"047c1bd3ddfa3755be4ce12ba7cb8e68a0e37d8d"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1737,7 +1735,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4000'
+      - '3829'
       Content-Type:
       - application/x-turtle
     body:
@@ -1745,49 +1743,48 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/b/ecfcd36c-46de-487d-b6bf-09035e8674d4>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/b/2a984346-7492-4bcc-90d7-be3f3fbd3783>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
-        , fedora:resource , ldp:Container ;\n\tns001:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , fedora:resource , ldp:Container ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"f56ee355-5073-494b-84e1-affb480bada1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"8140bbcf-a627-41fe-b1e9-209471f856c4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:02.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:29.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tns001:format
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format
         \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:02 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43
+    uri: http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8
     body:
       encoding: US-ASCII
       string: ''
@@ -1804,9 +1801,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c567e12b0f7eb92aab50bff8dc5318e519b1083b"'
+      - '"98a3b2d9102afa4002f4796c3f2d310eaaefc48c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:02 GMT
+      - Wed, 04 Mar 2015 19:26:29 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1819,7 +1816,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1827,41 +1824,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/a76d8b76-2126-465d-9357-e5c7a843430b/t/d3e5c13a-94fe-4579-9d3e-93dbe199ca43>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/913d14bf-db9e-4482-8d5f-159949f5ff80/t/70a12315-a6af-4db7-8022-621bd39b62a8>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4c6cc6ab-deaf-4a5e-8b37-1e83edf29140\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"72744bde-f601-4d07-8366-603597ef4ddd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:02.206Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:29.911Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:02.206Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:29.911Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ad44c9323b6e568e9d929e91e97578f61d2f85d6"'
+      - '"4d0bf4fe6bf299569d666be6dc73e51709a69281"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4185b21df26e77584e667b46be2ec4a284b3dc96"'
+      - '"d61e8b918052c2598b4dc16c2f8c937483725ea9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b
     body:
       encoding: UTF-8
       string: |
@@ -113,23 +113,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"882553a00fbc245dfd1bd5844dcf29ea86fcc406"'
+      - '"4cac52bb99a5653899a763c7b710b4bc8a8710cb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b
     body:
       encoding: UTF-8
       string: |
@@ -156,23 +156,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"84c82ce2dc184bb1fadbf25c6eb85f36bb9cd29e"'
+      - '"943131f2a22199bff8145c4c1f2a089524d72ce4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
     body:
       encoding: UTF-8
       string: |
@@ -182,7 +182,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -200,23 +200,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"43049c6616cba2c631ee3050d2cfd1dc92284657"'
+      - '"f19e9fe527f1db1d30fc80002c0ea6dd7c6f32ab"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t
     body:
       encoding: UTF-8
       string: |
@@ -238,23 +238,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"eb933d908be525f64eaae6bca58af2e9f9ceeb67"'
+      - '"1b9dbe732bc2216da43665a27b1dd25753e8bcec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7
+      - http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7
+      string: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
     body:
       encoding: US-ASCII
       string: ''
@@ -271,9 +271,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"364c681d27d6007b8b671579c55d7547c154f40b"'
+      - '"3d45d986a8aa4bf448067e2b8da155aa7fb050c7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -286,7 +286,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4629'
+      - '4581'
       Content-Type:
       - application/x-turtle
     body:
@@ -294,56 +294,56 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3872fff8-99aa-4fb8-abec-ce7c46b7d9e6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a54810e4-9d6c-4103-8f4a-e50642a146fb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.19Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.743Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:03.244Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.81Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb
     body:
       encoding: US-ASCII
       string: ''
@@ -360,9 +360,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"882553a00fbc245dfd1bd5844dcf29ea86fcc406"'
+      - '"4cac52bb99a5653899a763c7b710b4bc8a8710cb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -375,7 +375,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3743'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -383,46 +383,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"894d9475-1e14-40af-be9f-4438308c8c0c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2c9604fd-49cc-4bbe-9d31-750640294760\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.22Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.777Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.777Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:03.22Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tcontent:chars
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560
     body:
       encoding: US-ASCII
       string: ''
@@ -439,9 +439,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"84c82ce2dc184bb1fadbf25c6eb85f36bb9cd29e"'
+      - '"943131f2a22199bff8145c4c1f2a089524d72ce4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -454,7 +454,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3862'
+      - '3814'
       Content-Type:
       - application/x-turtle
     body:
@@ -462,48 +462,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"35b34ed9-2b89-4059-ba74-4f0bbe100378\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1752d52d-5d63-4ca9-8053-c27a46b5b5ed\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.232Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:03.232Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tcontent:chars \"I hate this!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
+        \"I hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:30 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed
     body:
       encoding: US-ASCII
       string: ''
@@ -520,9 +519,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eb933d908be525f64eaae6bca58af2e9f9ceeb67"'
+      - '"1b9dbe732bc2216da43665a27b1dd25753e8bcec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -535,7 +534,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -543,43 +542,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ba170665-70b8-4d17-9553-3b38f8aa4d00\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"21627652-8d8a-4df0-aac5-ce1032f52466\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.259Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.823Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:03.259Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.823Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -603,7 +601,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -617,7 +615,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:45:03 GMT
+      - Thu, 05 Mar 2015 01:26:31 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1733,10 +1731,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36
     body:
       encoding: US-ASCII
       string: ''
@@ -1753,9 +1751,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"364c681d27d6007b8b671579c55d7547c154f40b"'
+      - '"3d45d986a8aa4bf448067e2b8da155aa7fb050c7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1768,7 +1766,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4629'
+      - '4581'
       Content-Type:
       - application/x-turtle
     body:
@@ -1776,56 +1774,56 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        , <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        , <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f>
+        <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"3872fff8-99aa-4fb8-abec-ce7c46b7d9e6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a54810e4-9d6c-4103-8f4a-e50642a146fb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.19Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.743Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:03.244Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.81Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:commenting .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:03 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb
     body:
       encoding: US-ASCII
       string: ''
@@ -1842,9 +1840,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"882553a00fbc245dfd1bd5844dcf29ea86fcc406"'
+      - '"4cac52bb99a5653899a763c7b710b4bc8a8710cb"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1857,7 +1855,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3743'
+      - '3697'
       Content-Type:
       - application/x-turtle
     body:
@@ -1865,46 +1863,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/72058653-bdc3-4f62-ae26-b7d3554a421d>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/82a79e51-7215-4eb7-8e6c-17abca0dfdfb/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"894d9475-1e14-40af-be9f-4438308c8c0c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"2c9604fd-49cc-4bbe-9d31-750640294760\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.22Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.777Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.777Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:03.22Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tcontent:chars
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560
     body:
       encoding: US-ASCII
       string: ''
@@ -1921,9 +1919,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"84c82ce2dc184bb1fadbf25c6eb85f36bb9cd29e"'
+      - '"943131f2a22199bff8145c4c1f2a089524d72ce4"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1936,7 +1934,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3862'
+      - '3814'
       Content-Type:
       - application/x-turtle
     body:
@@ -1944,48 +1942,47 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/b/f7c55941-9d71-4648-b2bd-dfba9b8725d6>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/b/a9c98c53-b80c-47c7-a16d-89a2c5fe2560>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , content:ContentAsText
         , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"35b34ed9-2b89-4059-ba74-4f0bbe100378\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1752d52d-5d63-4ca9-8053-c27a46b5b5ed\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.232Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.795Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:45:03.232Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tcontent:chars \"I hate this!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        , \"content:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcontent:chars
+        \"I hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7
+    uri: http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed
     body:
       encoding: US-ASCII
       string: ''
@@ -2002,9 +1999,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eb933d908be525f64eaae6bca58af2e9f9ceeb67"'
+      - '"1b9dbe732bc2216da43665a27b1dd25753e8bcec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:45:03 GMT
+      - Wed, 04 Mar 2015 19:26:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -2017,7 +2014,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -2025,41 +2022,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/0508665b-c682-4df7-b982-dcf21116219f/t/0f4c090e-61b1-4d29-8c87-58fac8471bb7>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ec0938d5-1404-48e1-94e9-e1ba24dc3c36/t/1324aae8-cb10-41ae-b551-b13d5506e8ed/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ba170665-70b8-4d17-9553-3b38f8aa4d00\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"21627652-8d8a-4df0-aac5-ce1032f52466\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:45:03.259Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:30.823Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:45:03.259Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:30.823Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:45:04 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f5a21132105c494ff604ef7daaf24b2e248cb28a"'
+      - '"249146d6641f3046a88bb4a462feda9ca615fd72"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+      - http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+      string: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6f098b3528dd672c63a634d4877333cf1ef46ccc"'
+      - '"779933f28965279540ccf288c5495dd75b25bbe7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b
+      - http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b
+      string: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7d09b452cd1faf48c6b728ad2047a44bf45d8164"'
+      - '"d9b1fc1a6501c3ed118263da629ec382a371e6ec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54
+      - http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54
+      string: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5f65c7de54e53b71556a3ed52439d0d3e5995ab4"'
+      - '"f6b891e9e7f06805b413a3eb2253216c8f91e9f1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t
+      - http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t
+      string: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t
     body:
       encoding: UTF-8
       string: |
@@ -190,23 +190,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f232f43fa9b5b1707f3895df1f5d0abcc0c79c6d"'
+      - '"8f555a4ef2816437c68f2046946b4907b963d0bc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034
+      - http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034
+      string: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
     body:
       encoding: US-ASCII
       string: ''
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d6808cf20ae7d29176ccb6119c90bff1c337da67"'
+      - '"0322645a8dd12b08d4b94a821140e9fa7c08f227"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -238,7 +238,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4542'
       Content-Type:
       - application/x-turtle
     body:
@@ -246,54 +246,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        , <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        , <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        , <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        , <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"413ef1a4-c4d1-4b89-a0d8-e1cbc0f654fa\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"fcc8b7c9-35a5-4bd2-81d1-fd1106fe23c2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.804Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.267Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:10.86Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:33.312Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa
     body:
       encoding: US-ASCII
       string: ''
@@ -310,9 +311,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7d09b452cd1faf48c6b728ad2047a44bf45d8164"'
+      - '"d9b1fc1a6501c3ed118263da629ec382a371e6ec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -325,7 +326,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -333,120 +334,121 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"6b3421f1-c6cf-42b7-a4a8-2ac9aa1e36c1\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.84Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:10.84Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"f232f43fa9b5b1707f3895df1f5d0abcc0c79c6d"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3569'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
+        <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0d0b839a-bd8a-4c14-8afc-e138bea226f5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"f3a5f0f0-0a9d-48a9-a7e0-8b734d8cf678\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:10.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.297Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:33.297Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"8f555a4ef2816437c68f2046946b4907b963d0bc"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:33 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3638'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"54d9e513-8f40-49b5-8732-63cb4f666ea5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:33.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -470,7 +472,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -484,7 +486,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:10 GMT
+      - Thu, 05 Mar 2015 01:26:33 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1600,10 +1602,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570
     body:
       encoding: US-ASCII
       string: ''
@@ -1620,9 +1622,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d6808cf20ae7d29176ccb6119c90bff1c337da67"'
+      - '"0322645a8dd12b08d4b94a821140e9fa7c08f227"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1635,7 +1637,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4542'
       Content-Type:
       - application/x-turtle
     body:
@@ -1643,54 +1645,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        , <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        , <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/fcr:export?format=jcr/xml>
-        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        , <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        , <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"413ef1a4-c4d1-4b89-a0d8-e1cbc0f654fa\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"fcc8b7c9-35a5-4bd2-81d1-fd1106fe23c2\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.804Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.267Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:10.86Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:33.312Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa
     body:
       encoding: US-ASCII
       string: ''
@@ -1707,9 +1710,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7d09b452cd1faf48c6b728ad2047a44bf45d8164"'
+      - '"d9b1fc1a6501c3ed118263da629ec382a371e6ec"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1722,7 +1725,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1730,118 +1733,119 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/b/b722afe6-faa7-4b08-80c9-683a3dfc9d54>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"6b3421f1-c6cf-42b7-a4a8-2ac9aa1e36c1\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.84Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:10.84Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"f232f43fa9b5b1707f3895df1f5d0abcc0c79c6d"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:10 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3569'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t>
+        <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/eba37dc0-73b6-4b9a-a077-dcb3028d8243/t/e641ece6-5154-4313-8633-a9138394d034>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/b/771da4bf-ffa3-4b58-977a-32ee40fa75fa/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"0d0b839a-bd8a-4c14-8afc-e138bea226f5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"f3a5f0f0-0a9d-48a9-a7e0-8b734d8cf678\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:10.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:10.884Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.297Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:33.297Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"8f555a4ef2816437c68f2046946b4907b963d0bc"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:33 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3638'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/9c735e6a-f584-46cb-a183-79c6a1e34570/t/16396197-e029-4e66-b124-033fa86ac51a>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"54d9e513-8f40-49b5-8732-63cb4f666ea5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:33.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:33.326Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a6a31fbe88dfef3dedf2d65bba7ef0c55649dd34"'
+      - '"3bfd42149edb43c3f6a19c28ca281c45e5c6eec0"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+      - http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+      string: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"931ecc1abb97906a8544db41ea38ed730e3ba148"'
+      - '"671d8acf86812a327d9881d3c6c24d0898adfeaa"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b
+      - http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b
+      string: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b
     body:
       encoding: UTF-8
       string: |
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6698a55e2a59e4bedfcb18b9e8f8cba33ebe6711"'
+      - '"9dc9080e4ffa9cdb54bf0808955030dce70365c6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324
+      - http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324
+      string: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
     body:
       encoding: UTF-8
       string: |
@@ -140,7 +140,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f488ac922580f817770a7a5e911275ec39dbf69f"'
+      - '"31750242c605186aad049815a503db1228b36f53"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t
+      - http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t
+      string: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t
     body:
       encoding: UTF-8
       string: |
@@ -196,23 +196,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"971f62b41de4bf6e83bf90adf37cf86f08148136"'
+      - '"bbaf2b155ab18a2b64f1e7ef33205776094acf9c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392
+      - http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392
+      string: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
     body:
       encoding: US-ASCII
       string: ''
@@ -229,9 +229,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"831b236972c3c9d5c21ff6d6eb1bdaa7acf2b076"'
+      - '"524d9508b64c26b52c7190f40c3e36b64dcad846"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -244,7 +244,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4512'
+      - '4464'
       Content-Type:
       - application/x-turtle
     body:
@@ -252,55 +252,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        , <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        , <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        , <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        , <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5dfc0425-1ea4-400a-acb7-1abe8522dc05\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a6326542-3a9f-4335-9282-dc7f5e83f97e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.909Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.867Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:14.962Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:36.916Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c
     body:
       encoding: US-ASCII
       string: ''
@@ -317,9 +316,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6698a55e2a59e4bedfcb18b9e8f8cba33ebe6711"'
+      - '"9dc9080e4ffa9cdb54bf0808955030dce70365c6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -332,7 +331,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3839'
+      - '3667'
       Content-Type:
       - application/x-turtle
     body:
@@ -340,48 +339,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Sound , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"c303f53e-7ee1-49a7-a8b6-ca265a89d33d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"832d6939-0c3b-4e49-8b4d-0371e185cdbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.9Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:14.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tns001:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:36.9Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
+        \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format
+        \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd
     body:
       encoding: US-ASCII
       string: ''
@@ -398,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"971f62b41de4bf6e83bf90adf37cf86f08148136"'
+      - '"bbaf2b155ab18a2b64f1e7ef33205776094acf9c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -413,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3519'
       Content-Type:
       - application/x-turtle
     body:
@@ -421,43 +418,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"76624ac0-b315-4b8b-9e74-6a66915fd366\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"75a6730d-967d-4efe-935d-2978ac819499\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.975Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:36.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:14.975Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -481,7 +477,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -495,7 +491,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:14 GMT
+      - Thu, 05 Mar 2015 01:26:37 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1611,10 +1607,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513
     body:
       encoding: US-ASCII
       string: ''
@@ -1631,9 +1627,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"831b236972c3c9d5c21ff6d6eb1bdaa7acf2b076"'
+      - '"524d9508b64c26b52c7190f40c3e36b64dcad846"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1646,7 +1642,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4512'
+      - '4464'
       Content-Type:
       - application/x-turtle
     body:
@@ -1654,55 +1650,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        , <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        , <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        , <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        , <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"5dfc0425-1ea4-400a-acb7-1abe8522dc05\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"a6326542-3a9f-4335-9282-dc7f5e83f97e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.909Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.867Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:14.962Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:36.916Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c
     body:
       encoding: US-ASCII
       string: ''
@@ -1719,9 +1714,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6698a55e2a59e4bedfcb18b9e8f8cba33ebe6711"'
+      - '"9dc9080e4ffa9cdb54bf0808955030dce70365c6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1734,7 +1729,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3839'
+      - '3667'
       Content-Type:
       - application/x-turtle
     body:
@@ -1742,48 +1737,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/b/04e01221-05b7-43c9-9407-44548894a324>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/b/110c302f-4e2c-4e3d-a024-88987d57eb8c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Sound , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"c303f53e-7ee1-49a7-a8b6-ca265a89d33d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"832d6939-0c3b-4e49-8b4d-0371e185cdbd\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.9Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:14.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfcrepo:mixinTypes \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tns001:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:36.9Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
+        \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format
+        \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392
+    uri: http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd
     body:
       encoding: US-ASCII
       string: ''
@@ -1800,9 +1793,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"971f62b41de4bf6e83bf90adf37cf86f08148136"'
+      - '"bbaf2b155ab18a2b64f1e7ef33205776094acf9c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:14 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1815,7 +1808,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3519'
       Content-Type:
       - application/x-turtle
     body:
@@ -1823,41 +1816,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/c4f75516-b52b-4cc5-8b6d-0eca68132a3c/t/f544ce4f-32b6-4d64-8d65-2cc868b39392>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/8aea1fd5-d260-4ad3-b815-f601dca6d513/t/c370f2d7-d75e-418d-9b44-462106b2f0cd/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"76624ac0-b315-4b8b-9e74-6a66915fd366\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"75a6730d-967d-4efe-935d-2978ac819499\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:14.975Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:36.93Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:14.975Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:15 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"27b6ec650bdf53f16fe8996519b1ea61d1e9df02"'
+      - '"aec7739399db488bd18b0510b5ba450d296a0215"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+      - http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+      string: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7b32deb5de4a7775e464e65b76b6614ed04a3445"'
+      - '"f9edd4c4e81ea221832614baa979205bfa30f44b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b
+      - http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b
+      string: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b
     body:
       encoding: UTF-8
       string: |
@@ -111,23 +111,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a11f0fa2b063f20216975e14a605958fc5e48496"'
+      - '"851ab66241016d11a14c2804f0fc576b57bf7044"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a
+      - http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a
+      string: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
     body:
       encoding: UTF-8
       string: |
@@ -137,7 +137,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -155,23 +155,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"020949dbb99f1793921228a1d832db090ca8a15f"'
+      - '"4c741c7ee06292ce0b967cfc31ef267a3a97af90"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t
+      - http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t
+      string: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t
     body:
       encoding: UTF-8
       string: |
@@ -193,23 +193,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7b1657fcb81750a1393950b73620f710c41761c5"'
+      - '"ceab5aa927651e6b72f02c83b79c768c3cba4e4b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296
+      - http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296
+      string: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
     body:
       encoding: US-ASCII
       string: ''
@@ -226,9 +226,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3340e1988d1d27a332b732d2314219bc39689540"'
+      - '"6e5a3f5e98f24fe2f3a9a31c64fe78d8bf353550"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -241,7 +241,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4542'
       Content-Type:
       - application/x-turtle
     body:
@@ -249,55 +249,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        , <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        , <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        , <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        , <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"04d8cc38-e08c-4845-b1e3-17b6a661fa3a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1d1a80ad-ffd5-48c2-aa11-35160ec1e1f6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.916Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.986Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:13.96Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:36.036Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8
     body:
       encoding: US-ASCII
       string: ''
@@ -314,9 +314,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a11f0fa2b063f20216975e14a605958fc5e48496"'
+      - '"851ab66241016d11a14c2804f0fc576b57bf7044"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -329,7 +329,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3672'
+      - '3624'
       Content-Type:
       - application/x-turtle
     body:
@@ -337,46 +337,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
+        <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SemanticTag , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"0ebe2054-1574-403c-b60d-576d4a40df5b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"11769ce8-f77f-40b6-a53e-aa33b3398ab3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"openannotation:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.019Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:36.019Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"openannotation:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090
     body:
       encoding: US-ASCII
       string: ''
@@ -393,9 +393,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b1657fcb81750a1393950b73620f710c41761c5"'
+      - '"ceab5aa927651e6b72f02c83b79c768c3cba4e4b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -408,7 +408,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -416,42 +416,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"a72d7b94-995a-43db-a63f-d8c7e5957e4c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"18873c5e-95d4-4901-8279-b2ead179e6d4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.978Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.978Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:36.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -475,7 +475,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -489,7 +489,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:13 GMT
+      - Thu, 05 Mar 2015 01:26:36 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1605,10 +1605,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24
     body:
       encoding: US-ASCII
       string: ''
@@ -1625,9 +1625,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3340e1988d1d27a332b732d2314219bc39689540"'
+      - '"6e5a3f5e98f24fe2f3a9a31c64fe78d8bf353550"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1640,7 +1640,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4511'
+      - '4542'
       Content-Type:
       - application/x-turtle
     body:
@@ -1648,55 +1648,55 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        , <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        , <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        , <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        , <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"04d8cc38-e08c-4845-b1e3-17b6a661fa3a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"1d1a80ad-ffd5-48c2-aa11-35160ec1e1f6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.916Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.986Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:13.96Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:36.036Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8
     body:
       encoding: US-ASCII
       string: ''
@@ -1713,9 +1713,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a11f0fa2b063f20216975e14a605958fc5e48496"'
+      - '"851ab66241016d11a14c2804f0fc576b57bf7044"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1728,7 +1728,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3672'
+      - '3624'
       Content-Type:
       - application/x-turtle
     body:
@@ -1736,46 +1736,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b>
+        <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/b/49b17eb6-7e46-46bd-9e1e-859780e6547a/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/b/7be141a2-6ce3-4a25-a3f7-edd55544acf8/fcr:export?format=jcr/xml>
         ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , openannotation:SemanticTag , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"0ebe2054-1574-403c-b60d-576d4a40df5b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"11769ce8-f77f-40b6-a53e-aa33b3398ab3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"openannotation:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.019Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:36.019Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"openannotation:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296
+    uri: http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090
     body:
       encoding: US-ASCII
       string: ''
@@ -1792,9 +1792,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b1657fcb81750a1393950b73620f710c41761c5"'
+      - '"ceab5aa927651e6b72f02c83b79c768c3cba4e4b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1807,7 +1807,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1815,40 +1815,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/b568e83c-25e3-4c2e-92f5-05256e296898/t/935f58f5-80a5-4139-ab8e-96b47bc2d296>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f5122b4e-fc54-4084-be2a-63e6fb1c1b24/t/9cc90d8f-2d43-4502-be6b-6c5dbf363090>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"a72d7b94-995a-43db-a63f-d8c7e5957e4c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"18873c5e-95d4-4901-8279-b2ead179e6d4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.978Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:36.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.978Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:36.053Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:14 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1646c717e6c00570236487150568acbc6ac8949d"'
+      - '"0d096e038519a0d6ad780b7c93308b6fddce7b26"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9dfbb690aac5deb25f8f5e8dc54e140a851ec494"'
+      - '"c60f7e5baf88e8736a45b7a092591869add7be55"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ee0c34ee8e1655637c37b4614036ce54f1d10555"'
+      - '"815b437ec394ce0315a341ccd59110ef6ed8b480"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b
     body:
       encoding: UTF-8
       string: |
@@ -146,23 +146,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"57eec6d3a2f3709dda129c4cf6c9bc8fd508f0df"'
+      - '"a63ba5287fb5d834539eac30594ad40fd83965a3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
     body:
       encoding: UTF-8
       string: |
@@ -172,7 +172,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -190,23 +190,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"00a12d91ceb7db5ee52df5676211253b0abeade9"'
+      - '"d36d9e53a53ae9f1c8304adf0d518b5c1e565c94"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t
     body:
       encoding: UTF-8
       string: |
@@ -228,23 +228,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"09e2d51995f3ec0406644daa4e3b74022c8a807e"'
+      - '"099cd3ba32f840d5ceeba1828d55fb12d693fe2e"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872
+      - http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872
+      string: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
     body:
       encoding: US-ASCII
       string: ''
@@ -261,9 +261,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c5066822f31b8008e2e4a2817c5c560450670716"'
+      - '"78b2160d4ad80c12c0d6029ad0ca6c8290aec172"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -276,7 +276,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4631'
+      - '4583'
       Content-Type:
       - application/x-turtle
     body:
@@ -284,56 +284,56 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"bc94089b-8cfd-4cde-b262-f1f6d1048c54\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"47c95134-b956-43f5-9ea2-029526232d94\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.827Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.125Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.876Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:34.181Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41
     body:
       encoding: US-ASCII
       string: ''
@@ -350,9 +350,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ee0c34ee8e1655637c37b4614036ce54f1d10555"'
+      - '"815b437ec394ce0315a341ccd59110ef6ed8b480"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -365,7 +365,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -373,200 +373,199 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4edefb3b-e661-40b2-ae8f-e257e0e950cb\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:11 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"57eec6d3a2f3709dda129c4cf6c9bc8fd508f0df"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3565'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4b588e75-60ce-44e4-86e7-fc6761f9f696\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.865Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.865Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"09e2d51995f3ec0406644daa4e3b74022c8a807e"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3686'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ca472ee4-2eb1-4d96-a50e-55ae1781d775\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"92c16bd5-e600-4e36-9f8d-e95b0e5a1015\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.154Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.154Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"a63ba5287fb5d834539eac30594ad40fd83965a3"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:34 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3517'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"2442f624-71b2-47fa-9db6-4a8837e9f031\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"099cd3ba32f840d5ceeba1828d55fb12d693fe2e"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:34 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3517'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"4740bed7-198c-43dd-8ed1-3e8b38f02ac5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.2Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.2Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -590,7 +589,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -604,7 +603,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:11 GMT
+      - Thu, 05 Mar 2015 01:26:34 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1720,10 +1719,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce
     body:
       encoding: US-ASCII
       string: ''
@@ -1740,9 +1739,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c5066822f31b8008e2e4a2817c5c560450670716"'
+      - '"78b2160d4ad80c12c0d6029ad0ca6c8290aec172"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1755,7 +1754,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4631'
+      - '4583'
       Content-Type:
       - application/x-turtle
     body:
@@ -1763,56 +1762,56 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        , <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        , <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"bc94089b-8cfd-4cde-b262-f1f6d1048c54\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"47c95134-b956-43f5-9ea2-029526232d94\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.827Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.125Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.876Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:34.181Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41
     body:
       encoding: US-ASCII
       string: ''
@@ -1829,9 +1828,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ee0c34ee8e1655637c37b4614036ce54f1d10555"'
+      - '"815b437ec394ce0315a341ccd59110ef6ed8b480"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
+      - Wed, 04 Mar 2015 19:26:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1844,7 +1843,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1852,198 +1851,197 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/9fdfb98b-45b7-4b51-90bd-62a0df45e6c7>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4edefb3b-e661-40b2-ae8f-e257e0e950cb\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.854Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"57eec6d3a2f3709dda129c4cf6c9bc8fd508f0df"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3565'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/b/4692f3ea-001d-4f1a-975d-fae2b6c41162>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
-        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
-        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
-        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"4b588e75-60ce-44e4-86e7-fc6761f9f696\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.865Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.865Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
-    http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"09e2d51995f3ec0406644daa4e3b74022c8a807e"'
-      Last-Modified:
-      - Wed, 04 Feb 2015 01:44:11 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      Content-Length:
-      - '3686'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
-        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
-        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t>
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/16c50ea4-989c-4b31-b13c-9ef3a2593f56/t/b1c39a2b-302f-4854-8465-1d3dd8fef872>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/916b2b33-063d-4e4b-a479-3d797b827d41>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"ca472ee4-2eb1-4d96-a50e-55ae1781d775\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"92c16bd5-e600-4e36-9f8d-e95b0e5a1015\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:11.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.154Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.154Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"a63ba5287fb5d834539eac30594ad40fd83965a3"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:34 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3517'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/b/28c04d9c-3cf0-427b-b223-7ad760415f41/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"2442f624-71b2-47fa-9db6-4a8837e9f031\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.167Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 04 Mar 2015 19:26:34 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"099cd3ba32f840d5ceeba1828d55fb12d693fe2e"'
+      Last-Modified:
+      - Wed, 04 Mar 2015 19:26:34 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      Content-Length:
+      - '3517'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
+        <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
+        ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
+        <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/16364659-16a7-4799-9494-95be4baf06ce/t/1e9068a6-c14b-4ea8-912f-a30b53ebcb0b>
+        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
+        , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
+        \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
+        \"4740bed7-198c-43dd-8ed1-3e8b38f02ac5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:34.2Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:34.2Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
         \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:11.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7842ec7dadcf3e05e4005f22663b500ba3fe2c78"'
+      - '"49f189ebad6e5da2705f66c4fe822f4a00be1523"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab
+      - http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab
+      string: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c58c72156bd30a37dfe8929b8507e17229963fe4"'
+      - '"b9d6b054f58f53b8acb27cce2570660a5c732502"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t
+      - http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t
+      string: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e3a25e296e41d15ff5b410b2133e82b92ddf4ab5"'
+      - '"f532b6f90d07be8029529026fc9b6ab261835916"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324
+      - http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324
+      string: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t
     body:
       encoding: UTF-8
       string: |
@@ -146,23 +146,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6fd1ecd66898e76cb1638f4d2a129b432e31aa8c"'
+      - '"60a8fb7b0c3db44e4dc6b798defca4d0c7b1d5dc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3
+      - http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3
+      string: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d
     body:
       encoding: US-ASCII
       string: ''
@@ -179,9 +179,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"044842beace9c4e55c44e70af121cc162e085982"'
+      - '"af5029471987fb7e15295f0727f2d153f736896c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -194,7 +194,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4218'
+      - '4092'
       Content-Type:
       - application/x-turtle
     body:
@@ -202,51 +202,51 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        , <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
+        <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        , <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6608ec74-737d-4063-a75c-d31ff9969a7c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"af3f41b6-9988-4410-aa52-2b34b830425a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.896Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.478Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.914Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:32.494Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c
     body:
       encoding: US-ASCII
       string: ''
@@ -263,9 +263,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e3a25e296e41d15ff5b410b2133e82b92ddf4ab5"'
+      - '"f532b6f90d07be8029529026fc9b6ab261835916"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -278,7 +278,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -286,45 +286,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"11d70d8e-6823-4707-9987-b815af3d67e8\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e01b16f4-46b6-42cc-ac37-05c5bf2da3db\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.933Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.509Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:09.933Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:32.509Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902
     body:
       encoding: US-ASCII
       string: ''
@@ -341,9 +342,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6fd1ecd66898e76cb1638f4d2a129b432e31aa8c"'
+      - '"60a8fb7b0c3db44e4dc6b798defca4d0c7b1d5dc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -356,7 +357,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -364,42 +365,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"17b8c989-7c57-458a-bc51-a99f00ad1a58\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"bf806a81-0b4e-4633-9ea2-350d73f9937a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.522Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:09.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:32.522Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -423,7 +424,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:33 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -437,7 +438,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:09 GMT
+      - Thu, 05 Mar 2015 01:26:33 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1553,10 +1554,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d
     body:
       encoding: US-ASCII
       string: ''
@@ -1573,9 +1574,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"044842beace9c4e55c44e70af121cc162e085982"'
+      - '"af5029471987fb7e15295f0727f2d153f736896c"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1588,7 +1589,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4218'
+      - '4092'
       Content-Type:
       - application/x-turtle
     body:
@@ -1596,51 +1597,51 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        , <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab>
+        <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        , <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
+        <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"6608ec74-737d-4063-a75c-d31ff9969a7c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"af3f41b6-9988-4410-aa52-2b34b830425a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.896Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.478Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.914Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:32.494Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c
     body:
       encoding: US-ASCII
       string: ''
@@ -1657,9 +1658,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e3a25e296e41d15ff5b410b2133e82b92ddf4ab5"'
+      - '"f532b6f90d07be8029529026fc9b6ab261835916"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1672,7 +1673,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1680,45 +1681,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/15cba46b-1e29-45d2-affe-260c9a39d324>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/3692ce68-af77-4324-a037-ded228e83e1c>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"11d70d8e-6823-4707-9987-b815af3d67e8\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e01b16f4-46b6-42cc-ac37-05c5bf2da3db\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.933Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.509Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:09.933Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:32.509Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3
+    uri: http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902
     body:
       encoding: US-ASCII
       string: ''
@@ -1735,9 +1737,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6fd1ecd66898e76cb1638f4d2a129b432e31aa8c"'
+      - '"60a8fb7b0c3db44e4dc6b798defca4d0c7b1d5dc"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1750,7 +1752,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3567'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1758,40 +1760,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f9e5d335-d7bf-42a0-9ccb-e57e9d7c00ab/t/bbea0607-4ecd-4623-a54d-032a95a271b3>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/5aadc1c8-ad38-4150-8218-b401e597f71d/t/8f34da6e-9f50-4833-aef1-fa8fe6fda902>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"17b8c989-7c57-458a-bc51-a99f00ad1a58\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"bf806a81-0b4e-4633-9ea2-350d73f9937a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:32.522Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:09.95Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:32.522Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:10 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"12a105d764cf6c5ab182063a28ec3e570a0dc41a"'
+      - '"61e6ea04a2ddb2973e1ef99cad90388090ccb154"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10
+      - http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10
+      string: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3ef53eebae404412c7cad6207871ecbcf424cc93"'
+      - '"ad9b26cabc485e274934f6adfaa64e3784fb876b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t
+      - http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t
+      string: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e434435a62c7f51d7de09c45b5cc7aeacd5b8c10"'
+      - '"8f82b64446811b2c49cc249a636d15722f91ce84"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c
+      - http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c
+      string: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f6374b7292bc255ae7cec310b0779d1bdd15393d"'
+      - '"9ef498515367e6b19a1a68eed8676cd49b613576"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4098'
+      - '4051'
       Content-Type:
       - application/x-turtle
     body:
@@ -164,50 +164,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"7cf31465-ecd4-4e28-9a91-007d73dcfd71\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"04cc74c1-abca-438d-aca2-97dab9ee5e03\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:31.755Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.152Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:31.771Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e434435a62c7f51d7de09c45b5cc7aeacd5b8c10"'
+      - '"8f82b64446811b2c49cc249a636d15722f91ce84"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -247,43 +247,42 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"30e65bdf-05d4-4c0b-a283-f619031aa715\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"9a9d228f-9831-4a57-abc4-c0ff91383b9b\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.173Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.173Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:31.794Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:31.794Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:31 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -307,7 +306,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:32 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -321,7 +320,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:09 GMT
+      - Thu, 05 Mar 2015 01:26:32 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1437,10 +1436,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3
     body:
       encoding: US-ASCII
       string: ''
@@ -1457,9 +1456,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f6374b7292bc255ae7cec310b0779d1bdd15393d"'
+      - '"9ef498515367e6b19a1a68eed8676cd49b613576"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1472,7 +1471,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4098'
+      - '4051'
       Content-Type:
       - application/x-turtle
     body:
@@ -1480,50 +1479,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"7cf31465-ecd4-4e28-9a91-007d73dcfd71\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"04cc74c1-abca-438d-aca2-97dab9ee5e03\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:31.755Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.152Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:31.771Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c
+    uri: http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533
     body:
       encoding: US-ASCII
       string: ''
@@ -1540,9 +1539,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e434435a62c7f51d7de09c45b5cc7aeacd5b8c10"'
+      - '"8f82b64446811b2c49cc249a636d15722f91ce84"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:09 GMT
+      - Wed, 04 Mar 2015 19:26:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1555,7 +1554,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3686'
+      - '3521'
       Content-Type:
       - application/x-turtle
     body:
@@ -1563,41 +1562,40 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/3a123dde-434e-455e-a56c-a36a4a695c10/t/d056664c-fe17-4028-b182-7cd00a3bb04c>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f0502ccd-1484-4b2b-9c73-9cb1ccc3e6f3/t/8d4bdc45-b4c9-4bd9-995f-507e24cf3533>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"30e65bdf-05d4-4c0b-a283-f619031aa715\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"9a9d228f-9831-4a57-abc4-c0ff91383b9b\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:09.173Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:09.173Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:31.794Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:31.794Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:09 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"85a440073b19064ee190d38e3058a7eb8c62ec55"'
+      - '"b22766fdf29203a6c97b926fd4a50f3237bf6a08"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+      - http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+      string: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f632ef0fcaac28615b12c8e90fddae64cf9fc2d"'
+      - '"3d652e24c4e4f67654a276d11d5c24e3aefb4c7b"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b
+      - http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b
+      string: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3771e021b13a31e7c36c6802b94492681f77fe50"'
+      - '"f30cef285f776766119a9b1cf4aa53a728ba73f3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab
+      - http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab
+      string: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
     body:
       encoding: UTF-8
       string: |
@@ -134,7 +134,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -152,23 +152,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d5c78c4c7f0f01d0171747bb79380d09e029324c"'
+      - '"cc7d6f6eb42369f62ac6c046651e3e546b85f8fd"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t
+      - http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t
+      string: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:12 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t
     body:
       encoding: UTF-8
       string: |
@@ -196,23 +196,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"531304100063eff3861d1119e9e15d0eff7cc7af"'
+      - '"e4e17314291163deffc0fa3d79e016e799e5e131"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c
+      - http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c
+      string: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
     body:
       encoding: US-ASCII
       string: ''
@@ -229,9 +229,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c98f5ab24a817bdcb4c8cc149eb044b22ac3d05b"'
+      - '"aa75d9503b1b62a6dabad690dc3e0b01267cafe1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -244,7 +244,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4590'
+      - '4464'
       Content-Type:
       - application/x-turtle
     body:
@@ -252,55 +252,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        , <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        , <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        , <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        , <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"41bd0cfa-7c4e-40b8-9d25-309802b0d782\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d80b1293-2262-4939-94c6-7d4a70090c36\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:12.939Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.092Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:12.987Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:35.138Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28
     body:
       encoding: US-ASCII
       string: ''
@@ -317,9 +316,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3771e021b13a31e7c36c6802b94492681f77fe50"'
+      - '"f30cef285f776766119a9b1cf4aa53a728ba73f3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -332,7 +331,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3568'
+      - '3639'
       Content-Type:
       - application/x-turtle
     body:
@@ -340,45 +339,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"bfc37189-31f7-4b0f-a7fe-f5adea61c09d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"d10a445b-05f2-41f6-aa2b-ff9764ce6ac5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:12.97Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.123Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:12.97Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:35.123Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197
     body:
       encoding: US-ASCII
       string: ''
@@ -395,9 +395,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"531304100063eff3861d1119e9e15d0eff7cc7af"'
+      - '"e4e17314291163deffc0fa3d79e016e799e5e131"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -410,7 +410,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3828'
+      - '3660'
       Content-Type:
       - application/x-turtle
     body:
@@ -418,45 +418,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
+        <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"28c875f8-8719-48f2-a9be-8d432d3ebf61\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6efe8ea2-6236-45fb-b6ec-3bb6cccd8d47\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://external.com/index.html> ;\n\tfcrepo:mixinTypes
-        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.155Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://external.com/index.html> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:35.155Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -480,7 +478,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -494,7 +492,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:44:12 GMT
+      - Thu, 05 Mar 2015 01:26:35 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1610,10 +1608,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf
     body:
       encoding: US-ASCII
       string: ''
@@ -1630,9 +1628,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c98f5ab24a817bdcb4c8cc149eb044b22ac3d05b"'
+      - '"aa75d9503b1b62a6dabad690dc3e0b01267cafe1"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1645,7 +1643,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4590'
+      - '4464'
       Content-Type:
       - application/x-turtle
     body:
@@ -1653,55 +1651,54 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        , <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        , <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043>
-        a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        , <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ;\n\topenannotation:hasBody <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        , <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/fcr:export?format=jcr/xml>
+        ;\n\ta <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"41bd0cfa-7c4e-40b8-9d25-309802b0d782\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d80b1293-2262-4939-94c6-7d4a70090c36\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:12.939Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.092Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:44:12.987Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:35.138Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:identifying .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28
     body:
       encoding: US-ASCII
       string: ''
@@ -1718,9 +1715,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3771e021b13a31e7c36c6802b94492681f77fe50"'
+      - '"f30cef285f776766119a9b1cf4aa53a728ba73f3"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:12 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1733,7 +1730,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3568'
+      - '3639'
       Content-Type:
       - application/x-turtle
     body:
@@ -1741,45 +1738,46 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
         ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
-        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b>
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/b/dd241520-46b6-4a83-ba01-9781267944ab>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/b/e42b98a0-8a18-45b0-9bb9-d2e329ed4f28>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"bfc37189-31f7-4b0f-a7fe-f5adea61c09d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"d10a445b-05f2-41f6-aa2b-ff9764ce6ac5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:12.97Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.123Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:12.97Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfcrepo:mixinTypes
-        \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        \"2015-03-04T19:26:35.123Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c
+    uri: http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197
     body:
       encoding: US-ASCII
       string: ''
@@ -1796,9 +1794,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"531304100063eff3861d1119e9e15d0eff7cc7af"'
+      - '"e4e17314291163deffc0fa3d79e016e799e5e131"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:44:13 GMT
+      - Wed, 04 Mar 2015 19:26:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1811,7 +1809,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3828'
+      - '3660'
       Content-Type:
       - application/x-turtle
     body:
@@ -1819,43 +1817,41 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
+        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
         ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t>
+        <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/bc779b3e-73ac-4226-9731-e8b210eaa043/t/3e426610-c3f3-4bf8-a72d-448bdfce218c>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/94077ba7-42a5-43a2-893c-6df7274c21bf/t/d14753e4-a958-49d8-a372-d22a2f389197>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Text , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"28c875f8-8719-48f2-a9be-8d432d3ebf61\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6efe8ea2-6236-45fb-b6ec-3bb6cccd8d47\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:44:13.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://external.com/index.html> ;\n\tfcrepo:mixinTypes
-        \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:44:13.002Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tns001:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        ;\n\tfcrepo:created \"2015-03-04T19:26:35.155Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://external.com/index.html> ;\n\tfcrepo:lastModified
+        \"2015-03-04T19:26:35.155Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:44:13 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
@@ -26,23 +26,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"05d1ec223fbbe2554938302bb0402478aa205ee2"'
+      - '"610d6397d7c293d08382a4e341d8dcab7800a8b9"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Content-Length:
       - '75'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1
+      - http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1
+      string: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:37 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736
     body:
       encoding: UTF-8
       string: |
@@ -52,7 +52,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation openannotation:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3ba8ccdf9bdad53856bac3d05cad2275f5900578"'
+      - '"ac0d307cf79c17604dfcc08069f717a522ce7ce6"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Content-Length:
       - '77'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t
+      - http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t
+      string: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:37 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t
     body:
       encoding: UTF-8
       string: |
@@ -108,23 +108,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1734fd36ca32c9e6001468fd2ddb44e3e67c7bc1"'
+      - '"707024c1b6fdfb8c39c95c047ba3d28d10a6e24f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281
+      - http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281
+      string: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:37 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736
     body:
       encoding: US-ASCII
       string: ''
@@ -141,9 +141,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2c085f390c6e15a11e0b98e815870b5a4b851aa"'
+      - '"478827f5a40441669592343335e92c0368057ec7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -156,7 +156,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4021'
+      - '3972'
       Content-Type:
       - application/x-turtle
     body:
@@ -164,50 +164,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
+        <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"ab8a97a6-9569-4fb6-80ec-765c2e1ab00b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4695fd7-8031-4d9a-8fd9-dff6eb76d4a5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:43:37.932Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:37.734Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:43:37.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:37.75Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333
     body:
       encoding: US-ASCII
       string: ''
@@ -224,9 +224,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1734fd36ca32c9e6001468fd2ddb44e3e67c7bc1"'
+      - '"707024c1b6fdfb8c39c95c047ba3d28d10a6e24f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -239,7 +239,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -247,42 +247,43 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"741d8ce3-0df9-47ee-b682-b74ee9f6529a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"8ec3f4bb-f0b2-4b6b-aad1-ecf9065037ab\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:43:37.979Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:37.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:43:37.979Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:37.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:37 GMT
 - request:
     method: get
     uri: http://www.w3.org/ns/oa.jsonld
@@ -306,7 +307,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:38 GMT
       Server:
       - Apache/2
       Last-Modified:
@@ -320,7 +321,7 @@ http_interactions:
       Cache-Control:
       - max-age=21600
       Expires:
-      - Wed, 04 Feb 2015 07:43:37 GMT
+      - Thu, 05 Mar 2015 01:26:38 GMT
       P3p:
       - policyref="http://www.w3.org/2014/08/p3p.xml"
       Content-Type:
@@ -1436,10 +1437,10 @@ http_interactions:
 
 
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736
     body:
       encoding: US-ASCII
       string: ''
@@ -1456,9 +1457,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2c085f390c6e15a11e0b98e815870b5a4b851aa"'
+      - '"478827f5a40441669592343335e92c0368057ec7"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1471,7 +1472,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '4021'
+      - '3972'
       Content-Type:
       - application/x-turtle
     body:
@@ -1479,50 +1480,50 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tldp:member
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
-        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tldp:member <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ;\n\topenannotation:hasTarget <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
         fedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1>
+        <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , openannotation:Annotation , fedora:resource , fedora:object , fedora:relations
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:DublinCoreDescribable
         , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:uuid \"ab8a97a6-9569-4fb6-80ec-765c2e1ab00b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfcrepo:uuid \"d4695fd7-8031-4d9a-8fd9-dff6eb76d4a5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:43:37.932Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:37.734Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"openannotation:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:lastModified \"2015-02-04T01:43:37.947Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:lastModified \"2015-03-04T19:26:37.75Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\topenannotation:motivatedBy openannotation:bookmarking .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281
+    uri: http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333
     body:
       encoding: US-ASCII
       string: ''
@@ -1539,9 +1540,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1734fd36ca32c9e6001468fd2ddb44e3e67c7bc1"'
+      - '"707024c1b6fdfb8c39c95c047ba3d28d10a6e24f"'
       Last-Modified:
-      - Wed, 04 Feb 2015 01:43:37 GMT
+      - Wed, 04 Mar 2015 19:26:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Resource>;rel="type"
@@ -1554,7 +1555,7 @@ http_interactions:
       Vary:
       - Accept, Range, Accept-Encoding, Accept-Language
       Content-Length:
-      - '3569'
+      - '3638'
       Content-Type:
       - application/x-turtle
     body:
@@ -1562,40 +1563,41 @@ http_interactions:
       string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix fedorarelsext:
         <http://fedora.info/definitions/v4/rels-ext#> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
         .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix content:
-        <http://www.w3.org/2011/content#> .\n@prefix ns001: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .\n@prefix mode:
-        <http://www.modeshape.org/1.0> .\n@prefix openannotation: <http://www.w3.org/ns/oa#>
-        .\n@prefix xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix fcrepo:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#>
-        .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        <http://www.w3.org/2011/content#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix openannotation:
+        <http://www.w3.org/ns/oa#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix fcrepo: <http://fedora.info/definitions/v4/repository#> .\n@prefix
+        fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix mix:
+        <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
         .\n@prefix image: <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
         .\n@prefix test: <info:fedora/test/> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
         .\n@prefix triannon: <http://triannon.stanford.edu/ns/> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         .\n@prefix fedora: <http://fedora.info/definitions/v4/rest-api#> .\n@prefix
         ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ldp:hasMemberRelation ldp:member ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
-        ;\n\ta ldp:Container , ldp:DirectContainer , ldp:RDFSource ;\n\tfcrepo:hasParent
-        <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ldp:membershipResource <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        ;\n\tldp:hasMemberRelation ldp:member ;\n\ta ldp:Container , ldp:DirectContainer
+        , ldp:RDFSource ;\n\tfcrepo:hasParent <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281/fcr:export?format=jcr/xml>
-        ns001:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/f9f88757-c5ad-4d34-9650-5d0a279881b1/t/26911ce7-fba6-458b-886c-b84b0bfdd281>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333/fcr:export?format=jcr/xml>
+        dc:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/6b6c7350-d078-4746-b984-b9644dd58736/t/022adf1a-9d8d-45e2-889b-9bce083d6333>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:resource , fedora:object , fedora:relations , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:DublinCoreDescribable , fedora:resource , ldp:Container ;\n\tfcrepo:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfcrepo:uuid
-        \"741d8ce3-0df9-47ee-b682-b74ee9f6529a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"8ec3f4bb-f0b2-4b6b-aad1-ecf9065037ab\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfcrepo:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfcrepo:created \"2015-02-04T01:43:37.979Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfcrepo:created \"2015-03-04T19:26:37.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfcrepo:lastModified
-        \"2015-02-04T01:43:37.979Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-03-04T19:26:37.765Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfcrepo:mixinTypes \"fedora:resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:object\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Wed, 04 Feb 2015 01:43:38 GMT
+  recorded_at: Wed, 04 Mar 2015 19:26:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/models/triannon/annotation_spec.rb
+++ b/spec/models/triannon/annotation_spec.rb
@@ -120,6 +120,13 @@ describe Triannon::Annotation, :vcr do
         anno = Triannon::Annotation.new data: "xxx " + @rdfxml_data
         expect(anno.graph).to be_nil
       end
+      it "converts data to turtle" do
+        anno = Triannon::Annotation.new data: @rdfxml_data
+        c = anno.graph.count
+        g = RDF::Graph.new
+        g.from_ttl(anno.data)
+        expect(g.count).to eql c
+      end
     end
   end # data_as_graph
 


### PR DESCRIPTION
* model converts rdfxml into ttl data so LdpWriter works properly
* annotations controller #create checks for params[annotation].empty? so requests with Content-Type of json (but not jsonld) don't barf
* update rdf fixture object to have no id specified