### PR TITLE
Feature/omniauth

### DIFF
--- a/app/assets/javascripts/triannon/sessions.js
+++ b/app/assets/javascripts/triannon/sessions.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/triannon/sessions.css
+++ b/app/assets/stylesheets/triannon/sessions.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/app/controllers/triannon/application_controller.rb
+++ b/app/controllers/triannon/application_controller.rb
@@ -1,4 +1,18 @@
 module Triannon
   class ApplicationController < ActionController::Base
+      helper_method :current_user, :logged_in?
+      private
+      def current_user
+        # triannon has no User db (as yet), details are in the session.
+        # @current_user ||= User.find(session[:user_id]) if session[:user_id]
+        @current_user ||= session[:current_user] if session[:current_user]
+      end
+      def current_user=(user)
+          session[:current_user] = user
+          @current_user = user
+      end
+      def logged_in?
+          !!current_user
+      end
   end
 end

--- a/app/controllers/triannon/sessions_controller.rb
+++ b/app/controllers/triannon/sessions_controller.rb
@@ -1,19 +1,79 @@
 require_dependency "triannon/application_controller"
 
 module Triannon
-  # This copied from https://github.com/intridea/omniauth#integrating-omniauth-into-your-application
   class SessionsController < ApplicationController
+    # def new
+    #   @identity = request.env['omniauth.auth']
+    # end
+
     def create
-      @user = User.find_or_create_from_auth_hash(auth_hash)
-      self.current_user = @user
-      redirect_to '/'
+      # Note: this code aims to provide a way for a known application, like
+      # SearchWorks, to authenticate to triannon and provide information about
+      # members of authorized workgroups so that triannon can respond with an
+      # array of authorized annotation containers.  The secure information is
+      # stored in session data, while the insecure information is available in
+      # cookies.  TODO: determine whether to use secure cookies.
+      @identity = request.env['omniauth.auth']
+      # TODO: switch yard for different providers?
+      raise 'Cannot work with provider' unless @identity['provider'] == 'developer'
+      if authenticate(@identity['info'])
+        current_user = @identity.to_json
+        # TODO: find LDAP data and add container info to cookie?
+        # workgroups = request.headers['TBD']
+        workgroups = ['sul-curators',]
+        find_containers(workgroups) # set containers in cookies
+        respond_to do |format|
+          # TODO: support a json response format
+          # format.json {
+          #   accept_return_type = mime_type_from_accept(["application/json", "text/x-json", "application/jsonrequest"])
+          #   render :json => @identity.to_json, content_type: accept_return_type
+          # }
+          format.html {
+            redirect_to root_url, notice: 'Successfully authenticated.'
+            # render :create
+          }
+        end
+      else
+        failure
+      end
+      # NOTE: code commented out here relies in using a conventional rails db
+      # persistence layer that is not available in triannon.
+      # user = User.find_or_create_from_auth_hash(auth_hash)
+      # self.current_user = user
+      # redirect_to root_url, :notice => "Logged in successfully."
     end
 
-    protected
-
-    def auth_hash
-      request.env['omniauth.auth']
+    def destroy
+      current_user = nil
+      cookies[:containers] = nil
+      redirect_to root_url, notice: 'Successfully logged out.'
     end
+
+    def failure
+      redirect_to root_url, alert: "Failed to authorize: #{@identity['uid']}"
+    end
+
+    private
+
+    # Authenticates a known application client
+    # @param app [Hash] app['name'] and app['email'] identify an application
+    def authenticate(app)
+      # TODO: use a configuration value to authenticate known apps; triannon
+      # has no user db (as yet)
+      # @authorized_apps ||= JSON.parse(ENV['AUTHORIZED_APPS'])
+      @authorized_apps ||= {'SearchWorks' => 'secret', 'Mirador' => 'secret'}
+      @authorized_apps[app['name']] == app['email']
+    end
+
+    # Sets cookies[:containers] to authorized annotation containers.
+    # @param workgroups [Array<String>] An array of LDAP workgroups
+    def find_containers(workgroups)
+      # TODO: use a configuration value to map workgroups to containers
+      # @containers ||= JSON.parse(ENV['WORKGROUP_CONTAINERS'])
+      @containers ||= {'sul-curators' => ['annotations']}
+      containers = workgroups.collect {|g| @containers[g] }.compact
+      cookies[:containers] = containers.flatten.uniq
+    end
+
   end
-
-end # Triannon
+end

--- a/app/controllers/triannon/sessions_controller.rb
+++ b/app/controllers/triannon/sessions_controller.rb
@@ -1,0 +1,19 @@
+require_dependency "triannon/application_controller"
+
+module Triannon
+  # This copied from https://github.com/intridea/omniauth#integrating-omniauth-into-your-application
+  class SessionsController < ApplicationController
+    def create
+      @user = User.find_or_create_from_auth_hash(auth_hash)
+      self.current_user = @user
+      redirect_to '/'
+    end
+
+    protected
+
+    def auth_hash
+      request.env['omniauth.auth']
+    end
+  end
+
+end # Triannon

--- a/app/helpers/triannon/sessions_helper.rb
+++ b/app/helpers/triannon/sessions_helper.rb
@@ -1,0 +1,4 @@
+module Triannon
+  module SessionsHelper
+  end
+end

--- a/app/views/layouts/triannon/application.html.erb
+++ b/app/views/layouts/triannon/application.html.erb
@@ -30,6 +30,11 @@
           </ul>
         </div><!--/.nav-collapse -->
       </div><!--/.container-fluid -->
+      <div class="container-fluid">
+        <% flash.each do |name, msg| -%>
+          <%= content_tag :div, msg, class: name %>
+        <% end -%>
+      </div><!--/.container-fluid -->
     </div>
     <%= yield %>
   </div>

--- a/app/views/triannon/sessions/create.html.erb
+++ b/app/views/triannon/sessions/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Session#create</h1>
+<p>Find me in app/views/triannon/sessions/create.html.erb</p>

--- a/app/views/triannon/sessions/destroy.html.erb
+++ b/app/views/triannon/sessions/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Sessions#destroy</h1>
+<p>Find me in app/views/triannon/sessions/destroy.html.erb</p>

--- a/app/views/triannon/sessions/failure.html.erb
+++ b/app/views/triannon/sessions/failure.html.erb
@@ -1,0 +1,2 @@
+<h1>Sessions#failure</h1>
+<p>Find me in app/views/triannon/sessions/failure.html.erb</p>

--- a/app/views/triannon/sessions/new.html.erb
+++ b/app/views/triannon/sessions/new.html.erb
@@ -1,0 +1,9 @@
+<div>
+<% if logged_in? %>
+
+    <b><%= current_user.name %></b> is logged in.
+
+<% else %>
+    ...
+<% end %>
+</div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,9 @@
 # adapted from https://github.com/intridea/omniauth#getting-started
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
+  # The :developer provides has useful default fields that could be
+  # overridden, but a better implementation must use an alternative provider.
+  #provider :identity, :fields => [:name, :email]
   #provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 end
 OmniAuth.config.logger = Rails.logger

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,6 @@
+# adapted from https://github.com/intridea/omniauth#getting-started
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer unless Rails.env.production?
+  #provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
+end
+OmniAuth.config.logger = Rails.logger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,7 @@ Triannon::Engine.routes.draw do
                           (jsonld_context =~ /^iiif$/ || jsonld_context =~ /^oa$/ ) && id !~ /^new$/
                  }
 
+  get '/auth', to: '/auth/developer'
+  get '/auth/:provider/callback', to: 'sessions#create'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,13 @@ Triannon::Engine.routes.draw do
                           (jsonld_context =~ /^iiif$/ || jsonld_context =~ /^oa$/ ) && id !~ /^new$/
                  }
 
-  get '/auth/:provider/callback', to: 'sessions#create'
+  post '/auth/:provider/callback', :to => 'sessions#create'
+  get '/auth/failure', :to => 'sessions#failure'
+  get '/logout', :to => 'sessions#destroy', :as => 'logout'
+  # root :to => 'sessions#new'
+  # get 'sessions/new'
+  # get 'sessions/create'
+  # get 'sessions/destroy'
+  # get 'sessions/failure'
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,6 @@ Triannon::Engine.routes.draw do
                           (jsonld_context =~ /^iiif$/ || jsonld_context =~ /^oa$/ ) && id !~ /^new$/
                  }
 
-  get '/auth', to: '/auth/developer'
   get '/auth/:provider/callback', to: 'sessions#create'
 
 end

--- a/lib/triannon.rb
+++ b/lib/triannon.rb
@@ -1,5 +1,6 @@
 require 'linkeddata'
 require 'oa/graph'
+require 'omniauth'
 require 'rdf/triannon_vocab'
 require 'bootstrap-sass'
 require 'faraday' # for writing to LDP store

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/json_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/json_specified_for_jsonld.yml
@@ -104,4 +104,3608 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:10 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:48 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:48 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:49 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:49 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:49 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:49 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:50 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:50 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:50 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:50 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:50 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:50 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:51 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:51 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:51 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:51 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:51 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/jsonrequest_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/jsonrequest_specified_for_jsonld.yml
@@ -104,4 +104,3608 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:10 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:24 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:24 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:24 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:24 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:24 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:25 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:25 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:25 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:25 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:25 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:25 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:26 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:26 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:26 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:26 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:26 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:26 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/rdf_xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/rdf_xml_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:34 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:34 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:34 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:34 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:34 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-turtle_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-turtle_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:31 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:31 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:32 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:32 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:32 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-xml_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:12 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:40 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:40 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:40 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:40 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:40 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/xml_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:12 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:38 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:38 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:38 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:38 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:38 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:36 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:36 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:36 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:36 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:36 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_xml_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:35 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:35 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:35 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:35 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:35 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/turtle_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/turtle_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:32 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:32 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:33 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:33 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:33 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/xml_specified_and_provided.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:12 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:39 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:39 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:39 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:39 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:39 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/iiif_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/iiif_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -454,4 +454,102 @@ http_interactions:
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:14 GMT
+- request:
+    method: get
+    uri: http://iiif.io/api/presentation/2/context.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 May 2015 01:59:35 GMT
+      Server:
+      - Apache/2.2.15 (Red Hat)
+      Last-Modified:
+      - Wed, 13 May 2015 19:46:47 GMT
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '4235'
+      Cache-Control:
+      - max-age=86400
+      Expires:
+      - Sat, 30 May 2015 01:59:35 GMT
+      Content-Type:
+      - application/ld+json
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: "{\n\t\"@context\": [\n\t\t{\n\t\t\t\"sc\":      \"http://iiif.io/api/presentation/2#\",\n\t
+        \       \"iiif\":    \"http://iiif.io/api/image/2#\",\n\t        \"exif\":
+        \   \"http://www.w3.org/2003/12/exif/ns#\",\n\t        \"oa\":      \"http://www.w3.org/ns/oa#\",\n\t
+        \       \"cnt\":     \"http://www.w3.org/2011/content#\",\n\t        \"dc\":
+        \     \"http://purl.org/dc/elements/1.1/\",\n\t        \"dcterms\": \"http://purl.org/dc/terms/\",\n\t
+        \       \"dctypes\": \"http://purl.org/dc/dcmitype/\",\n\t        \"foaf\":
+        \   \"http://xmlns.com/foaf/0.1/\",\n\t        \"rdf\":     \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n\t
+        \       \"rdfs\":    \"http://www.w3.org/2000/01/rdf-schema#\",\n\t        \"xsd\":
+        \    \"http://www.w3.org/2001/XMLSchema#\",\n\t\t\t\"svcs\":    \"http://rdfs.org/sioc/services#\",\n\n\t
+        \       \"license\":     {\"@type\":\"@id\", \"@id\":\"dcterms:license\"},\n\t
+        \       \"service\":     {\"@type\":\"@id\", \"@id\":\"svcs:has_service\"},\n\t
+        \       \"seeAlso\":    {\"@type\":\"@id\", \"@id\":\"foaf:page\"},\n\t        \"within\":
+        \     {\"@type\":\"@id\", \"@id\":\"dcterms:isPartOf\"},\n\t        \"profile\":
+        \    {\"@type\":\"@id\", \"@id\":\"dcterms:conformsTo\"},\n\t        \"related\":
+        \    {\"@type\":\"@id\", \"@id\":\"dcterms:relation\"},\n\t        \"logo\":
+        \       {\"@type\":\"@id\", \"@id\":\"foaf:logo\"},\n\t        \"thumbnail\":
+        \  {\"@type\":\"@id\", \"@id\":\"foaf:thumbnail\"},\n\t        \"startCanvas\":
+        {\"@type\":\"@id\", \"@id\":\"sc:hasStartCanvas\"},\n\n\t        \"collections\":
+        {\"@type\":\"@id\", \"@id\":\"sc:hasCollections\", \"@container\":\"@list\"},\n\t
+        \       \"manifests\":   {\"@type\":\"@id\", \"@id\":\"sc:hasManifests\",
+        \"@container\":\"@list\"},\n\t        \"sequences\":   {\"@type\":\"@id\",
+        \"@id\":\"sc:hasSequences\", \"@container\":\"@list\"},\n\t        \"canvases\":
+        \   {\"@type\":\"@id\", \"@id\":\"sc:hasCanvases\", \"@container\":\"@list\"},\n\t
+        \       \"resources\":   {\"@type\":\"@id\", \"@id\":\"sc:hasAnnotations\",
+        \"@container\":\"@list\"},\n\t        \"images\":      {\"@type\":\"@id\",
+        \"@id\":\"sc:hasImageAnnotations\",\"@container\":\"@list\"},\n\t        \"otherContent\":
+        {\"@type\":\"@id\", \"@id\":\"sc:hasLists\", \"@container\":\"@list\"},\n\t
+        \       \"structures\":  {\"@type\":\"@id\", \"@id\":\"sc:hasRanges\", \"@container\":\"@list\"},\n\t
+        \       \"ranges\" :     {\"@type\": \"@id\", \"@id\": \"sc:hasRanges\", \"@container\":\"@list\"},\n\n\t
+        \       \"metadata\":    {\"@type\":\"@id\", \"@id\":\"sc:metadataLabels\",
+        \"@container\":\"@list\"},\n\n\t        \"description\": {\"@id\": \"dc:description\"},\n\t
+        \       \"height\":      {\"@type\":\"xsd:integer\", \"@id\":\"exif:height\"},\n\t
+        \       \"width\":       {\"@type\":\"xsd:integer\", \"@id\":\"exif:width\"},\n\n\t
+        \       \"attribution\": {\"@id\": \"sc:attributionLabel\"},\n\t        \"viewingDirection\":
+        {\"@id\": \"sc:viewingDirection\", \"@type\":\"@id\"},\n\t        \"viewingHint\":
+        {\"@id\": \"sc:viewingHint\", \"@type\":\"@id\"},\n\n\t        \"left-to-right\":
+        {\"@id\":\"sc:leftToRightDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
+        \       \"right-to-left\": {\"@id\":\"sc:rightToLeftDirection\", \"@type\":\"sc:ViewingDirection\"},\n\t
+        \       \"top-to-bottom\": {\"@id\":\"sc:topToBottomDirection\", \"@type\":\"sc:ViewingDirection\"},\t
+        \       \n\t        \"bottom-to-top\": {\"@id\":\"sc:bottomToTopDirection\",
+        \"@type\":\"sc:ViewingDirection\"},\n\n\t        \"paged\":         {\"@id\":\"sc:pagedHint\",
+        \"@type\":\"sc:ViewingHint\"},\n\t        \"non-paged\":     {\"@id\":\"sc:nonPagedHint\",
+        \"@type\":\"sc:ViewingHint\"},   \n\t        \"continuous\":    {\"@id\":\"sc:continuousHint\",
+        \"@type\":\"sc:ViewingHint\"},\n\t        \"individuals\":   {\"@id\":\"sc:individualsHint\",
+        \"@type\":\"sc:ViewingHint\"}, \n\t        \"top\":           {\"@id\":\"sc:topHint\",
+        \"@type\":\"sc:ViewingHint\"},\n\n\t        \"motivation\":  {\"@type\":\"@id\",
+        \"@id\":\"oa:motivatedBy\"},\n\t        \"resource\":    {\"@type\":\"@id\",
+        \"@id\":\"oa:hasBody\"},\n\t        \"on\":          {\"@type\":\"@id\", \"@id\":\"oa:hasTarget\"},\n\t
+        \       \"full\":        {\"@type\":\"@id\", \"@id\":\"oa:hasSource\"},\n\t
+        \       \"selector\":    {\"@type\":\"@id\", \"@id\":\"oa:hasSelector\"},\n\t
+        \       \"stylesheet\":  {\"@type\":\"@id\", \"@id\":\"oa:styledBy\"},\n\t
+        \       \"style\":       {\"@id\":\"oa:styleClass\"},\n\n\t\t    \"default\":
+        \    {\"@type\":\"@id\", \"@id\" : \"oa:default\"},\n\t\t    \"item\":        {\"@type\":\"@id\",
+        \"@id\" : \"oa:item\"},\n\t\t    \"chars\":       {\"@id\": \"cnt:chars\"},\n\t\t
+        \   \"encoding\":    {\"@id\": \"cnt:characterEncoding\"},\n\t\t    \"bytes\":
+        \      {\"@id\": \"cnt:bytes\"},\n\t\t    \"format\":      {\"@id\": \"dc:format\"},\n\t\t
+        \   \"language\":    {\"@id\": \"dc:language\"},\n\t\t    \"value\":       {\"@id\":
+        \"rdf:value\"},\n\t\t    \"label\":       {\"@id\": \"rdfs:label\"}\n\t\t}\n\t]\n}"
+    http_version: 
+  recorded_at: Fri, 29 May 2015 01:56:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -1652,4 +1652,41 @@ http_interactions:
         </body></html>
     http_version: 
   recorded_at: Thu, 28 May 2015 02:32:43 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      If-Modified-Since:
+      - Tue, 06 May 2014 11:14:49 GMT
+      If-None-Match:
+      - '"b533-4f8b95b2a9c40"'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 304
+      message: Not Modified
+    headers:
+      Date:
+      - Fri, 29 May 2015 01:56:31 GMT
+      Server:
+      - Apache/2
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Expires:
+      - Fri, 29 May 2015 07:56:31 GMT
+      Cache-Control:
+      - max-age=21600
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 29 May 2015 01:56:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -451,4 +451,1205 @@ http_interactions:
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:13 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:42 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:42 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:42 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:42 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:42 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_matches_data.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_matches_data.yml
@@ -104,4 +104,3608 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:08 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:37 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:37 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:37 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:37 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:37 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:39 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:39 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:39 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:39 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:39 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:39 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:41 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:42 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:42 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:42 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:42 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:42 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/text/x-json_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/text/x-json_specified_for_jsonld.yml
@@ -104,4 +104,3608 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:10 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:04 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:04 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:05 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:05 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:05 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:05 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:05 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:05 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:05 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:06 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:06 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:06 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:06 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:06 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:06 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:30:07 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:30:07 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:30:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_jsonld.yml
@@ -104,4 +104,3608 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:28 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:28 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:28 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:28 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:28 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:29 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:29 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:29 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:29 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:29 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:29 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:29 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:29 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:29 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:30 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:30 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:30 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_ttl.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_ttl.yml
@@ -104,4 +104,1212 @@ http_interactions:
         a oa:Annotation ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:11 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:30 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:30 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:31 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:32:31 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:32:31 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:32:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
@@ -451,4 +451,2420 @@ http_interactions:
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:08 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:35 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:35 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:35 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:35 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:35 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:36 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:36 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:36 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:36 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:36 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:36 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
@@ -451,4 +451,2420 @@ http_interactions:
         {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
   recorded_at: Tue, 05 May 2015 00:47:08 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:32 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:32 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:32 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:32 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:32 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:33 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa-context-20130208.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:33 GMT
+      Server:
+      - Apache/2
+      Location:
+      - http://www.w3.org/ns/oa.jsonld
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:33 GMT
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>307 Temporary Redirect</title>
+        </head><body>
+        <h1>Temporary Redirect</h1>
+        <p>The document has moved <a href="http://www.w3.org/ns/oa.jsonld">here</a>.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:33 GMT
+- request:
+    method: get
+    uri: http://www.w3.org/ns/oa.jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/n-triples, text/plain;q=0.5, application/n-quads, text/x-nquads,
+        application/ld+json, application/x-ld+json, application/rdf+json, text/html;q=0.5,
+        application/xhtml+xml;q=0.7, image/svg+xml, text/n3, text/rdf+n3, application/rdf+n3,
+        application/rdf+xml, text/csv, text/tab-separated-values, application/trig,
+        application/x-trig, application/trix, text/turtle, text/rdf+turtle, application/turtle,
+        application/x-turtle, */*;q=0.1
+      Accept-Encoding:
+      - gzip, deflate
+      Cookie:
+      - ''
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 28 May 2015 02:29:34 GMT
+      Server:
+      - Apache/2
+      Last-Modified:
+      - Tue, 06 May 2014 11:14:49 GMT
+      Etag:
+      - '"b533-4f8b95b2a9c40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '46387'
+      Cache-Control:
+      - max-age=21600
+      Expires:
+      - Thu, 28 May 2015 08:29:34 GMT
+      P3p:
+      - policyref="http://www.w3.org/2014/08/p3p.xml"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/ld+json
+    body:
+      encoding: UTF-8
+      string: |+
+        {
+          "@context": {
+            "oa": "http://www.w3.org/ns/oa#",
+            "cnt": "http://www.w3.org/2011/content#",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "dctypes": "http://purl.org/dc/dcmitype/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "prov": "http://www.w3.org/ns/prov#",
+            "trig": "http://www.w3.org/2004/03/trix/rdfg-1/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+
+            "hasBody" :         {"@type":"@id", "@id" : "oa:hasBody"},
+            "hasTarget" :       {"@type":"@id", "@id" : "oa:hasTarget"},
+            "hasSource" :       {"@type":"@id", "@id" : "oa:hasSource"},
+            "hasSelector" :     {"@type":"@id", "@id" : "oa:hasSelector"},
+            "hasState" :        {"@type":"@id", "@id" : "oa:hasState"},
+            "hasScope" :        {"@type":"@id", "@id" : "oa:hasScope"},
+            "annotatedBy" :  {"@type":"@id", "@id" : "oa:annotatedBy"},
+            "serializedBy" : {"@type":"@id", "@id" : "oa:serializedBy"},
+            "motivatedBy" :  {"@type":"@id", "@id" : "oa:motivatedBy"},
+            "equivalentTo" : {"@type":"@id", "@id" : "oa:equivalentTo"},
+            "styledBy" :     {"@type":"@id", "@id" : "oa:styledBy"},
+            "cachedSource" : {"@type":"@id", "@id" : "oa:cachedSource"},
+            "conformsTo" :   {"@type":"@id", "@id" : "dcterms:conformsTo"},
+            "default" :      {"@type":"@id", "@id" : "oa:default"},
+            "item" :         {"@type":"@id", "@id" : "oa:item"},
+            "first":         {"@type":"@id", "@id" : "rdf:first"},
+            "rest":          {"@type":"@id", "@id" : "rdf:rest", "@container" : "@list"},
+
+            "annotatedAt" :  { "@type": "xsd:dateTimeStamp", "@id": "oa:annotatedAt" },
+            "end" :          { "@type": "xsd:nonNegativeInteger", "@id": "oa:end" },
+            "exact" :        "oa:exact",
+            "prefix" :       "oa:prefix",
+            "serializedAt" : { "@type": "xsd:dateTimeStamp", "@id": "oa:serializedAt" },
+            "start" :        { "@type": "xsd:nonNegativeInteger", "@id": "oa:start" },
+            "styleClass" :   "oa:styleClass",
+            "suffix" :       "oa:suffix",
+            "when" :         { "@type": "xsd:dateTimeStamp", "@id": "oa:when" },
+
+            "chars" :        "cnt:chars",
+            "bytes" :        "cnt:bytes",
+            "format" :       "dc:format",
+            "language" :     "dc:language",
+            "value" :        "rdf:value",
+            "label" :        "rdfs:label",
+            "name" :         "foaf:name",
+            "mbox" :         "foaf:mbox"
+
+          },
+          "@graph": [
+            {
+              "@id": "oa:annotatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is a resource that identifies the agent responsible for creating the Annotation. This may be either a human or software agent. \n\nThere SHOULD be exactly 1 oa:annotatedBy relationship per Annotation, but MAY be 0 or more than 1, as the Annotation may be anonymous, or multiple agents may have worked together on it.\n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:commenting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a commentary about or review of the target resource(s). For example to provide a commentary about a particular PDF."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "commenting"
+              }
+            },
+            {
+              "@id": "oa:SvgSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which selects an area specified as an SVG shape.\n\nThe SVG document should either be retrievable by resolving the URI of this resource, or be included as an Embedded Resource using cnt:Content.\n\nIt is RECOMMENDED that the document contain only a single shape element and that element SHOULD be one of: path, rect, circle, ellipse, polyline, polygon or g. The g element SHOULD ONLY be used to construct a multi-element group, for example to define a donut shape requiring an outer circle and a clipped inner circle.\n\nThe dimensions of both the shape and the SVG canvas MUST be relative to the dimensions of the Source resource. For example, given an image which is 600 pixels by 400 pixels, and the desired section is a circle of 100 pixel radius at the center of the image, then the SVG element would be: <circle cx=\"300\" cy=\"200\" r=\"100\"/>\n\nIt is NOT RECOMMENDED to include style information within the SVG element, nor Javascript, animation, text or other non shape oriented information. Clients SHOULD ignore such information if present."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SvgSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:Selector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the segment of interest in a representation of a Source resource, indicated with oa:hasSelector from the Specific Resource. \n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe nature of the Selector will be dependent on the type of the representation for which the segment is conveyed. The specific type of selector should be indicated using a subclass of oa:Selector.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Selector"
+              }
+            },
+            {
+              "@id": "oa:Style",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes the style in which the selection or resource should be rendered, indicated with oa:styledBy from an oa:Annotation.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe content of the resource provides the rendering hints about the Annotation's constituent resources. \n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Style"
+              }
+            },
+            {
+              "@id": "oa:exact",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A copy of the text which is being selected, after normalization.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "exact"
+              }
+            },
+            {
+              "@id": "oa:hasBody",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and body. The body is somehow \"about\" the oa:hasTarget of the annotation.\n\nThe Body may be of any media type, and contain any type of content. The Body SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded bodies SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Body\" as a body might be a target of a different annotation. However, there SHOULD be 1 or more content-based classes associated with the body resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasBody"
+              }
+            },
+            {
+              "@id": "oa:Choice",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that it should select one of the constituent resources to display to the user, and not render/use all of them. \n\noa:Choice can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 1 or more oa:item relationships for each oa:Choice.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Choice"
+              },
+              "rdfs:subClassOf": {
+                "@id": "rdf:Alt"
+              }
+            },
+            {
+              "@id": "oa:when",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The timestamp at which the Source resource should be interpreted for the Annotation, typically the time that the Annotation was created."
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "when"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:serializedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The object of the relationship is the agent, likely software, responsible for generating the serialization of the Annotation's serialization. \n\nIt is RECOMMENDED to use these and other FOAF terms to describe agents: foaf:Person, prov:SoftwareAgent, foaf:Organization, foaf:name, foaf:mbox, foaf:openid, foaf:homepage\n\nThere MAY be 0 or more oa:serializedBy relationships per Annotation."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedBy"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:wasAttributedTo"
+              }
+            },
+            {
+              "@id": "oa:motivatedBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between an Annotation and a Motivation, indicating the reasons why the Annotation was created.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship, and MAY be more than 1."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivatedBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Motivation"
+              }
+            },
+            {
+              "@id": "oa:moderating",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an assignment of value or quality to the target resource(s). For example annotating an Annotation to moderate it up in a trust network or threaded discussion."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "moderating"
+              }
+            },
+            {
+              "@id": "oa:highlighting",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a highlighted section of the target resource or segment. For example to draw attention to the selected text that the annotator disagrees with. A Highlight may or may not have a Body resource"
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "highlighting"
+              }
+            },
+            {
+              "@id": "oa:styledBy",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:Annotation and a oa:Style.\n\nThere MAY be 0 or 1 styledBy relationships for each Annotation.\n\nIf there are multiple Style resources that must be associated with the Annotation, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styledBy"
+              },
+              "rdfs:range": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:FragmentSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes the segment of interest in a representation, through the use of the fragment identifier component of a URI.\n\nIt is RECOMMENDED to use oa:FragmentSelector as the selector on a Specific Resource rather than annotating the fragment URI directly, in order to improve discoverability of annotation on the Source.\n\nThe oa:FragmentSelector MUST have exactly 1 rdf:value property, containing the fragment identifier component of a URI that describes the segment of interest in the resource, excluding the initial \"#\".\n\nThe Fragment Selector SHOULD have a dcterms:conformsTo relationship with the object being the specification that defines the syntax of the fragment, for instance <http://tools.ietf.org/rfc/rfc3236> for HTML fragments. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "FragmentSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:SpecificResource",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource identifies part of another Source resource, a particular representation of a resource, a resource with styling hints for renders, or any combination of these. \n\nThe Specific Resource takes the role of oa:hasBody or oa:hasTarget in an oa:Annotation instead of the Source resource.\n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a Specific Resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each Specific Resource.\n\nIf the Specific Resource has an HTTP URI, then the exact segment of the Source resource that it identifies, and only the segment, MUST be returned when the URI is dereferenced. For example, if the segment of interest is a region of an image and the Specific Resource has an HTTP URI, then dereferencing it MUST return the selected region of the image as it was at the time when the annotation was created. Typically this would be a burden to support, and thus the Specific Resource SHOULD be identified by a globally unique URI, such as a UUID URN. If it is not considered important to allow other Annotations or systems to refer to the Specific Resource, then a blank node MAY be used instead."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SpecificResource"
+              }
+            },
+            {
+              "@id": "oa:annotatedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the Annotation was created. \n\nThere SHOULD be exactly 1 oa:annotatedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "annotatedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:editing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a request for a modification or edit to the target resource. For example, an Annotation that requests a typo to be corrected."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "editing"
+              }
+            },
+            {
+              "@id": "oa:Annotation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "Typically an Annotation has a single Body (oa:hasBody), which is the comment or other descriptive resource, and a single Target (oa:hasTarget) that the Body is somehow \"about\". The Body provides the information which is annotating the Target. \n\nThis \"aboutness\" may be further clarified or extended to notions such as classifying or identifying with oa:motivatedBy."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Annotation"
+              }
+            },
+            {
+              "@id": "oa:equivalentTo",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The subject and object resources of the oa:equivalentTo relationship represent the same resource, but potentially have different metadata such as oa:serializedBy, oa:serializedAt and serialization format.  oa:equivalentTo is a symmetrical and transitive relationship; if A oa:equivalentTo B, then it is also true that B oa:equivalent A; and that if B oa:equivalentTo C, then it is also true that A oa:equivalentTo C. \n\nThe Annotation MAY include 0 or more instances of the oa:equivalentTo relationship between copies of the Annotation or other resources, and SHOULD include as many as are available.\n\nIf a system publishes an embedded resource (a cnt:Content) at a new HTTP URI, then it SHOULD express the oa:equivalentTo relationship between the resource's URN and the new URI from which it is available."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "equivalentTo"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "prov:alternateOf"
+              }
+            },
+            {
+              "@id": "oa:Motivation",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Motivation for creating an Annotation, indicated with oa:motivatedBy, is a reason for its creation, and might include things like oa:replying to another annotation, oa:commenting on a resource, or oa:linking to a related resource.\n\nEach Annotation SHOULD have at least one oa:motivatedBy relationship to an instance of oa:Motivation, which is a subClass of skos:Concept."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Motivation"
+              },
+              "rdfs:subClassOf": {
+                "@id": "skos:Concept"
+              }
+            },
+            {
+              "@id": "oa:tagging",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents adding a Tag on the target resource(s). One or more of the bodies of the annotation should be typed as a oa:Tag or oa:SemanticTag."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "tagging"
+              }
+            },
+            {
+              "@id": "oa:List",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted, and in a particular order. \n\noa:List can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:List, with their order defined using the rdf:List construct of rdf:first/rdf:rest/rdf:nil.\n\nAll the elements of the list should also be declared using oa:item, and each of the oa:items should appear at least once in the list."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "List"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Composite"
+              }
+            },
+            {
+              "@id": "oa:TextQuoteSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector that describes a textual segment by means of quoting it, plus passages before or after it.\n\nFor example, if the document were \"abcdefghijklmnopqrstuvwxyz\", one could select \"efg\" by a oa:prefix of \"abcd\", the quotation of oa:exact \"efg\" and a oa:suffix of \"hijk\".\n\nThe text MUST be normalized before recording.\n\nEach TextQuoteSelector MUST have exactly 1 oa:exact property.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:prefix property, and MUST NOT have more than 1.\n\nEach TextQuoteSelector SHOULD have exactly 1 oa:suffix property, and MUST NOT have more than 1."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextQuoteSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:cachedSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A link to a copy of the Source resource's representation appropriate for the Annotation, typically a copy of the original at the time that the Annotation was created"
+              },
+              "rdfs:domain": {
+                "@id": "oa:TimeState"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "cachedSource"
+              }
+            },
+            {
+              "@id": "oa:bookmarking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the creation of a bookmark to the target resources or recorded point or points within one or more resources. For example, an Annotation that bookmarks the point in a text where the reader finished reading. Bookmark Annotations may or may not have a Body resource."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "bookmarking"
+              }
+            },
+            {
+              "@id": "oa:SemanticTag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a semantic tagging resource; a URI that identifies a concept, rather than an embedded string, frequently a term from a controlled vocabulary.\n\nIt is NOT RECOMMENDED to use the URI of a document as a Semantic Tag, as it might also be used as a regular Body in other Annotations which would inherit the oa:SemanticTag class assignment. Instead it is more appropriate to create a new URI and link it to the document, using the foaf:page predicate."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "SemanticTag"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Tag"
+              }
+            },
+            {
+              "@id": "oa:hasSource",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and the resource that it is a more specific representation of. \n\nThere MUST be exactly 1 oa:hasSource relationship associated with a Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSource"
+              }
+            },
+            {
+              "@id": "oa:default",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The constituent resource of a oa:Choice to use as a default option, if there is no other means to determine which would be most appropriate.\n\nThere SHOULD be exactly 1 default relationship for each Choice."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Choice"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "default"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "oa:item"
+              }
+            },
+            {
+              "@id": "oa:hasSelector",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:Selector.\n\nThere MUST be exactly 0 or 1 oa:hasSelector relationship associated with a \nSpecific Resource. \n\nIf multiple Selectors are required, either to express a choice between different optional, equivalent selectors, or a chain of selectors that should all be processed, it is necessary to use oa:Choice, oa:Composite or oa:List as a selector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasSelector"
+              },
+              "rdfs:range": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:hasTarget",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between oa:Annotation and target. The target resource is what the oa:hasBody is somewhat \"about\".\n\nThe target may be of any media type, and contain any type of content. The target SHOULD be identified by HTTP URIs unless they are embedded within the Annotation.\n\nEmbedded targets SHOULD be instances of cnt:ContentAsText and embed their content with cnt:chars. They SHOULD declare their media type with dc:format, and MAY indicate their language using dc:language and a RFC-3066 language tag. \n\nThere is no OA class provided for \"Target\" as a target might be a body in a different annotation. However, there SHOULD be 1 or more content-based classes associated with the target resources of an Annotation, and the dctypes: vocabulary is recommended for this purpose, for instance dctypes:Text to declare textual content."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasTarget"
+              }
+            },
+            {
+              "@id": "oa:TextPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "An oa:Selector which describes a range of text based on its start and end positions.\n\nThe text MUST be normalized before counting characters. For a Selector that works from the bitstream rather than the rendered characters, see oa:DataPositionSelector.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:start property.\n\nEach oa:TextPositionSelector MUST have exactly 1 oa:end property."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TextPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:serializedAt",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The time at which the agent referenced by oa:serializedBy generated the first serialization of the Annotation, and any subsequent substantially different one. The annotation graph MUST have changed for this property to be updated, and as such represents the last modified datestamp for the Annotation. This might be used to determine if it should be re-imported into a triplestore when discovered. \n\nThere MAY be exactly 1 oa:serializedAt property per Annotation, and MUST NOT be more than 1. The datetime MUST be expressed in the xsd:dateTime format, and SHOULD have a timezone specified.\n"
+              },
+              "rdfs:domain": {
+                "@id": "oa:Annotation"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "serializedAt"
+              },
+              "rdfs:range": {
+                "@id": "xsd:dateTimeStamp"
+              }
+            },
+            {
+              "@id": "oa:Composite",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A multiplicity construct that conveys to a consuming application that all of the constituent resources are required for the Annotation to be correctly interpreted. \n\noa:Composite can be used as the object of the object of the oa:hasBody, oa:hasTarget, oa:hasSelector, oa:hasState, oa:styledBy and oa:hasScope relationships, \n\nThere MUST be 2 or more oa:item relationships for each oa:Composite."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": "Composite",
+              "rdfs:subClassOf": {
+                "@id": "rdf:Bag"
+              }
+            },
+            {
+              "@id": "oa:classifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of a classification type, typically from a controlled vocabulary, to the target resource(s). For example to classify an Image resource as a Portrait."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "classifying"
+              }
+            },
+            {
+              "@id": "oa:identifying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents the assignment of an identity to the target resource(s). For example, annotating the name of a city in a string of text with the URI that identifies it."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "identifying"
+              }
+            },
+            {
+              "@id": "oa:HttpRequestState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource for the Annotation, based on the HTTP Request headers to send to the server.\n\nThere MUST be exactly 1 rdf:value property per HttpRequestState, containing HTTP request headers as a single, complete string, exactly as they would appear in an HTTP request. "
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "HttpRequestState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:DataPositionSelector",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A Selector which describes a range of data based on its start and end positions within the byte stream of the representation.\n\nEach DataPositionSelector MUST have exactly 1 oa:start property.\n\nEach TextPositionSelector MUST have exactly 1 oa:end property.\n\nSee oa:TextPositionSelector for selection at normalized character level rather than bytestream level."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "DataPositionSelector"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Selector"
+              }
+            },
+            {
+              "@id": "oa:linking",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents an untyped link to a resource related to the target."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "linking"
+              }
+            },
+            {
+              "@id": "oa:motivationScheme",
+              "@type": [
+                "skos:ConceptScheme",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The concept scheme for Open Annotation Motivations"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "motivationScheme"
+              }
+            },
+            {
+              "@id": "oa:replying",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a reply to a previous statement, either an Annotation or another resource. For example providing the assistance requested in the above."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "replying"
+              }
+            },
+            {
+              "@id": "oa:start",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The starting position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:start is included within the selected segment. \n\nSee oa:DataPositionSelector and oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "start"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:end",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The end position of the segment of text or bytes. The first character/byte in the full text/stream is position 0. The character/byte indicated at position oa:end is NOT included within the selected segment. \n\nSee oa:DataPositionSelector and oa:oa:TextPositionSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "end"
+              },
+              "rdfs:range": {
+                "@id": "xsd:nonNegativeInteger"
+              }
+            },
+            {
+              "@id": "oa:TimeState",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation.\n\nThere MUST be at least one of oa:cachedSource or oa:when specified. If there is more than 1, each gives an alternative copy of the representation."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "TimeState"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:State",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes how to retrieve an appropriate representation of the Source resource, indicated with oa:hasState from the Specific Resource.\n\nThis class is not used directly in Annotations, only its subclasses are.\n\nThe Specifier's description MAY be conveyed as an external or embedded resource (cnt:Content), or as RDF properties within the graph. The description SHOULD use existing standards whenever possible. If the Specifier has an HTTP URI, then its description, and only its description, MUST be returned when the URI is dereferenced."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "State"
+              }
+            },
+            {
+              "@id": "oa:CssStyle",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A resource which describes styles for resources participating in the Annotation using CSS.\n\nSpecific Resources MAY be assigned a CSS style class using oa:styleClass.\n\nThe CSS resource MAY have its own dereferencable URI that provides the information. For example, \"Style1\" in the diagram below might actually have the URI \"http://www.example.com/styles/annotations.css\". It MAY be embedded within the Annotation using the inline constructions described in Embedding Resources."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "CssStyle"
+              },
+              "rdfs:subClassOf": {
+                "@id": "oa:Style"
+              }
+            },
+            {
+              "@id": "oa:item",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a multiplicity construct node and its constituent resources.\n\nThere MUST be 1 or more item relationships for each multiplicity construct oa:Choice, oa:Composite and oa:List."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "item"
+              },
+              "rdfs:subPropertyOf": {
+                "@id": "rdfs:member"
+              }
+            },
+            {
+              "@id": "oa:hasScope",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a Specific Resource and the resource that provides the scope or context for it in this Annotation.\n\nThere MAY be 0 or more hasScope relationships for each Specific Resource."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasScope"
+              }
+            },
+            {
+              "@id": "oa:suffix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The snippet of text that occurs immediately after the text which is being selected. \n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "suffix"
+              }
+            },
+            {
+              "@id": "oa:hasState",
+              "@type": "owl:ObjectProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The relationship between a oa:SpecificResource and a oa:State resource.\n\nThere MAY be 0 or 1 oa:hasState relationship for each SpecificResource.\n\nIf there are multiple State resources that must be associated with the specific resource, then the use of the Multiplicity Constructs oa:Choice, oa:Composite or oa:List is RECOMMENDED."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "hasState"
+              },
+              "rdfs:range": {
+                "@id": "oa:State"
+              }
+            },
+            {
+              "@id": "oa:",
+              "@type": "owl:Ontology",
+              "dc:contributor": {
+                "@language": "en",
+                "@value": "Stian Soiland-Reyes"
+              },
+              "dc:creator": [
+                {
+                  "@language": "en",
+                  "@value": "Robert Sanderson"
+                },
+                {
+                  "@language": "it",
+                  "@value": "Paolo Ciccarese"
+                },
+                {
+                  "@language": "vls",
+                  "@value": "Herbert Van de Sompel"
+                }
+              ],
+              "dc:description": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web. Open Annotations can easily be shared between platforms, with sufficient richness of expression to satisfy complex requirements while remaining simple enough to also allow for the most common use cases, such as attaching a piece of text to a single web resource.\n\nAn Annotation is considered to be a set of connected resources, typically including a body and target, where the body is somehow about the target. The full model supports additional functionality, enabling semantic annotations, embedding content, selecting segments of resources, choosing the appropriate representation of a resource and providing styling hints for consuming clients."
+              },
+              "dc:title": {
+                "@language": "en",
+                "@value": "Open Annotation Data Model"
+              },
+              "dcterms:modified": {
+                "@type": "xsd:dateTime",
+                "@value": "2013-02-22T21:40:51+01:00"
+              },
+              "owl:versionIRI": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/oa.owl"
+              },
+              "owl:versionInfo": "0.9.20130208",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The Open Annotation Core Data Model specifies an interoperable framework for creating associations between related resources, annotations, using a methodology that conforms to the Architecture of the World Wide Web.\n\nThis ontology is a non-normative OWL formalization of the textual OA specification at http://www.openannotation.org/spec/core/20130208/index.html\n\nNote that OWL imports are disabled in the published version in order to reduce external implications, improve OWL 2 Profile conformity and increase interoperability. Some OWL tools might thus misleadingly show this ontology as (re)defining properties like skos:prefLabel."
+              },
+              "rdfs:seeAlso": {
+                "@id": "http://www.openannotation.org/spec/core/20130208/index.html"
+              }
+            },
+            {
+              "@id": "oa:questioning",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents asking a question about the target resource(s). For example to ask for assistance with a particular section of text, or question its veracity."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "questioning"
+              }
+            },
+            {
+              "@id": "oa:describing",
+              "@type": [
+                "oa:Motivation",
+                "owl:NamedIndividual"
+              ],
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The motivation that represents a description of the target resource(s), as opposed to a comment about them. For example describing the above PDF's contents, rather than commenting on their accuracy."
+              },
+              "skos:inScheme": {
+                "@id": "oa:motivationScheme"
+              },
+              "skos:prefLabel": {
+                "@language": "en",
+                "@value": "describing"
+              }
+            },
+            {
+              "@id": "oa:styleClass",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "The string name of the class used in the CSS description that should be applied to the Specific Resource.\n\nThere MAY be 0 or more styleClass properties on a Specific Resource.\n\nSee oa:CssStyle."
+              },
+              "rdfs:domain": {
+                "@id": "oa:SpecificResource"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "styleClass"
+              }
+            },
+            {
+              "@id": "oa:Tag",
+              "@type": "owl:Class",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A class assigned to the Body when it is a tag, such as a embedded text string with cnt:chars.\n\nTags are typically keywords or labels, and used for organization, description or discovery of the resource being tagged. In the Semantic Web, URIs are used instead of strings to avoid the issue of polysemy where one word has multiple meanings, such usage MUST be indicated using the subclass oa:SemanticTag.\n\nAnnotations that tag resources, either with text or semantic tags, SHOULD also have the oa:tagging motivation to make the reason for the Annotation more clear to applications, and MAY have other motivations as well."
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "Tag"
+              }
+            },
+            {
+              "@id": "oa:prefix",
+              "@type": "owl:DatatypeProperty",
+              "rdfs:comment": {
+                "@language": "en",
+                "@value": "A snippet of text that occurs immediately before the text which is being selected.\n\nSee oa:TextQuoteSelector."
+              },
+              "rdfs:domain": {
+                "@id": "oa:Selector"
+              },
+              "rdfs:isDefinedBy": {
+                "@id": "oa:"
+              },
+              "rdfs:label": {
+                "@language": "en",
+                "@value": "prefix"
+              }
+            }
+          ]
+        }
+
+
+    http_version: 
+  recorded_at: Thu, 28 May 2015 02:29:35 GMT
 recorded_with: VCR 2.9.3

--- a/triannon.gemspec
+++ b/triannon.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2'
   s.add_dependency 'linkeddata'
   s.add_dependency 'oa-graph'
+  s.add_dependency 'omniauth'
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'faraday' # for writing to LDP store
   s.add_dependency 'rsolr'


### PR DESCRIPTION
Proposing to merge this branch with master (prefer it was develop, but that doesn't exist), so that further work on using omniauth can hack an oauth2 provider.  This branch is a bare-bones addition of omniauth that is completely hacked to suit the proposed SearchWorks use case for authorization to get containers.  It's not using oauth2 at present, only the base :developer provider.  But at least that is working (see /auth/developer in the UI and note that is is already rigged to only accept a couple of 'authorized apps').