### PR TITLE
Feature/gem updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,19 +13,30 @@ gemspec
 # To use a debugger
 gem 'pry-byebug', group: [:development, :test]
 
-group :test do
+def load_engine_cart_gemset
   file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
   if File.exists?(file)
     puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
     instance_eval File.read(file)
+    true
   else
-    gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+    false
+  end
+end
 
-    if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] =~ /^4.2/
-      gem 'responders', "~> 2.0"
-      gem 'sass-rails', ">= 5.0"
-    else
-      gem 'sass-rails', "< 5.0"
-    end
+engine_cart_loaded = load_engine_cart_gemset
+
+# Use development constraints on gem dependencies here.
+# To exclude this group from the bundle, use:
+# bundle install --without :dev
+group :dev do
+  unless engine_cart_loaded
+    # gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+    # if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] =~ /^4.2/
+    #   gem 'responders', "~> 2.0"
+    #   gem 'sass-rails', ">= 5.0"
+    # else
+    #   gem 'sass-rails', "< 5.0"
+    # end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_destroy/calls_solr_delete_method_after_successful_destroy_in_LDP_store.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_destroy/calls_solr_delete_method_after_successful_destroy_in_LDP_store.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b73242cab485fea784154d2d1aaf8980fa71ba31"'
+      - '"b2bf33a468bb8bc20de1a050dfcdea204f4ebede"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1454eb79243aaf799321a11641e22fcedb33a068"'
+      - '"39fb4b47a81ef1325f465191e235d79171510144"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2485690eead82c11cb6f358c68961c01b0ff4bab"'
+      - '"dd664bd2abc1b3b13427245e29bef40a4928e3f0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2de2bfc5603f3cdee18dde2fc2f9ed9e7016e78f"'
+      - '"79444a25b43d22b45906d541810cba5ae8abb16a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t/cf/85/c1/f4/cf85c1f4-89fc-41d1-8b6c-bebb9a301e9a
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t/f5/17/24/37/f5172437-4e4d-49c8-8da2-76a2df534608
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t/cf/85/c1/f4/cf85c1f4-89fc-41d1-8b6c-bebb9a301e9a
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t/f5/17/24/37/f5172437-4e4d-49c8-8da2-76a2df534608
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"129c992ebe4a21a5d346cbca4510ad0e54ec11cb"'
+      - '"0ca3039b973cb036a1f81cab7746c90f32dca2dd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t/cf/85/c1/f4/cf85c1f4-89fc-41d1-8b6c-bebb9a301e9a>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t/f5/17/24/37/f5172437-4e4d-49c8-8da2-76a2df534608>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t/cf/85/c1/f4/cf85c1f4-89fc-41d1-8b6c-bebb9a301e9a
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t/f5/17/24/37/f5172437-4e4d-49c8-8da2-76a2df534608
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2de2bfc5603f3cdee18dde2fc2f9ed9e7016e78f"'
+      - '"79444a25b43d22b45906d541810cba5ae8abb16a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c/t/cf/85/c1/f4/cf85c1f4-89fc-41d1-8b6c-bebb9a301e9a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5/t/f5/17/24/37/f5172437-4e4d-49c8-8da2-76a2df534608>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c</field><field
+        name="id">annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,10 +325,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5
     body:
       encoding: US-ASCII
       string: ''
@@ -350,5 +350,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_find/sets_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_find/sets_anno_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d9322f96ad31fdd9d1c8e1e8647584707a23daa2"'
+      - '"4f54ba5fba442d4c090f56ca58c9661ea6252ff1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1c921b901e2f68aad1ab77e0e3ca5981b43e4862"'
+      - '"6320024a2d3d22df190b66f09f7bb7d367794ac7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"88051f54a7eab440b50e80859a36339dd042ad76"'
+      - '"4c18455eef84479967cf2682b8455899454ad40a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4d0c8e82f3c9a5263a67f6ff023a2eedac7a43ce"'
+      - '"ef7107a08cdcf8b8315be5bf3928887df12a1280"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e452b7d654f483b5779200c5b1c7e6deebbb03c2"'
+      - '"275f25680aee12ca8a577b9abc1024b8999314b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"41241fc74606b8dcf9719983de5a4e2723aa3ff8"'
+      - '"eef08deba4345fbf343f9291ddb5374ad77b53d6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8dd6752d2d8e16d5116123cf75857a472aeca915"'
+      - '"2d8967d1c2c35a522b343d94f4609452252c46af"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4d0c8e82f3c9a5263a67f6ff023a2eedac7a43ce"'
+      - '"ef7107a08cdcf8b8315be5bf3928887df12a1280"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"41241fc74606b8dcf9719983de5a4e2723aa3ff8"'
+      - '"eef08deba4345fbf343f9291ddb5374ad77b53d6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d</field><field
+        name="id">annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213</field><field
         name="root">annomodelspecs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318404471860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d","@type":"oa:Annotation","hasBody":"_:g70318404471860","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312725665620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213","@type":"oa:Annotation","hasBody":"_:g70312725665620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,10 +484,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213
     body:
       encoding: US-ASCII
       string: ''
@@ -506,9 +506,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8dd6752d2d8e16d5116123cf75857a472aeca915"'
+      - '"2d8967d1c2c35a522b343d94f4609452252c46af"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -542,18 +542,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea
     body:
       encoding: US-ASCII
       string: ''
@@ -572,9 +572,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4d0c8e82f3c9a5263a67f6ff023a2eedac7a43ce"'
+      - '"ef7107a08cdcf8b8315be5bf3928887df12a1280"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -608,14 +608,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/b/bc/0c/c3/df/bc0cc3df-4070-489e-a25e-e5e2cdb46057>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/b/6e/cf/e8/e1/6ecfe8e1-9858-43c0-8046-e4b0888fb6ea>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5
     body:
       encoding: US-ASCII
       string: ''
@@ -634,9 +634,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"41241fc74606b8dcf9719983de5a4e2723aa3ff8"'
+      - '"eef08deba4345fbf343f9291ddb5374ad77b53d6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -670,9 +670,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d/t/87/1c/a9/a8/871ca9a8-88b7-4cf0-8173-40227e678cbd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213/t/47/83/9d/64/47839d64-5098-4805-b0a3-e03591be1db5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/calls_solr_save_method_after_successful_save_to_LDP_Store.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/calls_solr_save_method_after_successful_save_to_LDP_Store.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c5fc3145e500ef72fbb02ea0497df22fa843e3be"'
+      - '"ebf7f3493ed450c0e6d2fb79b738366dacd3d893"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"009bc3dd94cfbb4a30875b461f55ec627063ac44"'
+      - '"23b39ee4ac4dc1df2e289cf15a5d9c7fa7d7d370"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e4733edafc7b60f2da651dee50341786553f150a"'
+      - '"3f5fe056e69cbe7797a6b1a8bf425e5f421397d4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"61308659a1973681bfa902aa86619fb521c417c7"'
+      - '"307b5fa823edc7736329e9d144d2cdc41295ab3d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t/8a/c5/f9/57/8ac5f957-372b-42a0-8b16-a0f9a909488b
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t/64/2e/ef/8c/642eef8c-3e2e-4748-82e0-70d74b9b2cec
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t/8a/c5/f9/57/8ac5f957-372b-42a0-8b16-a0f9a909488b
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t/64/2e/ef/8c/642eef8c-3e2e-4748-82e0-70d74b9b2cec
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8e17c4df17b411e8b842b321a684547177b072d8"'
+      - '"ed3965b1823ac649208784f370eb930550ea24c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t/8a/c5/f9/57/8ac5f957-372b-42a0-8b16-a0f9a909488b>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t/64/2e/ef/8c/642eef8c-3e2e-4748-82e0-70d74b9b2cec>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t/8a/c5/f9/57/8ac5f957-372b-42a0-8b16-a0f9a909488b
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t/64/2e/ef/8c/642eef8c-3e2e-4748-82e0-70d74b9b2cec
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"61308659a1973681bfa902aa86619fb521c417c7"'
+      - '"307b5fa823edc7736329e9d144d2cdc41295ab3d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,9 +293,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a/t/8a/c5/f9/57/8ac5f957-372b-42a0-8b16-a0f9a909488b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3/t/64/2e/ef/8c/642eef8c-3e2e-4748-82e0-70d74b9b2cec>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/doesn_t_call_solr_save_method_after_exception_for_LDP_store_create.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/doesn_t_call_solr_save_method_after_exception_for_LDP_store_create.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c397477706458dd2ee46c62c9b6c5e5557e00a39"'
+      - '"d0ade1ebfcac5f3be0fdcfdfe16459281ce92398"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ce4a9c72f8dceb8e7bf58594ee4d2b9c7aed2c69"'
+      - '"2b4b0aa28ab061aa4f94c618261833eada80e127"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"27bf2acabb69646644e17706b234d694d9976a54"'
+      - '"2a5c7643d7263770c940b89d4e0a99202d8acc3e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4b2daab34fac7be95cc9f869d8f1a71bf161f51a"'
+      - '"9e8a3645fa9e7c5594b050f70face1007a223b7b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t/c0/ba/17/9d/c0ba179d-c0c9-40d8-b327-c5733492fccb
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t/cb/43/a7/43/cb43a743-3a5e-4131-96e7-f2f5986c0144
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t/c0/ba/17/9d/c0ba179d-c0c9-40d8-b327-c5733492fccb
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t/cb/43/a7/43/cb43a743-3a5e-4131-96e7-f2f5986c0144
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"11c73098907f5330458ce2af69ccd1a9f1c34989"'
+      - '"8aa4688b4f4176252977a46bfc558d955e7b469e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t/c0/ba/17/9d/c0ba179d-c0c9-40d8-b327-c5733492fccb>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t/cb/43/a7/43/cb43a743-3a5e-4131-96e7-f2f5986c0144>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t/c0/ba/17/9d/c0ba179d-c0c9-40d8-b327-c5733492fccb
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t/cb/43/a7/43/cb43a743-3a5e-4131-96e7-f2f5986c0144
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4b2daab34fac7be95cc9f869d8f1a71bf161f51a"'
+      - '"9e8a3645fa9e7c5594b050f70face1007a223b7b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,9 +293,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a/t/c0/ba/17/9d/c0ba179d-c0c9-40d8-b327-c5733492fccb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7/t/cb/43/a7/43/cb43a743-3a5e-4131-96e7-f2f5986c0144>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/reloads_graph_from_storage_to_ensure_id_is_in_the_graph.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/reloads_graph_from_storage_to_ensure_id_is_in_the_graph.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2629cefeea3839a4a5a9dbc1d662da5243032933"'
+      - '"9bae4f09a8693db90124f856276c22cf6d246329"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"423ea51deb34fa52946f225ffce072b68e67bc95"'
+      - '"5cd8ba131ec92e2ca9a7a9cce73960eddf2c8914"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"791f1537297e989607c7e54213d73172fca3795d"'
+      - '"658e561bd78d7e945b7d12fb886568b72432b916"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e80930ceb5fd3a138f5b16fd1ea8be07e5700cac"'
+      - '"52242432e808f6f5e174869c0f0e2309ec94cca5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t/4a/63/dc/fb/4a63dcfb-fc99-43c4-90dd-7678d0ddbadf
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t/71/0c/61/d7/710c61d7-e50c-4d5f-9bb5-dd154ac1e8b1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t/4a/63/dc/fb/4a63dcfb-fc99-43c4-90dd-7678d0ddbadf
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t/71/0c/61/d7/710c61d7-e50c-4d5f-9bb5-dd154ac1e8b1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f440d8e1e78732574a883d3747779c3ddcef2619"'
+      - '"c126640235f30c668a88ed1286599c6812eb7039"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t/4a/63/dc/fb/4a63dcfb-fc99-43c4-90dd-7678d0ddbadf>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t/71/0c/61/d7/710c61d7-e50c-4d5f-9bb5-dd154ac1e8b1>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t/4a/63/dc/fb/4a63dcfb-fc99-43c4-90dd-7678d0ddbadf
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t/71/0c/61/d7/710c61d7-e50c-4d5f-9bb5-dd154ac1e8b1
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e80930ceb5fd3a138f5b16fd1ea8be07e5700cac"'
+      - '"52242432e808f6f5e174869c0f0e2309ec94cca5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5/t/4a/63/dc/fb/4a63dcfb-fc99-43c4-90dd-7678d0ddbadf>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02/t/71/0c/61/d7/710c61d7-e50c-4d5f-9bb5-dd154ac1e8b1>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5</field><field
+        name="id">annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/returns_false_if_graph_is_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/returns_false_if_graph_is_nil.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b73242cab485fea784154d2d1aaf8980fa71ba31"'
+      - '"b2bf33a468bb8bc20de1a050dfcdea204f4ebede"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,11 +58,11 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs> a ldp:BasicContainer
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/returns_false_if_graph_size_is_0.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/returns_false_if_graph_size_is_0.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b73242cab485fea784154d2d1aaf8980fa71ba31"'
+      - '"b2bf33a468bb8bc20de1a050dfcdea204f4ebede"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,11 +58,11 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs> a ldp:BasicContainer
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a>
-        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/53/03/d9/655303d9-6917-4fc9-b84c-7a1f9d70ea6a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3>
+        , <http://localhost:8983/fedora/rest/anno/annomodelspecs/5e/d6/02/df/5ed602df-8a7c-4476-be29-813e39b83ab7>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/sets_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_save/sets_anno_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6b2f8bf528ca7f1fcd35716b1339504586d5c924"'
+      - '"92b2b515e58dbcd72bbe5c4298264336035a2510"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b739558c8c7ca776f9823b6179783cb64eeb5c9a"'
+      - '"a9125dfd7e6501cf53ffb6f72bd0e9eacc91b441"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e2c1e1dc3890b7397d249742fe630ddbd1cae1db"'
+      - '"2095db40a7f02c25c3bee63ecfb402f6dac7201d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"69e9110e10b16056534bf589fe0a083ec6ee64ab"'
+      - '"d1c91d850f94e940a9ac556fd562acfdb1e0d349"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t/99/34/01/19/99340119-83ab-4aa5-8b21-a707a0a03a50
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t/87/96/d2/01/8796d201-a27b-4fea-81ed-eafe6c327551
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t/99/34/01/19/99340119-83ab-4aa5-8b21-a707a0a03a50
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t/87/96/d2/01/8796d201-a27b-4fea-81ed-eafe6c327551
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ad99796b855f20000b3385d07b22ccaa84631905"'
+      - '"93ac044dfd0ade5dca2eab2bae433e8c630eddb9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t/99/34/01/19/99340119-83ab-4aa5-8b21-a707a0a03a50>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t/87/96/d2/01/8796d201-a27b-4fea-81ed-eafe6c327551>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t/99/34/01/19/99340119-83ab-4aa5-8b21-a707a0a03a50
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t/87/96/d2/01/8796d201-a27b-4fea-81ed-eafe6c327551
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"69e9110e10b16056534bf589fe0a083ec6ee64ab"'
+      - '"d1c91d850f94e940a9ac556fd562acfdb1e0d349"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6/t/99/34/01/19/99340119-83ab-4aa5-8b21-a707a0a03a50>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f/t/87/96/d2/01/8796d201-a27b-4fea-81ed-eafe6c327551>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6</field><field
+        name="id">annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_SolrWriter_write_with_triannon_graph.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/calls_SolrWriter_write_with_triannon_graph.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"44bef5b06397b80c7f99f3c7c20bb56daa2419af"'
+      - '"805994881c15f18235046fc9ce145a0d499e4537"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"879427d40903b6f7bba218f5bf612582ffe1143c"'
+      - '"60c5f210f5269f5f1729c2567f0bab193055abba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c1c3e46e57375729ee363434e633082a6d2d8504"'
+      - '"4bd7cd34b7fb76a8a8f564205bc2c06f8b0630c7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"017923b752f67b183d4292e46eadb3c19227c584"'
+      - '"374320ec4214c6b6ca58bbe32d4db3b30542aeb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8417dcfb231f8970302e980e7f00095e82b04a54"'
+      - '"3d1ed51873725cd5876735b5dd44895bf3b1785b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"017923b752f67b183d4292e46eadb3c19227c584"'
+      - '"374320ec4214c6b6ca58bbe32d4db3b30542aeb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc</field><field
+        name="id">annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,12 +323,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8
     body:
       encoding: US-ASCII
       string: ''
@@ -347,9 +347,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8417dcfb231f8970302e980e7f00095e82b04a54"'
+      - '"3d1ed51873725cd5876735b5dd44895bf3b1785b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -383,16 +383,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4
     body:
       encoding: US-ASCII
       string: ''
@@ -411,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"017923b752f67b183d4292e46eadb3c19227c584"'
+      - '"374320ec4214c6b6ca58bbe32d4db3b30542aeb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -447,9 +447,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc/t/01/38/3a/29/01383a29-7bd0-42b9-b614-63d5ca8d6422>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8/t/54/b6/3a/20/54b63a20-8c5b-41ee-911f-dc8cbd9679a4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_NOT_call_SolrWriter_write_when_graph_has_no_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_NOT_call_SolrWriter_write_when_graph_has_no_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5bdafeeb350d85f1ee88471ed37a87e58315bd91"'
+      - '"eca7884e3f49e479b484a5682f6a615ea340b7c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c641f5593a677d6991624ebe01877db177ffc9a2"'
+      - '"665d7d4ccc3a814051bef70c72e5ea8a72a46d1c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b8f7ddbe3b9ec96f640b97e27d873d7ec74f3b83"'
+      - '"b64330371765a7b903cab3c6130aef1dc279ccc1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"45e08b885171604ff823b1d30100e93396c3111a"'
+      - '"63bafd18d349503fb0e377161e4a34e750650fa9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"13414e26d3890e155232a362b4562694bc67c785"'
+      - '"d395abed1cb980d4c4a7c5c671a7beddfbd509c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"45e08b885171604ff823b1d30100e93396c3111a"'
+      - '"63bafd18d349503fb0e377161e4a34e750650fa9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4</field><field
+        name="id">annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,10 +325,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4
     body:
       encoding: US-ASCII
       string: ''
@@ -347,9 +347,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"13414e26d3890e155232a362b4562694bc67c785"'
+      - '"d395abed1cb980d4c4a7c5c671a7beddfbd509c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -383,16 +383,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e
     body:
       encoding: US-ASCII
       string: ''
@@ -411,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"45e08b885171604ff823b1d30100e93396c3111a"'
+      - '"63bafd18d349503fb0e377161e4a34e750650fa9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -447,21 +447,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4/t/b2/e9/71/fb/b2e971fb-9291-4f51-a988-8cb8acb84155>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4/t/d2/83/4d/f2/d2834df2-e85a-40db-ab8b-4d7ecc7bde7e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4</field><field
+        name="id">annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -477,7 +477,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_NOT_call_SolrWriter_write_when_graph_is_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/does_NOT_call_SolrWriter_write_when_graph_is_nil.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5ef6ec523d3faa96f02169e5d48e3a33b6033896"'
+      - '"2a5e775ac0bddc6e89db03205d2bf72601823180"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:04 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"826a3b44e4ba68396b1cc45c541711b9b79876da"'
+      - '"4c2a3b08cf853f47731b74c8009ae04b22182a9d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"913d24606934e8687376bf63ec19bd979ed7df3c"'
+      - '"5e97e6e39afaff6570156c47229d503031147022"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:01 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f304b2caa565c8ceb4d231d4c09125cf577220df"'
+      - '"f4b7b932900315bacb7bda469d8dd4e243741358"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e4f45bd6c05cfe46a8c27cc301e3a6083fbd6b57"'
+      - '"cbdea63d384999913c55bca7e91d74ce271dce70"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f304b2caa565c8ceb4d231d4c09125cf577220df"'
+      - '"f4b7b932900315bacb7bda469d8dd4e243741358"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e</field><field
+        name="id">annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,10 +325,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286
     body:
       encoding: US-ASCII
       string: ''
@@ -347,9 +347,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e4f45bd6c05cfe46a8c27cc301e3a6083fbd6b57"'
+      - '"cbdea63d384999913c55bca7e91d74ce271dce70"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -383,16 +383,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669
     body:
       encoding: US-ASCII
       string: ''
@@ -411,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f304b2caa565c8ceb4d231d4c09125cf577220df"'
+      - '"f4b7b932900315bacb7bda469d8dd4e243741358"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -447,21 +447,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e/t/13/b8/6e/8d/13b86e8d-225f-4d75-a50c-2954baaa7673>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286/t/5f/d1/c6/15/5fd1c615-1bbf-4768-a820-76380c700669>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e</field><field
+        name="id">annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -479,5 +479,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/raises_exception_when_Solr_add_is_not_successful.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/_solr_save/raises_exception_when_Solr_add_is_not_successful.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"923e07277a566c851a65761591393dbb9eed512f"'
+      - '"1ffd2659addf2b4ec12d9845e017844c17f79a5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f2364bd388cdcf38be9460f25c8c1f373fa28ac6"'
+      - '"536302764a29e68bc32d837ac7dd0a43e39447f3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f7005cb6f132d4a1db1e62bcc4947f075d36e0a2"'
+      - '"ecd356f05de725d667b4dc1d091e6e5a4be014f1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"56e443da23849471807406c957cf228b0a161475"'
+      - '"be18b2acad66a5f9ac17a750d739b51c6238935c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Content-Length:
       - '153'
       Location:
-      - http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5
+      - http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5
+      string: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d00216f3c8ea67e7d3469fe9476a84cb1b2b5213"'
+      - '"7e85374ac274f839c40e7556b321e0bff5ee5272"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"56e443da23849471807406c957cf228b0a161475"'
+      - '"be18b2acad66a5f9ac17a750d739b51c6238935c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b</field><field
+        name="id">annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b</field><field
         name="root">annomodelspecs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,12 +323,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b
     body:
       encoding: US-ASCII
       string: ''
@@ -347,9 +347,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d00216f3c8ea67e7d3469fe9476a84cb1b2b5213"'
+      - '"7e85374ac274f839c40e7556b321e0bff5ee5272"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:05 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -383,16 +383,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5>
+        <http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5
+    uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b
     body:
       encoding: US-ASCII
       string: ''
@@ -411,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"56e443da23849471807406c957cf228b0a161475"'
+      - '"be18b2acad66a5f9ac17a750d739b51c6238935c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -447,9 +447,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b/t/df/a3/8a/5d/dfa38a5d-9484-45c8-a002-617499d9f2f5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b/t/93/25/3f/8b/93253f8b-df62-4102-ad64-d422ac55522b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b51a9c2371963b3777c9e9fa5d8f6edff6a91587"'
+      - '"bf527d85d10c4d305515124540d2055a6c17c9ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs/fcr:tombstone
@@ -86,13 +86,205 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/52/83/b5/39/5283b539-a81e-4e70-9948-b5631a3b3ab6</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/7f/a0/dd/b4/7fa0ddb4-d6b3-4200-8d45-b3301a52ec7f</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/74/b5/10/a7/74b510a7-3a8b-4f11-931e-031fa63f1d02</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/65/ea/c8/c1/65eac8c1-40d0-4eb7-abea-43ae7e7133a3</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/f1/fe/70/22/f1fe7022-d596-41bc-a100-7e6f7d8192a5</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/84/4d/d1/a2/844dd1a2-5da7-4280-a9b7-b72a476446f8</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/34/a4/e1/bd/34a4e1bd-3eb9-4998-bf18-9ed630228286</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/e9/ba/fe/3e/e9bafe3e-8dbd-4364-b8fa-80667fc0e8f4</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/7a/64/4d/64/7a644d64-249c-4563-a516-0d56da73d69b</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/80/bd/ee/f3/80bdeef3-1016-4c2c-a4ec-cf310804a213</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -110,199 +302,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>9}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/d9/84/c5/48/d984c548-8a46-4adf-8145-a2f94db3f1f5</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/b2/46/cf/1d/b246cf1d-05bb-450e-8a53-fd48cf21563a</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/45/49/ae/49/4549ae49-7c1d-4837-869c-1ce2416aa39c</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/47/bb/5f/ae/47bb5fae-c8e8-4b06-82f0-d9bb9f70d3bc</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/34/6d/19/d9/346d19d9-97f6-4edd-933c-c42a27392b8e</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/ec/0b/95/a9/ec0b95a9-f7b3-4870-8f87-5ba6ec03afe4</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/90/bb/37/f9/90bb37f9-3f66-4d62-91e6-47f7d4984a1b</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>annomodelspecs/d6/ca/40/69/d6ca4069-9733-4616-b953-c100251eaf7d</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -324,7 +324,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>49}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>89}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_Annotation/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_Annotation/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f6c82275bf526d7e6a51e5cf364ca6310ea2f62f"'
+      - '"81b50ac2c8aef0ec235f4eed0bb50566f470efee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/annomodelspecs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6b2f8bf528ca7f1fcd35716b1339504586d5c924"'
+      - '"92b2b515e58dbcd72bbe5c4298264336035a2510"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:03 GMT
+      - Wed, 08 Jul 2015 18:55:00 GMT
       Content-Length:
       - '53'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/annomodelspecs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/json_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/json_specified_for_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c61a64bd99a6b0d217cdf4f5778896b89ef6c235"'
+      - '"8cdbc6fba32feb674bbf72c597f65d510d305b19"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:42 GMT
+      - Wed, 08 Jul 2015 18:53:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"566d6271c0b0fad46530ad15ff597f5b71647c2b"'
+      - '"22f44cdf375c58de4f12c676399b6435aac523b3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:45 GMT
+      - Wed, 08 Jul 2015 18:53:47 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"566d6271c0b0fad46530ad15ff597f5b71647c2b"'
+      - '"22f44cdf375c58de4f12c676399b6435aac523b3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:45 GMT
+      - Wed, 08 Jul 2015 18:53:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/jsonrequest_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/application/jsonrequest_specified_for_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"747ab36c9cb809870766d357edfc9d74203ea884"'
+      - '"f281b85879470a915081c41bf215304a4f293fb8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:47 GMT
+      - Wed, 08 Jul 2015 18:53:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:51 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"359838e7fbfec383cddea92b1a39cdafa18b585f"'
+      - '"ebb5ebbc654a04eb210ae101e41ffbd970fea80b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:50 GMT
+      - Wed, 08 Jul 2015 18:53:51 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:51 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"359838e7fbfec383cddea92b1a39cdafa18b585f"'
+      - '"ebb5ebbc654a04eb210ae101e41ffbd970fea80b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:50 GMT
+      - Wed, 08 Jul 2015 18:53:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_does_NOT_match_data/application/rdf_xml_specified_and_NOT_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_does_NOT_match_data/application/rdf_xml_specified_and_NOT_provided.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2a6f7e7d15907d5366c7c08c5f8688a2302990c9"'
+      - '"70ce54799e278574712c6c33bec9630410b9cab3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:59 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,20 +58,20 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs>
-        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6>
+        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_does_NOT_match_data/application/x-turtle_specified_and_NOT_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_does_NOT_match_data/application/x-turtle_specified_and_NOT_provided.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2d3d7b25f8306b9abeee0cedd18ebb7ff11d8ea5"'
+      - '"9e1727e71d34c96c8d462d1a0c65c39a7ce9ff52"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:56 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,17 +58,17 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs>
-        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169>
+        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/rdf_xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/rdf_xml_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2d3d7b25f8306b9abeee0cedd18ebb7ff11d8ea5"'
+      - '"9e1727e71d34c96c8d462d1a0c65c39a7ce9ff52"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:56 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:57 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3e4a8d0b9de8a27b92453d4f15d5f20a85c77349"'
+      - '"cda3ca0304db09d41a7ccaff125869f9a95d43b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:57 GMT
+      - Wed, 08 Jul 2015 18:53:57 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3e4a8d0b9de8a27b92453d4f15d5f20a85c77349"'
+      - '"cda3ca0304db09d41a7ccaff125869f9a95d43b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:57 GMT
+      - Wed, 08 Jul 2015 18:53:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-turtle_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-turtle_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f547763ee863d649000ca0dec945504d7c69d3b4"'
+      - '"0a5f37ff5442e081dd51a72c9082f434dc8372ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:54 GMT
+      - Wed, 08 Jul 2015 18:53:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fa235d9445885b59ae910dcabab682fe834080a7"'
+      - '"d38a75c65a8ca47c65af7fa9fef5cf0e75afe629"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:55 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fa235d9445885b59ae910dcabab682fe834080a7"'
+      - '"d38a75c65a8ca47c65af7fa9fef5cf0e75afe629"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:55 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/x-xml_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e8fb7285e2c0ffdda7a6fdbec06c9018472f4b64"'
+      - '"9b85faab9b1f89d32fe4047fd1fba8e0a119f3cb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:01 GMT
+      - Wed, 08 Jul 2015 18:54:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:02 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:01 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6f2ace6f140bc86a1d510077d4bbcfa142f0ce92"'
+      - '"cbd811f12e4a1f9dea24662ce72ff0643b5862a3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:02 GMT
+      - Wed, 08 Jul 2015 18:54:01 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:02 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:01 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6f2ace6f140bc86a1d510077d4bbcfa142f0ce92"'
+      - '"cbd811f12e4a1f9dea24662ce72ff0643b5862a3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:02 GMT
+      - Wed, 08 Jul 2015 18:54:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:02 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/application/xml_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2a6f7e7d15907d5366c7c08c5f8688a2302990c9"'
+      - '"70ce54799e278574712c6c33bec9630410b9cab3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:59 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:59 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b337de871cdd3cb1cf66259c08aa00659a583165"'
+      - '"638698f439a38a4f49c49064925c7318b34cee9f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:00 GMT
+      - Wed, 08 Jul 2015 18:53:59 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:59 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b337de871cdd3cb1cf66259c08aa00659a583165"'
+      - '"638698f439a38a4f49c49064925c7318b34cee9f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:00 GMT
+      - Wed, 08 Jul 2015 18:53:59 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:59 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e4f9769ac6a1b8736dc4b9553c11330df2be95b2"'
+      - '"928d17ad03f8d90feb6e7c114232e0cc2affa5ac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:58 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"485eaaa94d9feb4b48b1c3a1dc2d753af16175c0"'
+      - '"fe025acbaff8b555a37d28ebed0139078fd8793e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:59 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"485eaaa94d9feb4b48b1c3a1dc2d753af16175c0"'
+      - '"fe025acbaff8b555a37d28ebed0139078fd8793e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:59 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/rdf_xml_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3fed08b00f4d68c41cd17b54a884424652bdff11"'
+      - '"56d957a1d25c0abbb4ceda36c79976a61554f5f1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:57 GMT
+      - Wed, 08 Jul 2015 18:53:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"677d61f7f70f64100666738a8b4ac187bfd5dd6f"'
+      - '"ff6b74c2dbdce2b759f2b0fd6f97b615c5b41aa4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:58 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"677d61f7f70f64100666738a8b4ac187bfd5dd6f"'
+      - '"ff6b74c2dbdce2b759f2b0fd6f97b615c5b41aa4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:58 GMT
+      - Wed, 08 Jul 2015 18:53:58 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/turtle_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/turtle_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f547763ee863d649000ca0dec945504d7c69d3b4"'
+      - '"d19b5bcf6a99ce1a2e37b4c626fd8f994695d365"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:54 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:56 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c77671e05c522732e898c0dd026a2b33c47a4ec2"'
+      - '"423a2057985dec90bc6e9b89f69a992f4d3ac751"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:56 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:56 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c77671e05c522732e898c0dd026a2b33c47a4ec2"'
+      - '"423a2057985dec90bc6e9b89f69a992f4d3ac751"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:56 GMT
+      - Wed, 08 Jul 2015 18:53:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:56 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/xml_specified_and_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/behaves_like_header_matches_data/text/xml_specified_and_provided.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a6db8ae63f2760c8c8895fb6b54216c965b08099"'
+      - '"bf53b5b623803f3d68f5aa5b4b27666acd224ba6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:00 GMT
+      - Wed, 08 Jul 2015 18:53:59 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:01 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:00 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c01c10ed267755213687555f97a08d8d4dea675f"'
+      - '"af9d87b2c1646e098d03f57b6e4ea814fe8a5030"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:01 GMT
+      - Wed, 08 Jul 2015 18:54:00 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:01 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:00 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c01c10ed267755213687555f97a08d8d4dea675f"'
+      - '"af9d87b2c1646e098d03f57b6e4ea814fe8a5030"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:01 GMT
+      - Wed, 08 Jul 2015 18:54:00 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:01 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:00 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/iiif_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/iiif_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c0dace1c2079f3f0e2fbd4da9d0c976499853019"'
+      - '"95a51592524deda10b36660b8553e1f781dec8cc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2587d1d605543dac5a72b352daef393519b02e97"'
+      - '"f396923e636c77e9ea79f2e35eccf9cd304d2f70"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"327fa50f2bbdf366bbd33ecd22b5dc8c5fc764b7"'
+      - '"8f9885109851aa8f674b1333e02ddbe8a076a97e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b
     body:
       encoding: UTF-8
       string: |
@@ -163,23 +163,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8bdfb0527ea3887f9a936a647f88bfa8101d928a"'
+      - '"8505c612d0ed998db6528319fad1172fe70d4e14"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b/f8/c4/fc/27/f8c4fc27-c2d0-4dbe-98b7-d00ba4ef959c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b/2c/e7/6d/c6/2ce76dc6-bbdd-4ebb-aaab-93259eaf0385
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b/f8/c4/fc/27/f8c4fc27-c2d0-4dbe-98b7-d00ba4ef959c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b/2c/e7/6d/c6/2ce76dc6-bbdd-4ebb-aaab-93259eaf0385
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
     body:
       encoding: UTF-8
       string: |
@@ -189,7 +189,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"960d3888b059a90439d7e5e1df58403c8d533f0b"'
+      - '"dd304e8952880a2ba71ff91c42ce7c0b57e378b3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t
     body:
       encoding: UTF-8
       string: |
@@ -252,23 +252,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fc4ae4ad87129d974915dfa6b173a5c36288b2b8"'
+      - '"5846ea86a13b7443afc300343390458d0235159f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t/e7/f0/43/e3/e7f043e3-ea91-4fb4-adfc-4251e22768f6
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t/8c/d2/4f/5a/8cd24f5a-cea3-4ff6-b30a-38445f62bd14
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t/e7/f0/43/e3/e7f043e3-ea91-4fb4-adfc-4251e22768f6
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t/8c/d2/4f/5a/8cd24f5a-cea3-4ff6-b30a-38445f62bd14
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
     body:
       encoding: US-ASCII
       string: ''
@@ -287,9 +287,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9b473f23b4450cb891fceb226cb127c288dcc261"'
+      - '"3b49809ecefb27dd188a75633c55f27757bec9b4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -323,18 +323,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b/f8/c4/fc/27/f8c4fc27-c2d0-4dbe-98b7-d00ba4ef959c>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t/e7/f0/43/e3/e7f043e3-ea91-4fb4-adfc-4251e22768f6>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b/2c/e7/6d/c6/2ce76dc6-bbdd-4ebb-aaab-93259eaf0385>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t/8c/d2/4f/5a/8cd24f5a-cea3-4ff6-b30a-38445f62bd14>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b/f8/c4/fc/27/f8c4fc27-c2d0-4dbe-98b7-d00ba4ef959c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b/2c/e7/6d/c6/2ce76dc6-bbdd-4ebb-aaab-93259eaf0385
     body:
       encoding: US-ASCII
       string: ''
@@ -353,9 +353,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8bdfb0527ea3887f9a936a647f88bfa8101d928a"'
+      - '"8505c612d0ed998db6528319fad1172fe70d4e14"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -389,15 +389,15 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/b/f8/c4/fc/27/f8c4fc27-c2d0-4dbe-98b7-d00ba4ef959c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/b/2c/e7/6d/c6/2ce76dc6-bbdd-4ebb-aaab-93259eaf0385>
         a ldp:BasicContainer , cnt:ContentAsText ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tcnt:chars
         \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t/e7/f0/43/e3/e7f043e3-ea91-4fb4-adfc-4251e22768f6
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t/8c/d2/4f/5a/8cd24f5a-cea3-4ff6-b30a-38445f62bd14
     body:
       encoding: US-ASCII
       string: ''
@@ -416,9 +416,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fc4ae4ad87129d974915dfa6b173a5c36288b2b8"'
+      - '"5846ea86a13b7443afc300343390458d0235159f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -452,23 +452,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b/t/e7/f0/43/e3/e7f043e3-ea91-4fb4-adfc-4251e22768f6>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569/t/8c/d2/4f/5a/8cd24f5a-cea3-4ff6-b30a-38445f62bd14>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b</field><field
+        name="id">anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318422270400","@type":"cnt:ContentAsText","chars":"I
-        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b","@type":"oa:Annotation","hasBody":"_:g70318422270400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312686203880","@type":"cnt:ContentAsText","chars":"I
+        love this!","format":"text/plain","language":"en"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569","@type":"oa:Annotation","hasBody":"_:g70312686203880","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,7 +484,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_dated_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_dated_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3f80d854e787cac8ca17007493d425c4c0824966"'
+      - '"b506d02caf15a07214fca519beea38e1eebac389"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"580d5f67f62c9d6c0395c189b4d5d8040d7b12b5"'
+      - '"5a905510a6c001750a981c305afb947b8619a742"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bec2192010f43b831a47f068e15f60110847cea4"'
+      - '"18e7a5bd0f458283ee29300315a446c991e8508f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bcce368778ba86a74c68d20459d98c31ee7a2129"'
+      - '"da130ee6d8f9128a3a82752d573ad8ce128ad61a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b/7d/52/5c/7c/7d525c7c-36e3-4f8e-b0a2-2927585c1f5c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b/a8/4c/f1/2f/a84cf12f-6f39-46c9-8907-bc719d20cf4a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b/7d/52/5c/7c/7d525c7c-36e3-4f8e-b0a2-2927585c1f5c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b/a8/4c/f1/2f/a84cf12f-6f39-46c9-8907-bc719d20cf4a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5754adc34238898f2b4c13a725f97ea41e41f74e"'
+      - '"6645862ec5fc737338f48ec6fa503c53ee8571d2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2d4ebaaeff7fe66e1cf595f4c9a5e2f4a7bc425d"'
+      - '"c4a47cbce6602a01fafca97e24406cb5978ec861"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t/39/0f/03/45/390f0345-e50f-4664-b3d4-e6a987b26419
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t/5d/96/1d/28/5d961d28-fd66-4417-aaa7-b1cc3295e1da
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t/39/0f/03/45/390f0345-e50f-4664-b3d4-e6a987b26419
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t/5d/96/1d/28/5d961d28-fd66-4417-aaa7-b1cc3295e1da
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cc886adcd4edef4f4dcea621e9e458a5a055eefd"'
+      - '"a3325400be736e3190efff0a81c2ced9318bfd11"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b/7d/52/5c/7c/7d525c7c-36e3-4f8e-b0a2-2927585c1f5c>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t/39/0f/03/45/390f0345-e50f-4664-b3d4-e6a987b26419>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t/5d/96/1d/28/5d961d28-fd66-4417-aaa7-b1cc3295e1da>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b/a8/4c/f1/2f/a84cf12f-6f39-46c9-8907-bc719d20cf4a>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b/7d/52/5c/7c/7d525c7c-36e3-4f8e-b0a2-2927585c1f5c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b/a8/4c/f1/2f/a84cf12f-6f39-46c9-8907-bc719d20cf4a
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bcce368778ba86a74c68d20459d98c31ee7a2129"'
+      - '"da130ee6d8f9128a3a82752d573ad8ce128ad61a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/b/7d/52/5c/7c/7d525c7c-36e3-4f8e-b0a2-2927585c1f5c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/b/a8/4c/f1/2f/a84cf12f-6f39-46c9-8907-bc719d20cf4a>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t/39/0f/03/45/390f0345-e50f-4664-b3d4-e6a987b26419
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t/5d/96/1d/28/5d961d28-fd66-4417-aaa7-b1cc3295e1da
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2d4ebaaeff7fe66e1cf595f4c9a5e2f4a7bc425d"'
+      - '"c4a47cbce6602a01fafca97e24406cb5978ec861"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b/t/39/0f/03/45/390f0345-e50f-4664-b3d4-e6a987b26419>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c/t/5d/96/1d/28/5d961d28-fd66-4417-aaa7-b1cc3295e1da>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b</field><field
+        name="id">anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318375270020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b","@type":"oa:Annotation","hasBody":"_:g70318375270020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312745538320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c","@type":"oa:Annotation","hasBody":"_:g70312745538320","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/oa_generic_uri_inline/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"414ef98d0dd2ea7d584ff8ef0ca7750eb11b6040"'
+      - '"5e90b501524bf96d8d150a661e830ba2b37a6e71"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:02 GMT
+      - Wed, 08 Jul 2015 18:54:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"062fb9b881a214f27260426fc3723496c6c18e01"'
+      - '"5174925d1a06b693cfbf2e03f2b01388b70918c5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"75ed47d9748763a59b71a89c34114a81afdc1bc5"'
+      - '"3131187d71dd2d9a0a7ae6b3b461fff1f62d8a5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"474e1f44c2ddcfb01a16d7d58822f418288d3701"'
+      - '"36e7c6e42dedb447bc15fa62ff7b30985256f1b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b/c3/c4/3f/41/c3c43f41-75fd-47a3-9863-9695d68e5c91
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b/38/12/49/56/38124956-90cd-4125-aaa9-9f0909790540
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b/c3/c4/3f/41/c3c43f41-75fd-47a3-9863-9695d68e5c91
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b/38/12/49/56/38124956-90cd-4125-aaa9-9f0909790540
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4dc16163a271d0a9da01e0716de7febe3ee53288"'
+      - '"efaf6b5066c7e7af0f7126fc841a4b741f9e011e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b73fbf5b4fe34c478c5f443d749271d3e83bd412"'
+      - '"93b397bead5b768885d758b3a2cf3eb2f7f14922"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t/85/02/7d/e2/85027de2-59f3-47ac-8442-189db6b2fd3e
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t/6b/10/12/cf/6b1012cf-277f-448e-8e12-447fb3d13c05
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t/85/02/7d/e2/85027de2-59f3-47ac-8442-189db6b2fd3e
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t/6b/10/12/cf/6b1012cf-277f-448e-8e12-447fb3d13c05
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"591a3bc5eea17501e8f418aa6ac56676ec68a844"'
+      - '"2f98c052a2114469987c499a3a4cf41f283fca7f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t/85/02/7d/e2/85027de2-59f3-47ac-8442-189db6b2fd3e>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b/c3/c4/3f/41/c3c43f41-75fd-47a3-9863-9695d68e5c91>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t/6b/10/12/cf/6b1012cf-277f-448e-8e12-447fb3d13c05>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b/38/12/49/56/38124956-90cd-4125-aaa9-9f0909790540>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b/c3/c4/3f/41/c3c43f41-75fd-47a3-9863-9695d68e5c91
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b/38/12/49/56/38124956-90cd-4125-aaa9-9f0909790540
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"474e1f44c2ddcfb01a16d7d58822f418288d3701"'
+      - '"36e7c6e42dedb447bc15fa62ff7b30985256f1b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/b/c3/c4/3f/41/c3c43f41-75fd-47a3-9863-9695d68e5c91>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/b/38/12/49/56/38124956-90cd-4125-aaa9-9f0909790540>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t/85/02/7d/e2/85027de2-59f3-47ac-8442-189db6b2fd3e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t/6b/10/12/cf/6b1012cf-277f-448e-8e12-447fb3d13c05
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b73fbf5b4fe34c478c5f443d749271d3e83bd412"'
+      - '"93b397bead5b768885d758b3a2cf3eb2f7f14922"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:03 GMT
+      - Wed, 08 Jul 2015 18:54:02 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e/t/85/02/7d/e2/85027de2-59f3-47ac-8442-189db6b2fd3e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa/t/6b/10/12/cf/6b1012cf-277f-448e-8e12-447fb3d13c05>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:03 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e</field><field
+        name="id">anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318403020020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e","@type":"oa:Annotation","hasBody":"_:g70318403020020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312664652700","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa","@type":"oa:Annotation","hasBody":"_:g70312664652700","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,5 +484,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:04 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/raises_400_error_when_no_context_specified_inline.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_context/NOT_included_in_header/raises_400_error_when_no_context_specified_inline.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"414ef98d0dd2ea7d584ff8ef0ca7750eb11b6040"'
+      - '"5e90b501524bf96d8d150a661e830ba2b37a6e71"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:02 GMT
+      - Wed, 08 Jul 2015 18:54:01 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,23 +58,23 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs>
-        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2>
+        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:02 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_NOT_provided.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_NOT_provided.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c61a64bd99a6b0d217cdf4f5778896b89ef6c235"'
+      - '"8cdbc6fba32feb674bbf72c597f65d510d305b19"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:42 GMT
+      - Wed, 08 Jul 2015 18:53:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,10 +58,10 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs>
-        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
+        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_matches_data.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/jsonld_specified_and_matches_data.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"72c8ff13353cb7dab6568d648f3155cf26db240c"'
+      - '"7bb1c26ce3ae801aacc8356c4509e495792c9c76"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"58c588e0f2ce6a36e4a74d7f85f068f0a05f2dea"'
+      - '"c40769d11f4d5df135f45c98999a550c29cf9b5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:42 GMT
+      - Wed, 08 Jul 2015 18:53:45 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"58c588e0f2ce6a36e4a74d7f85f068f0a05f2dea"'
+      - '"c40769d11f4d5df135f45c98999a550c29cf9b5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:42 GMT
+      - Wed, 08 Jul 2015 18:53:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/text/x-json_specified_for_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/text/x-json_specified_for_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d7ed0705493bf188627ff7318263a132a79762cc"'
+      - '"78c830997495ce70e7bf2043dd3b2419c7786fa8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:45 GMT
+      - Wed, 08 Jul 2015 18:53:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:49 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8778c597c67a502098221eaf129fcdf04337067d"'
+      - '"e340c18fc08cd3ed57fc228d2ccf7a2f8569fbbd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:47 GMT
+      - Wed, 08 Jul 2015 18:53:49 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8778c597c67a502098221eaf129fcdf04337067d"'
+      - '"e340c18fc08cd3ed57fc228d2ccf7a2f8569fbbd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:47 GMT
+      - Wed, 08 Jul 2015 18:53:49 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unknown_format_gives_400.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unknown_format_gives_400.yml
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b90a99011fe68fb7422704328d7dfe3f458f0b1"'
+      - '"54876a0981af6e981a1a8c3b091ab23c4db3ef66"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:50 GMT
+      - Wed, 08 Jul 2015 18:53:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -58,13 +58,13 @@ http_interactions:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
         .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs>
-        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766>
+        a ldp:BasicContainer ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:51 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:52 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b90a99011fe68fb7422704328d7dfe3f458f0b1"'
+      - '"54876a0981af6e981a1a8c3b091ab23c4db3ef66"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:50 GMT
+      - Wed, 08 Jul 2015 18:53:51 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:53 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:53 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a24e434d4f8f892360c46c09f64754b36552a195"'
+      - '"0b78fb83b2c30936c04522ec9586eb78847fabe4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:53 GMT
+      - Wed, 08 Jul 2015 18:53:53 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:53 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a24e434d4f8f892360c46c09f64754b36552a195"'
+      - '"0b78fb83b2c30936c04522ec9586eb78847fabe4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:53 GMT
+      - Wed, 08 Jul 2015 18:53:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:53 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_ttl.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/HTTP_Content-Type_header/unspecified_Content-Type_-_tries_to_infer_it_ttl.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7ba079ba5f7d457d8cd16d479fcc66b970debd4f"'
+      - '"e9c71b23ca741a02b6fc920e3a5906f49d6ab3b0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:53 GMT
+      - Wed, 08 Jul 2015 18:53:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:54 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3ca1379910699749d709da9c8554faeb6126502f"'
+      - '"84ecac30c7aa83e5d43b8aebc67a44b9a91b8395"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:54 GMT
+      - Wed, 08 Jul 2015 18:53:54 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:54 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ca1379910699749d709da9c8554faeb6126502f"'
+      - '"84ecac30c7aa83e5d43b8aebc67a44b9a91b8395"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:54 GMT
+      - Wed, 08 Jul 2015 18:53:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -140,8 +140,8 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/after_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
     body:
       encoding: US-ASCII
       string: ''
@@ -26,10 +26,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
     body:
       encoding: US-ASCII
       string: ''
@@ -53,10 +53,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7
     body:
       encoding: US-ASCII
       string: ''
@@ -80,10 +80,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518
     body:
       encoding: US-ASCII
       string: ''
@@ -107,10 +107,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff
     body:
       encoding: US-ASCII
       string: ''
@@ -134,10 +134,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc
     body:
       encoding: US-ASCII
       string: ''
@@ -161,10 +161,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404
     body:
       encoding: US-ASCII
       string: ''
@@ -188,10 +188,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e
     body:
       encoding: US-ASCII
       string: ''
@@ -215,10 +215,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b
     body:
       encoding: US-ASCII
       string: ''
@@ -242,10 +242,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3
     body:
       encoding: US-ASCII
       string: ''
@@ -269,10 +269,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb
     body:
       encoding: US-ASCII
       string: ''
@@ -296,10 +296,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06
     body:
       encoding: US-ASCII
       string: ''
@@ -323,10 +323,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62
     body:
       encoding: US-ASCII
       string: ''
@@ -350,10 +350,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01
     body:
       encoding: US-ASCII
       string: ''
@@ -377,10 +377,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda
     body:
       encoding: US-ASCII
       string: ''
@@ -404,10 +404,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a
     body:
       encoding: US-ASCII
       string: ''
@@ -431,10 +431,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa
     body:
       encoding: US-ASCII
       string: ''
@@ -458,10 +458,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c
     body:
       encoding: US-ASCII
       string: ''
@@ -485,10 +485,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569
     body:
       encoding: US-ASCII
       string: ''
@@ -512,10 +512,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
     body:
       encoding: US-ASCII
       string: ''
@@ -539,10 +539,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
     body:
       encoding: US-ASCII
       string: ''
@@ -566,10 +566,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
     body:
       encoding: US-ASCII
       string: ''
@@ -593,10 +593,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
     body:
       encoding: US-ASCII
       string: ''
@@ -620,10 +620,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
     body:
       encoding: US-ASCII
       string: ''
@@ -647,10 +647,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
     body:
       encoding: US-ASCII
       string: ''
@@ -674,10 +674,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
     body:
       encoding: US-ASCII
       string: ''
@@ -701,10 +701,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
     body:
       encoding: US-ASCII
       string: ''
@@ -728,10 +728,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
     body:
       encoding: US-ASCII
       string: ''
@@ -755,10 +755,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
     body:
       encoding: US-ASCII
       string: ''
@@ -782,10 +782,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
     body:
       encoding: US-ASCII
       string: ''
@@ -809,10 +809,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
     body:
       encoding: US-ASCII
       string: ''
@@ -836,10 +836,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
     body:
       encoding: US-ASCII
       string: ''
@@ -863,10 +863,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
     body:
       encoding: US-ASCII
       string: ''
@@ -890,10 +890,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
     body:
       encoding: US-ASCII
       string: ''
@@ -917,10 +917,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
     body:
       encoding: US-ASCII
       string: ''
@@ -944,10 +944,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
     body:
       encoding: US-ASCII
       string: ''
@@ -971,10 +971,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
     body:
       encoding: US-ASCII
       string: ''
@@ -998,10 +998,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7
     body:
       encoding: US-ASCII
       string: ''
@@ -1025,10 +1025,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa
     body:
       encoding: US-ASCII
       string: ''
@@ -1052,10 +1052,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55
     body:
       encoding: US-ASCII
       string: ''
@@ -1079,10 +1079,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c
     body:
       encoding: US-ASCII
       string: ''
@@ -1106,10 +1106,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f
     body:
       encoding: US-ASCII
       string: ''
@@ -1133,10 +1133,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7
     body:
       encoding: US-ASCII
       string: ''
@@ -1160,10 +1160,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb
     body:
       encoding: US-ASCII
       string: ''
@@ -1187,10 +1187,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f
     body:
       encoding: US-ASCII
       string: ''
@@ -1214,10 +1214,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1
     body:
       encoding: US-ASCII
       string: ''
@@ -1241,10 +1241,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
     body:
       encoding: US-ASCII
       string: ''
@@ -1268,10 +1268,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a
     body:
       encoding: US-ASCII
       string: ''
@@ -1295,10 +1295,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8
     body:
       encoding: US-ASCII
       string: ''
@@ -1322,10 +1322,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3
     body:
       encoding: US-ASCII
       string: ''
@@ -1349,10 +1349,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b
     body:
       encoding: US-ASCII
       string: ''
@@ -1376,10 +1376,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5
     body:
       encoding: US-ASCII
       string: ''
@@ -1403,10 +1403,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8
     body:
       encoding: US-ASCII
       string: ''
@@ -1430,10 +1430,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c
     body:
       encoding: US-ASCII
       string: ''
@@ -1457,10 +1457,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260
     body:
       encoding: US-ASCII
       string: ''
@@ -1484,10 +1484,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e
     body:
       encoding: US-ASCII
       string: ''
@@ -1511,10 +1511,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd
     body:
       encoding: US-ASCII
       string: ''
@@ -1538,10 +1538,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6
     body:
       encoding: US-ASCII
       string: ''
@@ -1565,10 +1565,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1
     body:
       encoding: US-ASCII
       string: ''
@@ -1592,10 +1592,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381
     body:
       encoding: US-ASCII
       string: ''
@@ -1619,10 +1619,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7
     body:
       encoding: US-ASCII
       string: ''
@@ -1646,10 +1646,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff
     body:
       encoding: US-ASCII
       string: ''
@@ -1673,10 +1673,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc
     body:
       encoding: US-ASCII
       string: ''
@@ -1700,10 +1700,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa
     body:
       encoding: US-ASCII
       string: ''
@@ -1727,10 +1727,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97
     body:
       encoding: US-ASCII
       string: ''
@@ -1754,10 +1754,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422
     body:
       encoding: US-ASCII
       string: ''
@@ -1781,10 +1781,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f
     body:
       encoding: US-ASCII
       string: ''
@@ -1808,10 +1808,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67
     body:
       encoding: US-ASCII
       string: ''
@@ -1835,10 +1835,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195
+    uri: http://localhost:8983/fedora/rest/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e
     body:
       encoding: US-ASCII
       string: ''
@@ -1862,7 +1862,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -1880,9 +1880,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cc0e4ed641e3986f08a803b71490b40fa34572bf"'
+      - '"f5ac42f11c5a7ade75a42398271dc31581b50f62"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -1901,7 +1901,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -1926,7 +1926,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fcr:tombstone
@@ -1949,13 +1949,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -1971,15 +1971,231 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>12}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>28}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d7/b2/17/e5/d7b217e5-d656-4221-aa2d-c58036b697f7</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/eb/2a/49/18/eb2a4918-1812-463c-b67c-ef063e8e6518</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ce/25/a0/3d/ce25a03d-91b4-4951-bf8b-cdedb9074eff</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/b1/11/82/28/b1118228-0ba5-427c-b2ae-8b733ca72adc</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/aa/f5/44/4e/aaf5444e-aca5-4945-b8ec-c76b2ae12404</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/dd/80/7a/0e/dd807a0e-151e-4f66-b813-3181b4aada2e</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c9/84/5c/ba/c9845cba-8f00-43fd-9565-18cb964a7a6b</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e3/71/7d/51/e3717d51-5e55-4d54-b86c-df7c262775a3</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/17/2c/41/59/172c4159-344a-4676-9652-461428147efb</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -1997,61 +2213,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6f/25/68/32/6f256832-7c3f-4f8f-a2ba-43974b51b818</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/23/2c/0e/aa/232c0eaa-47ec-4fe4-b607-9bd0634ce237</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/b6/ff/a3/cf/b6ffa3cf-b2d5-401b-865c-1ccaf78e208a</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c3/4a/19/a1/c34a19a1-12b4-41d1-b69a-858986cc1e06</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2069,13 +2237,37 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/34/a3/ea/b1/34a3eab1-8966-42f4-853f-53dcdc618766</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/53/b6/6a/e7/53b66ae7-b799-4425-9bee-ad2429810e62</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c6/d0/a2/2c/c6d0a22c-f1d8-415c-9fc4-63e4d65e0c01</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2093,13 +2285,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/42/70/14/d9/427014d9-3d96-4bee-9f1c-1130cdc5250c</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/84/ea/a8/a6/84eaa8a6-53ff-4b94-b442-1f0249570eda</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2115,63 +2307,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e8/1e/67/11/e81e6711-f1dd-4133-9214-9612c4b1c7ea</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/0c/e4/03/bc/0ce403bc-f139-4a87-adb8-6fc10a6a6203</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c1/1a/8e/65/c11a8e65-ee5e-469a-aaf5-0755a8eb0169</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/90/89/24/7f/9089247f-6d9c-430f-9454-cb447b894f7a</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2189,13 +2333,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/73/ce/6b/9d/73ce6b9d-8bf5-439e-a3f9-3495960c2730</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/8e/ff/99/0b/8eff990b-c8e6-48e0-a8a9-4dc7bc77c1fa</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2213,13 +2357,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/07/20/35/90/07203590-4222-436c-a0cc-a8d12b4e4542</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/b7/aa/c5/f6/b7aac5f6-e033-480c-a59e-79f42803d46c</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2235,15 +2379,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/cf/39/d7/f2/cf39d7f2-8685-4204-939f-57e05a1b39a6</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/0a/4d/9d/61/0a4d9d61-9230-4dde-a94b-64f8660e9569</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2259,15 +2403,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/da/61/7e/fc/da617efc-e0aa-43b2-a898-3aecdb3b037a</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2283,135 +2427,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d4/b9/08/ed/d4b908ed-556d-436d-9ca2-1c6d49df2d45</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/44/a6/e8/8d/44a6e88d-d648-442c-8ba3-837be67825a2</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/77/e6/cf/11/77e6cf11-a14a-4efa-98f7-cc366851405e</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>7}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:24 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/56/47/39/d7/564739d7-baa4-4478-a569-b037f9085f8b</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/f4/8f/56/34/f48f5634-38f0-4783-a22a-0de268d51d6b</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2429,133 +2453,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2573,13 +2477,229 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2597,13 +2717,37 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2621,13 +2765,109 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2645,13 +2885,37 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2669,13 +2933,445 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2693,13 +3389,109 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa</id></delete>
+    headers:
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
+- request:
+    method: post
+    uri: http://localhost:8983/solr/triannon/update?wt=ruby
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2717,13 +3509,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2741,13 +3533,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2765,61 +3557,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2837,61 +3581,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -2909,703 +3605,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
-- request:
-    method: post
-    uri: http://localhost:8983/solr/triannon/update?wt=ruby
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195</id></delete>
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -3627,7 +3627,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>27}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>116}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"14f890f33516c98df9936388b4d0d7994eb0120e"'
+      - '"795376cd82532d5e7de097e9a1016c2bf84c8f68"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:12 GMT
+      - Wed, 08 Jul 2015 18:52:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:36 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:40 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:36 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9e42ea36512f6f67b5c528278546e69f4ac95e9c"'
+      - '"f5c71fd1888d639fc25b32de261acbbf83d07f57"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:36 GMT
+      - Wed, 08 Jul 2015 18:53:40 GMT
       Content-Length:
       - '67'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:36 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_params_from_form.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5db68b5add7673f085e999ba7d8e16e694823bb1"'
+      - '"7736cd287e1f3b53cb90286a9e76937238088153"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1362ca92ec32efda23b2811d90431a360f747fa8"'
+      - '"41c33992f646d659fe5aaf5921e5302ea0b1f462"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"113b4bcc203550f34c6d762757fe9a071bebd304"'
+      - '"199bbbe802261f9b306ff654a88eea6bd3d5b103"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"24e0bfee327e54dd0a7a184e8850d667ba71cfbb"'
+      - '"2855b2bc546eb15f5285a845973fc1d719cd26f2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b/18/46/cb/45/1846cb45-ceb2-4427-a8d3-62eda50d6dca
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b/01/a3/42/79/01a34279-cc4a-4c81-8bf2-344528664eab
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b/18/46/cb/45/1846cb45-ceb2-4427-a8d3-62eda50d6dca
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b/01/a3/42/79/01a34279-cc4a-4c81-8bf2-344528664eab
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bc49c5f7e066be3fbec05cbcec12ff35934592b7"'
+      - '"119b479138036e6e7d94dcac7b6f8fd28130f10a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f79633177b814f922b9f1350927fbf1f910d1ccc"'
+      - '"1f63bcf2a43249ddbf980fd488472f8ef2e60276"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t/95/59/7d/19/95597d19-8e6f-42d6-9907-de08b0036276
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t/94/5f/e2/ee/945fe2ee-cca4-48a6-a40d-8cc31e11822b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t/95/59/7d/19/95597d19-8e6f-42d6-9907-de08b0036276
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t/94/5f/e2/ee/945fe2ee-cca4-48a6-a40d-8cc31e11822b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1a713851e9c091bd79a19efeb1e4cfba41e97eef"'
+      - '"b52b727fd63219b85ba247097465191af23a1029"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t/95/59/7d/19/95597d19-8e6f-42d6-9907-de08b0036276>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b/18/46/cb/45/1846cb45-ceb2-4427-a8d3-62eda50d6dca>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b/01/a3/42/79/01a34279-cc4a-4c81-8bf2-344528664eab>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t/94/5f/e2/ee/945fe2ee-cca4-48a6-a40d-8cc31e11822b>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b/18/46/cb/45/1846cb45-ceb2-4427-a8d3-62eda50d6dca
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b/01/a3/42/79/01a34279-cc4a-4c81-8bf2-344528664eab
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"24e0bfee327e54dd0a7a184e8850d667ba71cfbb"'
+      - '"2855b2bc546eb15f5285a845973fc1d719cd26f2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/b/18/46/cb/45/1846cb45-ceb2-4427-a8d3-62eda50d6dca>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/b/01/a3/42/79/01a34279-cc4a-4c81-8bf2-344528664eab>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t/95/59/7d/19/95597d19-8e6f-42d6-9907-de08b0036276
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t/94/5f/e2/ee/945fe2ee-cca4-48a6-a40d-8cc31e11822b
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f79633177b814f922b9f1350927fbf1f910d1ccc"'
+      - '"1f63bcf2a43249ddbf980fd488472f8ef2e60276"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:39 GMT
+      - Wed, 08 Jul 2015 18:53:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d/t/95/59/7d/19/95597d19-8e6f-42d6-9907-de08b0036276>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b/t/94/5f/e2/ee/945fe2ee-cca4-48a6-a40d-8cc31e11822b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:39 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:43 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d</field><field
+        name="id">anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318411706620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/0c/69/fb/0b/0c69fb0b-8bc7-4d5d-835a-a41dd7f7963d","@type":"oa:Annotation","hasBody":"_:g70318411706620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312755117940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e6/5e/13/1d/e65e131d-8eae-4855-a447-25d06e18271b","@type":"oa:Annotation","hasBody":"_:g70312755117940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>8}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>7}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/creates_a_new_annotation_from_the_body_of_the_request.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9e42ea36512f6f67b5c528278546e69f4ac95e9c"'
+      - '"f5c71fd1888d639fc25b32de261acbbf83d07f57"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:36 GMT
+      - Wed, 08 Jul 2015 18:53:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:36 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"761061021a77f27883ca9989044a33215b458cea"'
+      - '"682eb29912bf664c3909aafc6e60adcbf3b083ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2df50276acb7d507c8b40ecea5b034db1fb5fd57"'
+      - '"73344c61efca040371fff01f99f73a4fa6bb015c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6f77ecfb2297e5d28f4cc12a9e38b44ec200e99c"'
+      - '"a79f20eed21f68a91f3c14116cb2fe0f678e3c41"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b/08/0d/54/d9/080d54d9-18ae-49f4-8afe-8836281fe449
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b/5c/64/5f/5c/5c645f5c-bb2d-49bd-8c1f-7c9f8356be2e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b/08/0d/54/d9/080d54d9-18ae-49f4-8afe-8836281fe449
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b/5c/64/5f/5c/5c645f5c-bb2d-49bd-8c1f-7c9f8356be2e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4b0c88c61c42178477ceb2c72a4bfd88479722e6"'
+      - '"9b65c021b79e8eac2f5e36833b93f600733f1149"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7741771447f6598880269adf56c4a1a2ce0ab250"'
+      - '"5fc8614f5fbee095cec913c682fcff57b2ec053e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t/12/ce/f0/25/12cef025-3b13-445f-9b14-817fdf639d67
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t/97/d0/a0/92/97d0a092-5838-4688-9189-3c96c76e06ae
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t/12/ce/f0/25/12cef025-3b13-445f-9b14-817fdf639d67
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t/97/d0/a0/92/97d0a092-5838-4688-9189-3c96c76e06ae
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e5b1db4b85e1bd602e7305f56269652ff4903ac9"'
+      - '"5212ce2e9d37533ffa0ec96acf6885408ce512bd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b/08/0d/54/d9/080d54d9-18ae-49f4-8afe-8836281fe449>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t/12/ce/f0/25/12cef025-3b13-445f-9b14-817fdf639d67>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b/5c/64/5f/5c/5c645f5c-bb2d-49bd-8c1f-7c9f8356be2e>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t/97/d0/a0/92/97d0a092-5838-4688-9189-3c96c76e06ae>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b/08/0d/54/d9/080d54d9-18ae-49f4-8afe-8836281fe449
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b/5c/64/5f/5c/5c645f5c-bb2d-49bd-8c1f-7c9f8356be2e
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6f77ecfb2297e5d28f4cc12a9e38b44ec200e99c"'
+      - '"a79f20eed21f68a91f3c14116cb2fe0f678e3c41"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/b/08/0d/54/d9/080d54d9-18ae-49f4-8afe-8836281fe449>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/b/5c/64/5f/5c/5c645f5c-bb2d-49bd-8c1f-7c9f8356be2e>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t/12/ce/f0/25/12cef025-3b13-445f-9b14-817fdf639d67
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t/97/d0/a0/92/97d0a092-5838-4688-9189-3c96c76e06ae
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7741771447f6598880269adf56c4a1a2ce0ab250"'
+      - '"5fc8614f5fbee095cec913c682fcff57b2ec053e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:19:37 GMT
+      - Wed, 08 Jul 2015 18:53:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396/t/12/ce/f0/25/12cef025-3b13-445f-9b14-817fdf639d67>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a/t/97/d0/a0/92/97d0a092-5838-4688-9189-3c96c76e06ae>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:37 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:41 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396</field><field
+        name="id">anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318393930200","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/04/0c/99/00/040c9900-d8ce-41f3-829b-87d43b892396","@type":"oa:Annotation","hasBody":"_:g70318393930200","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312744856580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e9/b5/ea/c6/e9b5eac6-a836-49db-8198-43c34c74a37a","@type":"oa:Annotation","hasBody":"_:g70312744856580","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>158}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>151}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:19:38 GMT
+  recorded_at: Wed, 08 Jul 2015 18:53:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/_/_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/_/_gets_json-ld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"05e036e7cb801bfa256402f67a39f80f17b9ca00"'
+      - '"585c1d8079c4d9006146e25d93fdbfa44d02be68"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f8d427661917d2c506319509ec3d48541091323a"'
+      - '"0bfa6494d11ad9f99789fc23a0afb85bbf2fdef9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bdcfaac0189c4e8a13ea4cf6c2bd3bf00f8fdb88"'
+      - '"d441b5941a0087cb47c4464b0dc7ba2e0c1317b9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1168f05933bf7be08ff37708558ec00515cebb15"'
+      - '"8d8a0e3b4202046bb73d64b736211e47024b120f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b/fe/12/bc/40/fe12bc40-f872-4499-8217-890c4f5e2c92
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b/af/d4/a0/66/afd4a066-d4fa-4865-b6bc-a429214cc834
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b/fe/12/bc/40/fe12bc40-f872-4499-8217-890c4f5e2c92
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b/af/d4/a0/66/afd4a066-d4fa-4865-b6bc-a429214cc834
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"487ccbc205849b505824a1ba5e66942120839ece"'
+      - '"a1ff03cb19545e1eeeca0b553f1324cdc8c2cf4c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b7abdbc9d951783933a3a6ee44c6d37eddc65ee3"'
+      - '"2c547179787a78850735ce5ad5c967a372da0b91"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t/14/de/7e/bd/14de7ebd-25a7-41ff-872a-0836cadc5879
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t/ee/6f/12/36/ee6f1236-f54f-4e8e-a804-1507b9ab6da9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t/14/de/7e/bd/14de7ebd-25a7-41ff-872a-0836cadc5879
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t/ee/6f/12/36/ee6f1236-f54f-4e8e-a804-1507b9ab6da9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7bb492271f2c17f771b7f8d7b6111d4b4cfffa16"'
+      - '"2c8c9f0fd6927ebcbe79364332c6af00b860c33d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t/14/de/7e/bd/14de7ebd-25a7-41ff-872a-0836cadc5879>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b/fe/12/bc/40/fe12bc40-f872-4499-8217-890c4f5e2c92>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b/af/d4/a0/66/afd4a066-d4fa-4865-b6bc-a429214cc834>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t/ee/6f/12/36/ee6f1236-f54f-4e8e-a804-1507b9ab6da9>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b/fe/12/bc/40/fe12bc40-f872-4499-8217-890c4f5e2c92
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b/af/d4/a0/66/afd4a066-d4fa-4865-b6bc-a429214cc834
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1168f05933bf7be08ff37708558ec00515cebb15"'
+      - '"8d8a0e3b4202046bb73d64b736211e47024b120f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/b/fe/12/bc/40/fe12bc40-f872-4499-8217-890c4f5e2c92>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/b/af/d4/a0/66/afd4a066-d4fa-4865-b6bc-a429214cc834>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t/14/de/7e/bd/14de7ebd-25a7-41ff-872a-0836cadc5879
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t/ee/6f/12/36/ee6f1236-f54f-4e8e-a804-1507b9ab6da9
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b7abdbc9d951783933a3a6ee44c6d37eddc65ee3"'
+      - '"2c547179787a78850735ce5ad5c967a372da0b91"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22/t/14/de/7e/bd/14de7ebd-25a7-41ff-872a-0836cadc5879>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8/t/ee/6f/12/36/ee6f1236-f54f-4e8e-a804-1507b9ab6da9>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22</field><field
+        name="id">anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318345171460","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/d3/66/76/05/d3667605-d27c-45c3-a730-f2ff62002f22","@type":"oa:Annotation","hasBody":"_:g70318345171460","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312737806700","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/82/2e/26/26/822e2626-ff45-4802-a8e6-0b5a7af5c6e8","@type":"oa:Annotation","hasBody":"_:g70312737806700","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/empty_string_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/empty_string_gets_json-ld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"85e6a8b05e90636bb2d988d68d2e0beeba0c8187"'
+      - '"e9c81a41b5372d490ba01c938e9498100969e5b4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:04 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"13d1635d7c5bc91bf1cd319082d4cedc8352b2e9"'
+      - '"7a2f78ee594fc0f3a41b331d90e11ec1cb82fe64"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a03abd6cdb4a1d4b0bab101cc9de452303686d87"'
+      - '"0a6a0f190ef43501708f63cef30b3c59faf63804"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"826b38b8c0aee650ed4cab6d3cafe25b72303703"'
+      - '"6857dbdf2f8c8f75d3ea4dca22426e5476f2e350"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b/99/c3/98/99/99c39899-8992-44cd-bb3f-d947d2e7aa10
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b/7b/bc/53/4f/7bbc534f-77ce-4174-a75c-cb6dcacd5442
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b/99/c3/98/99/99c39899-8992-44cd-bb3f-d947d2e7aa10
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b/7b/bc/53/4f/7bbc534f-77ce-4174-a75c-cb6dcacd5442
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"69342a30459eb3bcccdc1b6c103d8b12a94d313a"'
+      - '"0473cd471b1d16d969e54944bef3c9efe73b3ce0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"20016fd2ad6f1b39bb165de4ca6a2749ac766469"'
+      - '"bd0f387a03e4014fba112ca4bc9405847d614d2b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t/d0/88/3d/10/d0883d10-8ac6-43a9-aea3-8d23fb146454
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t/43/6f/f6/43/436ff643-b6aa-4c3b-820f-8c7fbbe8376b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t/d0/88/3d/10/d0883d10-8ac6-43a9-aea3-8d23fb146454
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t/43/6f/f6/43/436ff643-b6aa-4c3b-820f-8c7fbbe8376b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5d3a114d72a4f0f09177d192b59b6bb4e45491f9"'
+      - '"5bef5a1ba9db754142954107874c4b3acaa9f2ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t/d0/88/3d/10/d0883d10-8ac6-43a9-aea3-8d23fb146454>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b/99/c3/98/99/99c39899-8992-44cd-bb3f-d947d2e7aa10>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b/7b/bc/53/4f/7bbc534f-77ce-4174-a75c-cb6dcacd5442>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t/43/6f/f6/43/436ff643-b6aa-4c3b-820f-8c7fbbe8376b>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b/99/c3/98/99/99c39899-8992-44cd-bb3f-d947d2e7aa10
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b/7b/bc/53/4f/7bbc534f-77ce-4174-a75c-cb6dcacd5442
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"826b38b8c0aee650ed4cab6d3cafe25b72303703"'
+      - '"6857dbdf2f8c8f75d3ea4dca22426e5476f2e350"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/b/99/c3/98/99/99c39899-8992-44cd-bb3f-d947d2e7aa10>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/b/7b/bc/53/4f/7bbc534f-77ce-4174-a75c-cb6dcacd5442>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:03 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t/d0/88/3d/10/d0883d10-8ac6-43a9-aea3-8d23fb146454
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t/43/6f/f6/43/436ff643-b6aa-4c3b-820f-8c7fbbe8376b
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"20016fd2ad6f1b39bb165de4ca6a2749ac766469"'
+      - '"bd0f387a03e4014fba112ca4bc9405847d614d2b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c/t/d0/88/3d/10/d0883d10-8ac6-43a9-aea3-8d23fb146454>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210/t/43/6f/f6/43/436ff643-b6aa-4c3b-820f-8c7fbbe8376b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c</field><field
+        name="id">anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318433811020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/72/ee/f7/09/72eef709-b632-4066-9268-0da1c9cd4b1c","@type":"oa:Annotation","hasBody":"_:g70318433811020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312749249400","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/af/37/b0/05/af37b005-0e5d-4658-89a5-87efbea51210","@type":"oa:Annotation","hasBody":"_:g70312749249400","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/html_uses_view.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/html_uses_view.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2de3c8bfaa2f74a8176cad2a28d148ac6d276196"'
+      - '"5eb3544a97d5ef2ed4e28bca23f25cb6240f3b10"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d238c448de938aa501f21861270869abe0c75f1e"'
+      - '"e2b726ba385a7db3289d147fc8c2aa2d62ae63d0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"61011be41c5995d0dae015520135d03b95735de5"'
+      - '"63683722eb46ff3b359ac89862ddf00fe2df2aa8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"de436372e168c3e2a9532b1f99260b9dacb005dd"'
+      - '"980243e3a86d1b3b015fac99840e9ca4306ee7d4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b/ff/47/86/bd/ff4786bd-4392-4936-a7c7-cd656e3bac01
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b/0c/f7/75/b6/0cf775b6-c65d-444e-afac-f9a5ae2d7eb1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b/ff/47/86/bd/ff4786bd-4392-4936-a7c7-cd656e3bac01
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b/0c/f7/75/b6/0cf775b6-c65d-444e-afac-f9a5ae2d7eb1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f6ef8d8cafb3d2c2be2e856165209f024624b889"'
+      - '"939173899d68c7a7754eb6a0c006b34b2d9d0684"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3dfb40334a207284e04740d5fd8f7dbaed6f1519"'
+      - '"749f7b65fdc994a335d9cc95888ee7020f0ed504"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t/52/dd/1b/ef/52dd1bef-2451-4ac7-9b93-d9dc89622fb2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t/eb/62/70/f9/eb6270f9-307e-497d-b29b-cdebe2d92c04
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t/52/dd/1b/ef/52dd1bef-2451-4ac7-9b93-d9dc89622fb2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t/eb/62/70/f9/eb6270f9-307e-497d-b29b-cdebe2d92c04
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"adad02970b377db9a652f989d27151e0f018e7a1"'
+      - '"9e9a5dbf4c85aae6bbff090c34f37eb2f6906cfd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t/52/dd/1b/ef/52dd1bef-2451-4ac7-9b93-d9dc89622fb2>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b/ff/47/86/bd/ff4786bd-4392-4936-a7c7-cd656e3bac01>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b/0c/f7/75/b6/0cf775b6-c65d-444e-afac-f9a5ae2d7eb1>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t/eb/62/70/f9/eb6270f9-307e-497d-b29b-cdebe2d92c04>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b/ff/47/86/bd/ff4786bd-4392-4936-a7c7-cd656e3bac01
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b/0c/f7/75/b6/0cf775b6-c65d-444e-afac-f9a5ae2d7eb1
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"de436372e168c3e2a9532b1f99260b9dacb005dd"'
+      - '"980243e3a86d1b3b015fac99840e9ca4306ee7d4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/b/ff/47/86/bd/ff4786bd-4392-4936-a7c7-cd656e3bac01>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/b/0c/f7/75/b6/0cf775b6-c65d-444e-afac-f9a5ae2d7eb1>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t/52/dd/1b/ef/52dd1bef-2451-4ac7-9b93-d9dc89622fb2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t/eb/62/70/f9/eb6270f9-307e-497d-b29b-cdebe2d92c04
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3dfb40334a207284e04740d5fd8f7dbaed6f1519"'
+      - '"749f7b65fdc994a335d9cc95888ee7020f0ed504"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847/t/52/dd/1b/ef/52dd1bef-2451-4ac7-9b93-d9dc89622fb2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590/t/eb/62/70/f9/eb6270f9-307e-497d-b29b-cdebe2d92c04>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847</field><field
+        name="id">anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318402297940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/17/fb/d7/e4/17fbd7e4-7c5d-4a9a-afb8-936fc5e4f847","@type":"oa:Annotation","hasBody":"_:g70318402297940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312682295140","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ac/5c/49/a4/ac5c49a4-a584-4990-9f36-449dc9787590","@type":"oa:Annotation","hasBody":"_:g70312682295140","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/json.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"dd35a7ed689f0492f98cb58967984e3492d17ba0"'
+      - '"3e451a7fdf64b7e412543cb7120a3c67d06dfc26"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e59c88aac432409507843aa1309598b012153f43"'
+      - '"409c36554eceee443b271466ad3e0af1d2926774"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e2bb7a6bc16c0b5bd77ebbf57de93ea7f33b916a"'
+      - '"2014843dc9739e3908d3758f947bf9a65ecbaf8c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e9494dfbacd7c7bd0e7600260131a04d5e7f4fee"'
+      - '"3f1226a4b987df26fd8488e566771a919050b096"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b/41/76/6f/f0/41766ff0-ebfe-4064-8d89-419ef2d69c35
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b/6b/15/ff/60/6b15ff60-0ca0-4423-8ccd-7e7f7a5c0b41
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b/41/76/6f/f0/41766ff0-ebfe-4064-8d89-419ef2d69c35
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b/6b/15/ff/60/6b15ff60-0ca0-4423-8ccd-7e7f7a5c0b41
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"437e5324243877565ff1d3f5749fedce159107c9"'
+      - '"5b42a3017183c576e62cfedc59984ea277209126"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e221e5a250e953e6967861f25901452703e01b12"'
+      - '"20d5aacb2d4d77ac83940b1c166e8cb4297e5235"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t/bf/0e/e5/2e/bf0ee52e-3510-4141-bf56-927ace19cd62
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t/d2/47/db/94/d247db94-2b80-487e-af0a-b55b40ec3e58
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t/bf/0e/e5/2e/bf0ee52e-3510-4141-bf56-927ace19cd62
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t/d2/47/db/94/d247db94-2b80-487e-af0a-b55b40ec3e58
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7c9ebc81bb17f224d71116b0168cafe8d74f3419"'
+      - '"f7982c4cfff0b09fe918a5450df1c7a5205d7e73"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t/bf/0e/e5/2e/bf0ee52e-3510-4141-bf56-927ace19cd62>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b/41/76/6f/f0/41766ff0-ebfe-4064-8d89-419ef2d69c35>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b/6b/15/ff/60/6b15ff60-0ca0-4423-8ccd-7e7f7a5c0b41>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t/d2/47/db/94/d247db94-2b80-487e-af0a-b55b40ec3e58>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b/41/76/6f/f0/41766ff0-ebfe-4064-8d89-419ef2d69c35
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b/6b/15/ff/60/6b15ff60-0ca0-4423-8ccd-7e7f7a5c0b41
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e9494dfbacd7c7bd0e7600260131a04d5e7f4fee"'
+      - '"3f1226a4b987df26fd8488e566771a919050b096"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/b/41/76/6f/f0/41766ff0-ebfe-4064-8d89-419ef2d69c35>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/b/6b/15/ff/60/6b15ff60-0ca0-4423-8ccd-7e7f7a5c0b41>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t/bf/0e/e5/2e/bf0ee52e-3510-4141-bf56-927ace19cd62
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t/d2/47/db/94/d247db94-2b80-487e-af0a-b55b40ec3e58
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e221e5a250e953e6967861f25901452703e01b12"'
+      - '"20d5aacb2d4d77ac83940b1c166e8cb4297e5235"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7/t/bf/0e/e5/2e/bf0ee52e-3510-4141-bf56-927ace19cd62>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84/t/d2/47/db/94/d247db94-2b80-487e-af0a-b55b40ec3e58>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7</field><field
+        name="id">anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318401176600","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/bf/2e/e2/7c/bf2ee27c-2584-4278-b227-4319bd4496e7","@type":"oa:Annotation","hasBody":"_:g70318401176600","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312752588900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/aa/1c/f0/c4/aa1cf0c4-f5ab-4c9a-9bfc-79a75c9ffc84","@type":"oa:Annotation","hasBody":"_:g70312752588900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>17}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/jsonrequest.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/jsonrequest.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b931708043de81b8f58764e790cb07c1ee1b2e58"'
+      - '"15769be28972ef6e65e005c8ac7d8d24b2913b4d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"65d117c78b9059caf329a6fbe0aa716354e34251"'
+      - '"d1cdf7b43a098fd90ee7da8cf85456a1ff844ab5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e63c851e5c12ae314e1c7c7aa4dae3706bb6ce1e"'
+      - '"8e714c2e7b3b155e736e62d1e8aa5d9cc168d238"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9d6586982e3bac31949e79839d5b9c66ba413897"'
+      - '"e54c851b02443a660ceddbf008966aaa7f2d9776"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b/55/d6/17/c7/55d617c7-533c-4142-aa3e-1fb4bef05f31
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b/4d/c0/77/86/4dc07786-c3a8-4b4d-a753-11fb909f2625
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b/55/d6/17/c7/55d617c7-533c-4142-aa3e-1fb4bef05f31
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b/4d/c0/77/86/4dc07786-c3a8-4b4d-a753-11fb909f2625
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1633621e155f9711c7c4ba152f4a64d3f4d066b4"'
+      - '"26d7a46c2fd356d95453d3d25fb1edfd236811b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bf9429bcbf59ecd5c4439948c7c1f2eb52940881"'
+      - '"a3152c9ac358fd0ec3c7163978d68380e4b3cb9f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t/21/6a/01/f4/216a01f4-5936-4a15-9594-c57433f02235
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t/83/5a/d7/08/835ad708-22cc-43b2-90f2-41f769613992
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t/21/6a/01/f4/216a01f4-5936-4a15-9594-c57433f02235
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t/83/5a/d7/08/835ad708-22cc-43b2-90f2-41f769613992
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"439b7ebf114d3ddbbc1d491be744d31896dc863a"'
+      - '"08ea759e82da3d187f51903e1a0462539b69c4c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b/55/d6/17/c7/55d617c7-533c-4142-aa3e-1fb4bef05f31>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t/21/6a/01/f4/216a01f4-5936-4a15-9594-c57433f02235>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b/4d/c0/77/86/4dc07786-c3a8-4b4d-a753-11fb909f2625>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t/83/5a/d7/08/835ad708-22cc-43b2-90f2-41f769613992>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b/55/d6/17/c7/55d617c7-533c-4142-aa3e-1fb4bef05f31
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b/4d/c0/77/86/4dc07786-c3a8-4b4d-a753-11fb909f2625
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9d6586982e3bac31949e79839d5b9c66ba413897"'
+      - '"e54c851b02443a660ceddbf008966aaa7f2d9776"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/b/55/d6/17/c7/55d617c7-533c-4142-aa3e-1fb4bef05f31>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/b/4d/c0/77/86/4dc07786-c3a8-4b4d-a753-11fb909f2625>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t/21/6a/01/f4/216a01f4-5936-4a15-9594-c57433f02235
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t/83/5a/d7/08/835ad708-22cc-43b2-90f2-41f769613992
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bf9429bcbf59ecd5c4439948c7c1f2eb52940881"'
+      - '"a3152c9ac358fd0ec3c7163978d68380e4b3cb9f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c/t/21/6a/01/f4/216a01f4-5936-4a15-9594-c57433f02235>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199/t/83/5a/d7/08/835ad708-22cc-43b2-90f2-41f769613992>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c</field><field
+        name="id">anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430447060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/67/66/f4/ec/6766f4ec-115c-4887-8b93-928cbb6a5e2c","@type":"oa:Annotation","hasBody":"_:g70318430447060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312769402180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3a/19/f0/08/3a19f008-ce32-4a4b-99da-a6c2bbb27199","@type":"oa:Annotation","hasBody":"_:g70312769402180","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/ld_json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/application/ld_json.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"dd35a7ed689f0492f98cb58967984e3492d17ba0"'
+      - '"8306c0230644710db4b6faec3e4806e3f5be78d4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"546949a9fce10999518e2bb8c27bbfbaf2fa34e5"'
+      - '"2cd71b23e0b1b191761f7d2eab79712d2ea513b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"438387546669a5e9bf6bf80add8f9770d4491ac7"'
+      - '"fb767cbabbb68e01c581c7104229c2dc126c0599"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ece9bafdfd97812af5d9c064a5205085e3f87e17"'
+      - '"caa64a4d2a36cc4102e0cd2ea32aaee7c3d21205"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b/9b/b1/ae/b5/9bb1aeb5-da81-48b2-b117-252eeb481761
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b/d4/17/e0/4f/d417e04f-3e6d-4bcf-994a-510d3e57c630
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b/9b/b1/ae/b5/9bb1aeb5-da81-48b2-b117-252eeb481761
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b/d4/17/e0/4f/d417e04f-3e6d-4bcf-994a-510d3e57c630
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b9d460825b9ca561b5c1800a22877ce11993eb7a"'
+      - '"2d5e212ed2bd8b5dd1b297e399dbf8f410d91712"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cc8c5eaaec9ccb3d8697fda2e82e795052d499f2"'
+      - '"b58fd4b26306e39923e0000389fd77ce950fd328"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t/28/ac/b8/6e/28acb86e-7d4d-446f-b396-60054ef92411
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t/5b/89/a6/b7/5b89a6b7-653c-4d1c-a0df-c7d6b8cd6331
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t/28/ac/b8/6e/28acb86e-7d4d-446f-b396-60054ef92411
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t/5b/89/a6/b7/5b89a6b7-653c-4d1c-a0df-c7d6b8cd6331
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"02d9971320fb5babe32da514ebe45ebac8ac816e"'
+      - '"5856cfa1cd2bf10e8f9b974bd04fd32ef0ea7d43"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t/28/ac/b8/6e/28acb86e-7d4d-446f-b396-60054ef92411>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b/9b/b1/ae/b5/9bb1aeb5-da81-48b2-b117-252eeb481761>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b/d4/17/e0/4f/d417e04f-3e6d-4bcf-994a-510d3e57c630>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t/5b/89/a6/b7/5b89a6b7-653c-4d1c-a0df-c7d6b8cd6331>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b/9b/b1/ae/b5/9bb1aeb5-da81-48b2-b117-252eeb481761
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b/d4/17/e0/4f/d417e04f-3e6d-4bcf-994a-510d3e57c630
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ece9bafdfd97812af5d9c064a5205085e3f87e17"'
+      - '"caa64a4d2a36cc4102e0cd2ea32aaee7c3d21205"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/b/9b/b1/ae/b5/9bb1aeb5-da81-48b2-b117-252eeb481761>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/b/d4/17/e0/4f/d417e04f-3e6d-4bcf-994a-510d3e57c630>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t/28/ac/b8/6e/28acb86e-7d4d-446f-b396-60054ef92411
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t/5b/89/a6/b7/5b89a6b7-653c-4d1c-a0df-c7d6b8cd6331
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cc8c5eaaec9ccb3d8697fda2e82e795052d499f2"'
+      - '"b58fd4b26306e39923e0000389fd77ce950fd328"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4/t/28/ac/b8/6e/28acb86e-7d4d-446f-b396-60054ef92411>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805/t/5b/89/a6/b7/5b89a6b7-653c-4d1c-a0df-c7d6b8cd6331>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4</field><field
+        name="id">anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318421589020","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ff/0c/dd/f9/ff0cddf9-08f0-4da6-aa24-4184449fb0f4","@type":"oa:Annotation","hasBody":"_:g70318421589020","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312765576500","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/d2/38/12/d1/d23812d1-4bf4-4841-b756-c6e565f79805","@type":"oa:Annotation","hasBody":"_:g70312765576500","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>12}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/text/x-json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/json/behaves_like_Accept_header_determines_media_type/text/x-json.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b50bcb6b33a890f76f227223c0cbfdac79c20120"'
+      - '"3e451a7fdf64b7e412543cb7120a3c67d06dfc26"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0418ffca9296740a99a9e6feffba741bb20f5d33"'
+      - '"20146980e02ef1b6201d3a80d2464df710e76a65"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d08153793eaa563e439e5844d2ebb5bd8050f467"'
+      - '"5a69b847cf862df9c58bbdc3872847534ef014a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:11 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7c76e7550c8a7f696b9348de427590a2307d1ec9"'
+      - '"b26ce7a37ff936b65b0895715d631dafa97fd2dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b/0f/f5/b3/b0/0ff5b3b0-e02c-49de-b992-d4a23e18ce92
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b/52/26/26/44/52262644-eb54-414b-8b9d-0f07e8b61c1e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b/0f/f5/b3/b0/0ff5b3b0-e02c-49de-b992-d4a23e18ce92
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b/52/26/26/44/52262644-eb54-414b-8b9d-0f07e8b61c1e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0be55eb451b3ef4f7fcacc097a3a07c028ba1a92"'
+      - '"9f25fdc818344557011a96e6abb9a87d84d7294b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2fcc2ff73f22c2a14eb54a757e1df6153020d71a"'
+      - '"24e41f0c27e18df3c8bdc8c4c4985d04a411a456"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t/2f/10/5a/3f/2f105a3f-b6b1-4d9e-8b5f-e16d3fc5ee68
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t/83/17/92/c9/831792c9-7e44-4861-a3e5-cf77e45f9fb5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t/2f/10/5a/3f/2f105a3f-b6b1-4d9e-8b5f-e16d3fc5ee68
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t/83/17/92/c9/831792c9-7e44-4861-a3e5-cf77e45f9fb5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cc39537d9595331d2164cd6b830b803212ece1ed"'
+      - '"6bbd901560e9152e3555decb64d9440d7946ccef"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b/0f/f5/b3/b0/0ff5b3b0-e02c-49de-b992-d4a23e18ce92>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t/2f/10/5a/3f/2f105a3f-b6b1-4d9e-8b5f-e16d3fc5ee68>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b/52/26/26/44/52262644-eb54-414b-8b9d-0f07e8b61c1e>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t/83/17/92/c9/831792c9-7e44-4861-a3e5-cf77e45f9fb5>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b/0f/f5/b3/b0/0ff5b3b0-e02c-49de-b992-d4a23e18ce92
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b/52/26/26/44/52262644-eb54-414b-8b9d-0f07e8b61c1e
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7c76e7550c8a7f696b9348de427590a2307d1ec9"'
+      - '"b26ce7a37ff936b65b0895715d631dafa97fd2dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/b/0f/f5/b3/b0/0ff5b3b0-e02c-49de-b992-d4a23e18ce92>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/b/52/26/26/44/52262644-eb54-414b-8b9d-0f07e8b61c1e>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t/2f/10/5a/3f/2f105a3f-b6b1-4d9e-8b5f-e16d3fc5ee68
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t/83/17/92/c9/831792c9-7e44-4861-a3e5-cf77e45f9fb5
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2fcc2ff73f22c2a14eb54a757e1df6153020d71a"'
+      - '"24e41f0c27e18df3c8bdc8c4c4985d04a411a456"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d/t/2f/10/5a/3f/2f105a3f-b6b1-4d9e-8b5f-e16d3fc5ee68>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330/t/83/17/92/c9/831792c9-7e44-4861-a3e5-cf77e45f9fb5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d</field><field
+        name="id">anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318375209920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/fa/2a/0d/09/fa2a0d09-0ca2-4e08-8662-abd841d5434d","@type":"oa:Annotation","hasBody":"_:g70318375209920","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312721618660","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/66/e4/82/cb/66e482cb-2b39-4544-8db7-5dff54606330","@type":"oa:Annotation","hasBody":"_:g70312721618660","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>8}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/context_specified_for_non-json_returns_non-json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/context_specified_for_non-json_returns_non-json.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"042e1489fdab0fd75dc81df64ce2cb99df9e5ffb"'
+      - '"83fb8582928b9fe5aecbffc45303e4f08c9ca0ed"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"65c97fa913bd73955427c38919409d29b52d7334"'
+      - '"cae72c1659578c8a225662fc33af1922e1a8bfac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2ed6645b10fb47a195a91abbc96a3254d3bd9851"'
+      - '"851856c0c303dec6282febd9fa92926d09fa8dc2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3b41fdc343ce556b65f5fdaaf0a58fe1f11eaa30"'
+      - '"e49e139f14d5973111417ce72c355d03394cc085"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b/ae/e4/42/b7/aee442b7-2c20-4f25-8b4e-80e78ddf2e0c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b/d2/b5/d1/a4/d2b5d1a4-d91f-49d0-81a9-131052751e94
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b/ae/e4/42/b7/aee442b7-2c20-4f25-8b4e-80e78ddf2e0c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b/d2/b5/d1/a4/d2b5d1a4-d91f-49d0-81a9-131052751e94
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7d481d5e65d6e897474ada694f9972f25a9a7557"'
+      - '"41870f4ee538656a2e691f6bb391581a08b229f0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"92614b566d1f141d8ecc7429e7da8ce61afbde35"'
+      - '"9cedd5d1e5007a8b8e5b64d3a48cc2f439ded410"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t/94/45/fc/0f/9445fc0f-4024-4a9d-8ffe-12ccfa687132
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t/96/b5/b2/d4/96b5b2d4-65d4-4add-bd87-b3893107c5e6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t/94/45/fc/0f/9445fc0f-4024-4a9d-8ffe-12ccfa687132
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t/96/b5/b2/d4/96b5b2d4-65d4-4add-bd87-b3893107c5e6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7828883316d786e92470b8a4bd3b690fe3b80247"'
+      - '"babfb078e9a70d2604a5f396519c934aacef9efb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t/94/45/fc/0f/9445fc0f-4024-4a9d-8ffe-12ccfa687132>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b/ae/e4/42/b7/aee442b7-2c20-4f25-8b4e-80e78ddf2e0c>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b/d2/b5/d1/a4/d2b5d1a4-d91f-49d0-81a9-131052751e94>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t/96/b5/b2/d4/96b5b2d4-65d4-4add-bd87-b3893107c5e6>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b/ae/e4/42/b7/aee442b7-2c20-4f25-8b4e-80e78ddf2e0c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b/d2/b5/d1/a4/d2b5d1a4-d91f-49d0-81a9-131052751e94
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3b41fdc343ce556b65f5fdaaf0a58fe1f11eaa30"'
+      - '"e49e139f14d5973111417ce72c355d03394cc085"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/b/ae/e4/42/b7/aee442b7-2c20-4f25-8b4e-80e78ddf2e0c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/b/d2/b5/d1/a4/d2b5d1a4-d91f-49d0-81a9-131052751e94>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t/94/45/fc/0f/9445fc0f-4024-4a9d-8ffe-12ccfa687132
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t/96/b5/b2/d4/96b5b2d4-65d4-4add-bd87-b3893107c5e6
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"92614b566d1f141d8ecc7429e7da8ce61afbde35"'
+      - '"9cedd5d1e5007a8b8e5b64d3a48cc2f439ded410"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f/t/94/45/fc/0f/9445fc0f-4024-4a9d-8ffe-12ccfa687132>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2/t/96/b5/b2/d4/96b5b2d4-65d4-4add-bd87-b3893107c5e6>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f</field><field
+        name="id">anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318402664040","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/4a/dc/f2/ce/4adcf2ce-6bd9-4354-9392-d5d02821e57f","@type":"oa:Annotation","hasBody":"_:g70318402664040","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312745560680","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/a2/92/f3/78/a292f378-49f2-4580-83bc-c467c04733f2","@type":"oa:Annotation","hasBody":"_:g70312745560680","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/iiif/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/iiif/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6aec3e4d49a2831dfbdfffecb9917fa332249705"'
+      - '"009511ccd971dadbd288de43d3eb4ea086fbef0a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5b43cedbd151c771aaa8a06d957a54a67cacf825"'
+      - '"7d0bd85ad24848a71923641027434ba71bd66b4a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"63eb203e59700328a4da431934416f5220427e5a"'
+      - '"a341edb551440e6e0daddeeb27a384348515a539"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a4f31b991e9291ef20a5a044779b6d128e6e3ddd"'
+      - '"066d38fc63ca96aa89939e762953bf18dc796c93"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t/a5/17/59/6e/a517596e-3a65-4ee3-b7c7-383d7a070cbe
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t/f2/a6/49/7d/f2a6497d-2889-4f4f-a18a-50cc2cc96fbd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t/a5/17/59/6e/a517596e-3a65-4ee3-b7c7-383d7a070cbe
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t/f2/a6/49/7d/f2a6497d-2889-4f4f-a18a-50cc2cc96fbd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d5c2912e26db79b62361b6bf433239c08f094005"'
+      - '"38ba841eb48fa2ff057570e5fdfd254fe36c8b64"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t/a5/17/59/6e/a517596e-3a65-4ee3-b7c7-383d7a070cbe>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t/f2/a6/49/7d/f2a6497d-2889-4f4f-a18a-50cc2cc96fbd>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t/a5/17/59/6e/a517596e-3a65-4ee3-b7c7-383d7a070cbe
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t/f2/a6/49/7d/f2a6497d-2889-4f4f-a18a-50cc2cc96fbd
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a4f31b991e9291ef20a5a044779b6d128e6e3ddd"'
+      - '"066d38fc63ca96aa89939e762953bf18dc796c93"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02/t/a5/17/59/6e/a517596e-3a65-4ee3-b7c7-383d7a070cbe>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1/t/f2/a6/49/7d/f2a6497d-2889-4f4f-a18a-50cc2cc96fbd>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02</field><field
+        name="id">anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/6c/1e/4a/1c/6c1e4a1c-c028-46c0-9d7c-482682682d02","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/2d/eb/b1/24/2debb124-9fc3-4f3f-b5c2-1c20963e25a1","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/missing_context_returns_oa_dated.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/missing_context_returns_oa_dated.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a9dbef611a524a2168b96712e16a8e0209d11872"'
+      - '"b62867ec62eab8602cf57066c92d21ad795403dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a1003a88fd825ad8c4ab4e18c3253ff28eccd922"'
+      - '"148c38807ee94b4aa2848f17ea571a3f624b8727"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cd9d9c700d1ee1db414b03a886353c8b5a19d68a"'
+      - '"03c300e0f5197e6693f732b37580c0844bb69658"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f6bb972ac3c11e0fe2cd31b0b08947ee9fe7f607"'
+      - '"a281d5784f568a68cd16d151d5aae14e5fd5ac1a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t/90/94/41/a5/909441a5-eba4-47aa-b3f6-71ad93ff4346
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t/25/53/63/ac/255363ac-fbfb-45bc-a4ac-d6d0757d13f5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t/90/94/41/a5/909441a5-eba4-47aa-b3f6-71ad93ff4346
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t/25/53/63/ac/255363ac-fbfb-45bc-a4ac-d6d0757d13f5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2d3c917e1eff5074429f7fdea0d83b2b6bc2f23c"'
+      - '"12ece608e1dbe52dbcc59aa1e9ac41244b2640b5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t/90/94/41/a5/909441a5-eba4-47aa-b3f6-71ad93ff4346>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t/25/53/63/ac/255363ac-fbfb-45bc-a4ac-d6d0757d13f5>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t/90/94/41/a5/909441a5-eba4-47aa-b3f6-71ad93ff4346
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t/25/53/63/ac/255363ac-fbfb-45bc-a4ac-d6d0757d13f5
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f6bb972ac3c11e0fe2cd31b0b08947ee9fe7f607"'
+      - '"a281d5784f568a68cd16d151d5aae14e5fd5ac1a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841/t/90/94/41/a5/909441a5-eba4-47aa-b3f6-71ad93ff4346>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7/t/25/53/63/ac/255363ac-fbfb-45bc-a4ac-d6d0757d13f5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841</field><field
+        name="id">anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/31/cc/6c/d5/31cc6cd5-1f31-43aa-b276-d1c312fa2841","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3b/9e/0f/51/3b9e0f51-8d8f-4d6f-83bc-95590db6a3b7","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>13}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/oa_dated/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/oa_dated/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6c1db3efe8543677a2d79bdeb4e285d4c6214f95"'
+      - '"b62867ec62eab8602cf57066c92d21ad795403dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2e4ce44ffb6bc3e8daf06f2fbf47127553e7017d"'
+      - '"f5c03beda3bf8bf50023e81c24cdc1a2499f84f3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d5511e58dd63da4c4e2ebf1bc414a86bb71e8ad4"'
+      - '"705525121b5040734f686a2283212093e8a962dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c1ac6b40e2a463d53e69edb744926b3f3f4cea01"'
+      - '"8ef930d9e83c32f3deeff6561e58c58adee144aa"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t/9e/3a/e8/12/9e3ae812-58c9-43f1-95d8-86cbcee28431
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t/5b/f6/49/a8/5bf649a8-f59b-4b72-9389-a2ec1810ef04
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t/9e/3a/e8/12/9e3ae812-58c9-43f1-95d8-86cbcee28431
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t/5b/f6/49/a8/5bf649a8-f59b-4b72-9389-a2ec1810ef04
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"92392b54e1edf7a95e198ef006b17aad4360a331"'
+      - '"2d0d6f5a7003c9fd7b589332f79e640766f8a38a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t/9e/3a/e8/12/9e3ae812-58c9-43f1-95d8-86cbcee28431>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t/5b/f6/49/a8/5bf649a8-f59b-4b72-9389-a2ec1810ef04>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t/9e/3a/e8/12/9e3ae812-58c9-43f1-95d8-86cbcee28431
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t/5b/f6/49/a8/5bf649a8-f59b-4b72-9389-a2ec1810ef04
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c1ac6b40e2a463d53e69edb744926b3f3f4cea01"'
+      - '"8ef930d9e83c32f3deeff6561e58c58adee144aa"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba/t/9e/3a/e8/12/9e3ae812-58c9-43f1-95d8-86cbcee28431>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb/t/5b/f6/49/a8/5bf649a8-f59b-4b72-9389-a2ec1810ef04>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba</field><field
+        name="id">anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/45/73/32/02/45733202-e375-4696-ae58-e13c60ed19ba","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e1/0c/57/cb/e10c57cb-e364-4d40-a7f9-29d30d1c70bb","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/oa_generic/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/json_be_nice_and_pay_attention_to_profile_/oa_generic/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3df84e0a5eb67f7b64da8f3ee4198da3b6e642a7"'
+      - '"71527a1f92fb7edf544786d80d6cb5da42a72a7e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"78c910f44d7a1acd32606089c0827a03550c45b6"'
+      - '"17e78aa6d78f81b2fd30ce14a5bbd8ad5b736a9f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"73cdf9ea736fdb1d47a192b60bb29e3787d89a37"'
+      - '"735de1e07810152a9bf557c1b668780094a2c019"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ac93b7bc1d4e85b7c8a2d7fa99688b8da47fd5bf"'
+      - '"3093d2b376ac322aae4098246f9e714dc7c84892"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t/7b/fb/57/3c/7bfb573c-7444-4c9b-8d15-098fec7fe035
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t/b7/d9/7a/6a/b7d97a6a-8675-4a13-a06e-d3b3bbb41e95
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t/7b/fb/57/3c/7bfb573c-7444-4c9b-8d15-098fec7fe035
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t/b7/d9/7a/6a/b7d97a6a-8675-4a13-a06e-d3b3bbb41e95
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b4826d2dd0693927c5dc9a4c0ceb27445f0b2ed8"'
+      - '"030de3cc3818f9439c85cdca6332def67d78686f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t/7b/fb/57/3c/7bfb573c-7444-4c9b-8d15-098fec7fe035>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t/b7/d9/7a/6a/b7d97a6a-8675-4a13-a06e-d3b3bbb41e95>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t/7b/fb/57/3c/7bfb573c-7444-4c9b-8d15-098fec7fe035
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t/b7/d9/7a/6a/b7d97a6a-8675-4a13-a06e-d3b3bbb41e95
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ac93b7bc1d4e85b7c8a2d7fa99688b8da47fd5bf"'
+      - '"3093d2b376ac322aae4098246f9e714dc7c84892"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4/t/7b/fb/57/3c/7bfb573c-7444-4c9b-8d15-098fec7fe035>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f/t/b7/d9/7a/6a/b7d97a6a-8675-4a13-a06e-d3b3bbb41e95>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4</field><field
+        name="id">anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e0/e9/6d/b0/e0e96db0-9614-490c-938e-1d9e17fce1b4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ab/d8/f9/74/abd8f974-c0c8-4284-acf7-68dfd96ddb9f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/iiif/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/iiif/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d4b79903bb05b640de2cc707f1f916fa9402e7d0"'
+      - '"77cafed62586fff8ce9f696c61887899b41ee381"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ffffd1102c1af455830abf1e7b0bea7fa619d28a"'
+      - '"80be3f27fed2d58ae2fe03afbb1a73f5cf64a77f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"80b0ae6a5a37895afb5de71301e1f01a72793b3a"'
+      - '"c818f872d96c22e7122a287e2e912a8848db4fff"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bc28e4a9671a26dfab42092efff0197ccae9f310"'
+      - '"cee88cae64d32a79ee0cd731e33e983b355768c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t/71/13/6a/d9/71136ad9-ec68-4064-aa6d-3646fb3f3bd6
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t/bc/cb/33/1b/bccb331b-9d86-48ca-ab1f-1fc5248c5c0e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t/71/13/6a/d9/71136ad9-ec68-4064-aa6d-3646fb3f3bd6
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t/bc/cb/33/1b/bccb331b-9d86-48ca-ab1f-1fc5248c5c0e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bfceb75801bd7c15d0ce0b8bd4947e1ca287ba12"'
+      - '"4e67bab58f5b87bce0d08e6a55d21a9060e53eb8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t/71/13/6a/d9/71136ad9-ec68-4064-aa6d-3646fb3f3bd6>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t/bc/cb/33/1b/bccb331b-9d86-48ca-ab1f-1fc5248c5c0e>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t/71/13/6a/d9/71136ad9-ec68-4064-aa6d-3646fb3f3bd6
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t/bc/cb/33/1b/bccb331b-9d86-48ca-ab1f-1fc5248c5c0e
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bc28e4a9671a26dfab42092efff0197ccae9f310"'
+      - '"cee88cae64d32a79ee0cd731e33e983b355768c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:15 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc/t/71/13/6a/d9/71136ad9-ec68-4064-aa6d-3646fb3f3bd6>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f/t/bc/cb/33/1b/bccb331b-9d86-48ca-ab1f-1fc5248c5c0e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc</field><field
+        name="id">anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/43/2d/d6/c0/432dd6c0-4aeb-4b27-9f2b-c9a436e9d9fc","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/42/21/81/56/42218156-040a-47de-b393-1128cdb0838f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/missing_context_returns_oa_dated.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/missing_context_returns_oa_dated.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0294803eee33bd85c78496ed35b75e22aa8078b0"'
+      - '"d1a11839e4834561466f4828d0e9f06272709793"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1d2a6d2f73b29a1a36c7dc2fa67a935e78b4898b"'
+      - '"9d56d5a8880b6cf91f730e11cbeaaeaa428f39b6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"44c79ed96b18e69eda42510702ec87f812cc1d5c"'
+      - '"b90ccb445e5cc08fee426e5c98e2c60ab49cdbdd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7cfa727d4f84dad4940966144c724cad18edd23c"'
+      - '"19536b59f307c0a6d37ba469868fba230b8bb5f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t/9a/9e/6c/51/9a9e6c51-83cc-408d-a701-34fd40a34d6b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t/bf/5d/14/93/bf5d1493-4de2-4ea5-9ff8-a5544d0a9def
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t/9a/9e/6c/51/9a9e6c51-83cc-408d-a701-34fd40a34d6b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t/bf/5d/14/93/bf5d1493-4de2-4ea5-9ff8-a5544d0a9def
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"44936a420bdc39265feabcef604ebea5e56db939"'
+      - '"f93ee494b2db77e0dee1774d13baca7b38f9659d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t/9a/9e/6c/51/9a9e6c51-83cc-408d-a701-34fd40a34d6b>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t/bf/5d/14/93/bf5d1493-4de2-4ea5-9ff8-a5544d0a9def>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t/9a/9e/6c/51/9a9e6c51-83cc-408d-a701-34fd40a34d6b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t/bf/5d/14/93/bf5d1493-4de2-4ea5-9ff8-a5544d0a9def
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7cfa727d4f84dad4940966144c724cad18edd23c"'
+      - '"19536b59f307c0a6d37ba469868fba230b8bb5f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2/t/9a/9e/6c/51/9a9e6c51-83cc-408d-a701-34fd40a34d6b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7/t/bf/5d/14/93/bf5d1493-4de2-4ea5-9ff8-a5544d0a9def>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2</field><field
+        name="id">anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/c1/44/13/3b/c144133b-79bf-4a7e-86f7-6db591e4f3f2","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e9/6b/8e/d7/e96b8ed7-8346-4f3a-8ff1-5832deb633e7","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>27}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/oa_dated/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/oa_dated/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"18def4f9319b8e222e482fcd8f0fb4b4ecfc6fea"'
+      - '"e5b2168371be28a47fb4b2ed99d8459764bdc484"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3a7dc447830c3f45e3a4fddec2760cc1b54389dd"'
+      - '"3f66605ce5a136bee282fd8c9b3d54088a7cef9c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3df02eaefea7cbdc33764da08df6ed7e6f1556dc"'
+      - '"da9bcfc07bfb995b9ff5ac05f4f24dc8eec7b178"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6cf5ce4e3f9af03a68391ffa14bc1756c17e681f"'
+      - '"85928b250ce9f0fcabd6391fd511774106603c5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t/ec/cb/a1/c3/eccba1c3-fb54-4ad2-aafe-3ae7b6b7ab94
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t/c0/24/51/78/c0245178-7627-48c5-80c6-53baf631da59
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t/ec/cb/a1/c3/eccba1c3-fb54-4ad2-aafe-3ae7b6b7ab94
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t/c0/24/51/78/c0245178-7627-48c5-80c6-53baf631da59
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e757decd757f0f65375fa8e911bc81a07193ab10"'
+      - '"8d586a1af2f29e8c9a9994c2a2c1522713d50309"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t/ec/cb/a1/c3/eccba1c3-fb54-4ad2-aafe-3ae7b6b7ab94>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t/c0/24/51/78/c0245178-7627-48c5-80c6-53baf631da59>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t/ec/cb/a1/c3/eccba1c3-fb54-4ad2-aafe-3ae7b6b7ab94
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t/c0/24/51/78/c0245178-7627-48c5-80c6-53baf631da59
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6cf5ce4e3f9af03a68391ffa14bc1756c17e681f"'
+      - '"85928b250ce9f0fcabd6391fd511774106603c5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e/t/ec/cb/a1/c3/eccba1c3-fb54-4ad2-aafe-3ae7b6b7ab94>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55/t/c0/24/51/78/c0245178-7627-48c5-80c6-53baf631da59>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e</field><field
+        name="id">anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/63/82/63/16/63826316-3c78-43ce-a217-e47bed12a96e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/a9/a0/f8/b0/a9a0f8b0-e77e-4436-8f0f-739280acaf55","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/oa_generic/behaves_like_creates_anno_successfully/.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/oa_generic/behaves_like_creates_anno_successfully/.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"91efe4c5727257cd6704a793a927c35ae299b34a"'
+      - '"24f6455a463c139f75abc1c4b72953db9455be78"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"460887dada1c76b18eab404c873a08f016351b9b"'
+      - '"588e6ba83a9e27f8b0560ca2ab66145fdc2ee76f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1c2f4ea0b1a9f7c2bb34311cb2a1cad09495e987"'
+      - '"0343474dd53d578b4bbb7ab883916ce48c63185e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c559c4678fee95da9bc57ca451d3a5bd8f0135ee"'
+      - '"a609aa5939094ade9ba1ff59fac549908e033347"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t/c4/22/f8/00/c422f800-d93a-44ac-a48b-e406d75fe9bd
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t/c0/39/bb/17/c039bb17-b54d-4b9e-bd48-24ff44d05a44
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t/c4/22/f8/00/c422f800-d93a-44ac-a48b-e406d75fe9bd
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t/c0/39/bb/17/c039bb17-b54d-4b9e-bd48-24ff44d05a44
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"328d317ea7c9a6392b96bb7dec97607bdf9f4b41"'
+      - '"46d64e27f3f7fd09a4b51cd59a7d989c03ab6d30"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t/c4/22/f8/00/c422f800-d93a-44ac-a48b-e406d75fe9bd>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t/c0/39/bb/17/c039bb17-b54d-4b9e-bd48-24ff44d05a44>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t/c4/22/f8/00/c422f800-d93a-44ac-a48b-e406d75fe9bd
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t/c0/39/bb/17/c039bb17-b54d-4b9e-bd48-24ff44d05a44
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c559c4678fee95da9bc57ca451d3a5bd8f0135ee"'
+      - '"a609aa5939094ade9ba1ff59fac549908e033347"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef/t/c4/22/f8/00/c422f800-d93a-44ac-a48b-e406d75fe9bd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c/t/c0/39/bb/17/c039bb17-b54d-4b9e-bd48-24ff44d05a44>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef</field><field
+        name="id">anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/1e/e8/6a/45/1ee86a45-3176-48b6-b117-3d5030edabef","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/2c/60/2b/cc/2c602bcc-3832-47e2-9db7-c6cd4ccc243c","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>13}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/unrecognized_context_returns_oa_dated.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Accept_header_profile_specifies_context_URL/jsonld/unrecognized_context_returns_oa_dated.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0294803eee33bd85c78496ed35b75e22aa8078b0"'
+      - '"d1a11839e4834561466f4828d0e9f06272709793"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:13 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a681f6d5d2070fb5fb7f98c4a0aa777f877ca033"'
+      - '"9650ce7b7ee1973e7cf085975757e8b6c1c1ed22"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9dfefe57dd6e0e505944ef14f6d0b050fb3aea26"'
+      - '"db8c8a0873d86ae43b8a338f63b8fcbbd0142d18"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9edfe3d96e94fbea50784ad22320eebfcd27797d"'
+      - '"6fe254c0ecd10b6e5f2dcb3c51acd2b8adab62ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t/1f/d2/9a/f9/1fd29af9-3214-42d1-b8af-c3f390a739f2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t/e6/09/ad/eb/e609adeb-daf4-4baf-9675-6b2af5a13981
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t/1f/d2/9a/f9/1fd29af9-3214-42d1-b8af-c3f390a739f2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t/e6/09/ad/eb/e609adeb-daf4-4baf-9675-6b2af5a13981
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"aa05d65b4736634df134ed8d6ae365faabf27340"'
+      - '"6f54ff5d69bf0a79b118a5e3d6cca06d2bd8826d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t/1f/d2/9a/f9/1fd29af9-3214-42d1-b8af-c3f390a739f2>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t/e6/09/ad/eb/e609adeb-daf4-4baf-9675-6b2af5a13981>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t/1f/d2/9a/f9/1fd29af9-3214-42d1-b8af-c3f390a739f2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t/e6/09/ad/eb/e609adeb-daf4-4baf-9675-6b2af5a13981
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9edfe3d96e94fbea50784ad22320eebfcd27797d"'
+      - '"6fe254c0ecd10b6e5f2dcb3c51acd2b8adab62ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:14 GMT
+      - Wed, 08 Jul 2015 18:54:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642/t/1f/d2/9a/f9/1fd29af9-3214-42d1-b8af-c3f390a739f2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa/t/e6/09/ad/eb/e609adeb-daf4-4baf-9675-6b2af5a13981>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642</field><field
+        name="id">anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/51/94/28/33/51942833-c982-4a42-bf31-6376d815e642","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/24/fc/a8/4b/24fca84b-2824-436a-9607-ed1fef7bdcaa","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/context_specified_for_non-json_returns_non-json.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/context_specified_for_non-json_returns_non-json.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8e8bccf70cc41b595cfb4670ee7dc762bd93c2c0"'
+      - '"230c37c6b7ca8e9a2fdfdb5190d25043787ecc7c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0748d340c2729b2a6ad5d8a2d0e2376a497f592a"'
+      - '"3700a3e2f491598e6f39dc0c3b82a80f3ceb0ac1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a41fe515fa80c341b841975fe7bbd4e09f376bb4"'
+      - '"f681b8cbe4ed3550047682eb8c2fa3f5a155ad79"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"69cea1c09f7dd57dcb67b09160947d0b4f179fd5"'
+      - '"c0923d9272e0633b87da1de853b9b2beee4291ea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b/ce/1a/f3/78/ce1af378-ca97-4bad-b03a-74c87d267c8d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b/f5/59/57/17/f5595717-4470-4de9-be13-80d6b4377dd5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b/ce/1a/f3/78/ce1af378-ca97-4bad-b03a-74c87d267c8d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b/f5/59/57/17/f5595717-4470-4de9-be13-80d6b4377dd5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3c8556d8aa288d429ce1fd122ee2585f7411c343"'
+      - '"4f1dbc3c73274e6fd7b46f6f846a4e979b12f1f6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e74dcf0f9e253cc9b432e8b80e060386fe2b4b87"'
+      - '"07c5ca3b4cd7147fc365f2eca5710de7aee25d5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t/a0/25/8a/8f/a0258a8f-9965-4970-89d3-16cb9b898222
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t/25/00/8c/bc/25008cbc-c18c-442e-afac-0d702578dc8e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t/a0/25/8a/8f/a0258a8f-9965-4970-89d3-16cb9b898222
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t/25/00/8c/bc/25008cbc-c18c-442e-afac-0d702578dc8e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"35add7d1b782ba9efb4f16d12733506291f40e18"'
+      - '"e652c8a5b7993d7cadb428c524bd3de2e4171d38"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t/a0/25/8a/8f/a0258a8f-9965-4970-89d3-16cb9b898222>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b/ce/1a/f3/78/ce1af378-ca97-4bad-b03a-74c87d267c8d>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t/25/00/8c/bc/25008cbc-c18c-442e-afac-0d702578dc8e>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b/f5/59/57/17/f5595717-4470-4de9-be13-80d6b4377dd5>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b/ce/1a/f3/78/ce1af378-ca97-4bad-b03a-74c87d267c8d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b/f5/59/57/17/f5595717-4470-4de9-be13-80d6b4377dd5
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"69cea1c09f7dd57dcb67b09160947d0b4f179fd5"'
+      - '"c0923d9272e0633b87da1de853b9b2beee4291ea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/b/ce/1a/f3/78/ce1af378-ca97-4bad-b03a-74c87d267c8d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/b/f5/59/57/17/f5595717-4470-4de9-be13-80d6b4377dd5>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t/a0/25/8a/8f/a0258a8f-9965-4970-89d3-16cb9b898222
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t/25/00/8c/bc/25008cbc-c18c-442e-afac-0d702578dc8e
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e74dcf0f9e253cc9b432e8b80e060386fe2b4b87"'
+      - '"07c5ca3b4cd7147fc365f2eca5710de7aee25d5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837/t/a0/25/8a/8f/a0258a8f-9965-4970-89d3-16cb9b898222>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391/t/25/00/8c/bc/25008cbc-c18c-442e-afac-0d702578dc8e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837</field><field
+        name="id">anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318433535380","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/c4/9d/81/41/c49d8141-2dd8-48bc-bfbd-9e1a53404837","@type":"oa:Annotation","hasBody":"_:g70318433535380","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312759032180","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/18/46/83/7b/1846837b-893c-4b55-a7c7-7ef2d4db0391","@type":"oa:Annotation","hasBody":"_:g70312759032180","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>10}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/iiif/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/iiif/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"707204f0f9638d81f621f6dffeb75aa66793268b"'
+      - '"5551c56186514e63705eb15861acd9427acb3559"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"091c4ac0dec9f721f8d26dddd25543739e55282a"'
+      - '"1e645516991c277317f2754c6642865447ce379a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"05538090cc65cd8fff4e7d25b6477e01e0572eb1"'
+      - '"3b531ab0c26f420fb7ac66fb3fb0337ddcfe9bc0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"16b3023222bfc716671198b19e0b3f4db575c1d8"'
+      - '"8fa1d0466fe4f64d1b4401545998ecdff4400ea2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t/7b/57/87/34/7b578734-cc2a-4891-ab6f-09b2b8dc2b5c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t/23/2d/b6/77/232db677-88d6-48ed-a24e-38ec9176a6f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t/7b/57/87/34/7b578734-cc2a-4891-ab6f-09b2b8dc2b5c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t/23/2d/b6/77/232db677-88d6-48ed-a24e-38ec9176a6f8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"372cf95f987205c102dc575d4e9e68f251ec0567"'
+      - '"a8c870ed004de29c574c26cb3554494018b56140"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t/7b/57/87/34/7b578734-cc2a-4891-ab6f-09b2b8dc2b5c>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t/23/2d/b6/77/232db677-88d6-48ed-a24e-38ec9176a6f8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t/7b/57/87/34/7b578734-cc2a-4891-ab6f-09b2b8dc2b5c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t/23/2d/b6/77/232db677-88d6-48ed-a24e-38ec9176a6f8
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"16b3023222bfc716671198b19e0b3f4db575c1d8"'
+      - '"8fa1d0466fe4f64d1b4401545998ecdff4400ea2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d/t/7b/57/87/34/7b578734-cc2a-4891-ab6f-09b2b8dc2b5c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c/t/23/2d/b6/77/232db677-88d6-48ed-a24e-38ec9176a6f8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d</field><field
+        name="id">anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/5c/0f/da/dd/5c0fdadd-2680-47bf-8d11-8bf833d12c6d","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ce/9d/44/89/ce9d4489-2704-4810-b109-c818f670357c","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>17}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/iiif/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/iiif/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"582f2ced01ad6b1427d33b685604e9943f211f3b"'
+      - '"5551c56186514e63705eb15861acd9427acb3559"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4b73c9c07b26fed588ae1c9d4fcbcf37abeec8e3"'
+      - '"86267ab3c23f0411611d7636719a20109f9c9130"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b619dde4480cf0b527ab64a880d30e5481ab9e1e"'
+      - '"468d3b487f428481bac65eb02341212f94d7f174"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7b82db4a23b44461a7de823c02f446572bf4b5ca"'
+      - '"1bd3801f9193400014115933288b066a15f5a66d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t/37/0a/ea/7d/370aea7d-7476-4c99-97fb-67154156e8b7
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t/dc/ff/22/fa/dcff22fa-6381-4bf4-90f3-84c2553871e4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t/37/0a/ea/7d/370aea7d-7476-4c99-97fb-67154156e8b7
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t/dc/ff/22/fa/dcff22fa-6381-4bf4-90f3-84c2553871e4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"838eb20913715c0702548a53590de1f28eb9c1aa"'
+      - '"b1cbb0f9525c2f7c0b9757160e75bf2d363808e5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t/37/0a/ea/7d/370aea7d-7476-4c99-97fb-67154156e8b7>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t/dc/ff/22/fa/dcff22fa-6381-4bf4-90f3-84c2553871e4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t/37/0a/ea/7d/370aea7d-7476-4c99-97fb-67154156e8b7
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t/dc/ff/22/fa/dcff22fa-6381-4bf4-90f3-84c2553871e4
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b82db4a23b44461a7de823c02f446572bf4b5ca"'
+      - '"1bd3801f9193400014115933288b066a15f5a66d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5/t/37/0a/ea/7d/370aea7d-7476-4c99-97fb-67154156e8b7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8/t/dc/ff/22/fa/dcff22fa-6381-4bf4-90f3-84c2553871e4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5</field><field
+        name="id">anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/98/92/10/d1/989210d1-2406-4ce2-a0f9-a091c46d1db5","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e3/d6/98/4e/e3d6984e-8c4b-4e55-bbb2-5962e17df3b8","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"57388e81b4fd6ed80ea45ac1aa9677ddeeca873f"'
+      - '"25e43e6ffd605883c97b7f59dc674b7f36376aa7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5021e005bccdb031d0ef3ffd5426defbc1d39b95"'
+      - '"ac52213a22c39bcb24404d1ce4c02d55b061fa6d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"310b98ad2b4be3619a57d59420e04231bc007711"'
+      - '"b1205f04f6f1e6cee6ecfda7cd801f3fcdb2c54d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"30e2452cdf119450665dff31c1960902e39e50e9"'
+      - '"4290a5a1ab6d6317ea04402173c8d365896601c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t/4c/ea/87/d7/4cea87d7-6dfe-4497-a18a-54f19aaf31ae
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t/f8/8c/fe/21/f88cfe21-1460-4316-8cce-3e8fbaf043b6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t/4c/ea/87/d7/4cea87d7-6dfe-4497-a18a-54f19aaf31ae
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t/f8/8c/fe/21/f88cfe21-1460-4316-8cce-3e8fbaf043b6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ea06f382cfcb2930f8ce9bda3961a2ebc55c204"'
+      - '"1a3b647866ed11b99b6e0388e66522e96535c0f0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t/4c/ea/87/d7/4cea87d7-6dfe-4497-a18a-54f19aaf31ae>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t/f8/8c/fe/21/f88cfe21-1460-4316-8cce-3e8fbaf043b6>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t/4c/ea/87/d7/4cea87d7-6dfe-4497-a18a-54f19aaf31ae
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t/f8/8c/fe/21/f88cfe21-1460-4316-8cce-3e8fbaf043b6
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"30e2452cdf119450665dff31c1960902e39e50e9"'
+      - '"4290a5a1ab6d6317ea04402173c8d365896601c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f/t/4c/ea/87/d7/4cea87d7-6dfe-4497-a18a-54f19aaf31ae>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6/t/f8/8c/fe/21/f88cfe21-1460-4316-8cce-3e8fbaf043b6>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f</field><field
+        name="id">anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/d0/ec/68/29/d0ec6829-15f1-4a48-b811-09ae068a478f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/d5/06/f5/7e/d506f57e-7b42-42df-866a-e66600e0e3c6","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a24ed9421504cc0df594ed3db871d29b51eadaec"'
+      - '"f0962377ef03db2ee1584bcb31e236fa7bcf71fb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e5bf465ade85df89bcf9fc9dcb2cb76499da4e8e"'
+      - '"eee73c54ed6c042fd7f1fdf70a22a6a0c8b4d0a1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"233cbff2f0bc1724822076e7a35f0cf6c08000c6"'
+      - '"0cf14a7124931c9213fe115f7e3900156cff1666"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0b20791d353b8ff53a5e9eda4433738f0150805c"'
+      - '"1bde49520d3aa60bcec0a331366576fec7907666"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t/c0/51/0a/52/c0510a52-a054-404d-8f70-c4fdf7473250
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t/d4/b1/a6/1d/d4b1a61d-4e47-4d06-a5c2-9a5f33898944
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t/c0/51/0a/52/c0510a52-a054-404d-8f70-c4fdf7473250
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t/d4/b1/a6/1d/d4b1a61d-4e47-4d06-a5c2-9a5f33898944
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"db505796b0c06b9ea4e8d8dbb34967df9b05e6b5"'
+      - '"a39d0865879e181cb319d968ab083d2cebe44493"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t/c0/51/0a/52/c0510a52-a054-404d-8f70-c4fdf7473250>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t/d4/b1/a6/1d/d4b1a61d-4e47-4d06-a5c2-9a5f33898944>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t/c0/51/0a/52/c0510a52-a054-404d-8f70-c4fdf7473250
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t/d4/b1/a6/1d/d4b1a61d-4e47-4d06-a5c2-9a5f33898944
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0b20791d353b8ff53a5e9eda4433738f0150805c"'
+      - '"1bde49520d3aa60bcec0a331366576fec7907666"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a/t/c0/51/0a/52/c0510a52-a054-404d-8f70-c4fdf7473250>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd/t/d4/b1/a6/1d/d4b1a61d-4e47-4d06-a5c2-9a5f33898944>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a</field><field
+        name="id">anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/fe/2e/bc/c6/fe2ebcc6-2df5-4bd7-8c4c-530ef857167a","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/16/1f/cb/b9/161fcbb9-7124-4b7d-94a5-77e17993f8dd","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/no_link_header_returns_oa_dated.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/no_link_header_returns_oa_dated.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1a91db0932a5bbea18c479e724e74f32356dd23b"'
+      - '"a6a1db83f4f37dffc6e8b1dcb9d038ca8fa9b4df"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0acc7fa6b8bbacc0ba0e61632825241fa4c082d8"'
+      - '"09addc5378bcfdcda186b2e5dfd18adccaf03b3f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"084c6791405a72a473f4939d6ca13036e30f9994"'
+      - '"a5e32b47e6193bbd0979c2485001565e2589cc2d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"55b597bf1e4190f48c0a5e1dca5d78d2ec35189e"'
+      - '"673e0443ac369895d6da1f2806212f4ecf034572"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t/74/5d/32/0c/745d320c-fe33-4cb7-96d0-8a1bd9202d5b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t/92/86/5e/a2/92865ea2-8386-4ba2-aa60-137ca9c85219
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t/74/5d/32/0c/745d320c-fe33-4cb7-96d0-8a1bd9202d5b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t/92/86/5e/a2/92865ea2-8386-4ba2-aa60-137ca9c85219
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"32fe0e1871607d247076e63941a3da7cf3f1ace9"'
+      - '"45ef5d870be4eb8e12ff27ecf97d2f192e9e0367"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t/74/5d/32/0c/745d320c-fe33-4cb7-96d0-8a1bd9202d5b>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t/92/86/5e/a2/92865ea2-8386-4ba2-aa60-137ca9c85219>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t/74/5d/32/0c/745d320c-fe33-4cb7-96d0-8a1bd9202d5b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t/92/86/5e/a2/92865ea2-8386-4ba2-aa60-137ca9c85219
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"55b597bf1e4190f48c0a5e1dca5d78d2ec35189e"'
+      - '"673e0443ac369895d6da1f2806212f4ecf034572"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc/t/74/5d/32/0c/745d320c-fe33-4cb7-96d0-8a1bd9202d5b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a/t/92/86/5e/a2/92865ea2-8386-4ba2-aa60-137ca9c85219>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc</field><field
+        name="id">anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/23/86/a7/87/2386a787-0829-4f7c-99d7-69f8a411b5dc","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/6d/30/98/81/6d309881-4117-4c74-bc91-620d3c9eda7a","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>16}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d79ef35de9cbbbaef7a85c266a859fa369934a3f"'
+      - '"3fd23703d80d78455e13c9a78ad45fdd4090f3be"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ef648bcbfa90fdcb9a4cda7e4d503773c287c190"'
+      - '"0e8f0ac754312c712ca9dbc49089c855dd2a2426"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9a534c3df4ea0b36df94027984049b65d9fd3f03"'
+      - '"3739a6e9d3db02e32be1dcebd741f2573f522f86"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"301ecc2158b004026a519a4703f4fc9dc5c4bf8b"'
+      - '"231db58438e31013739fb5f4b04881e1e02b2b0d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t/76/fb/ec/0b/76fbec0b-a25a-4c18-9e8f-f989671e7170
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t/21/22/ac/88/2122ac88-2fa4-4bd7-bdc6-4a67655646a5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t/76/fb/ec/0b/76fbec0b-a25a-4c18-9e8f-f989671e7170
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t/21/22/ac/88/2122ac88-2fa4-4bd7-bdc6-4a67655646a5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3f52e1f9e75b1b901aa6882dbf3abaa0ddf8a055"'
+      - '"2312baaf88866a71c03f90190efcee92f86689d7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t/76/fb/ec/0b/76fbec0b-a25a-4c18-9e8f-f989671e7170>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t/21/22/ac/88/2122ac88-2fa4-4bd7-bdc6-4a67655646a5>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t/76/fb/ec/0b/76fbec0b-a25a-4c18-9e8f-f989671e7170
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t/21/22/ac/88/2122ac88-2fa4-4bd7-bdc6-4a67655646a5
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"301ecc2158b004026a519a4703f4fc9dc5c4bf8b"'
+      - '"231db58438e31013739fb5f4b04881e1e02b2b0d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba/t/76/fb/ec/0b/76fbec0b-a25a-4c18-9e8f-f989671e7170>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3/t/21/22/ac/88/2122ac88-2fa4-4bd7-bdc6-4a67655646a5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba</field><field
+        name="id">anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/68/c0/81/8c/68c0818c-c77c-4f30-b48c-6077fdc622ba","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/15/d0/98/32/15d09832-6745-48ad-9f7e-1cd54c655fe3","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1a91db0932a5bbea18c479e724e74f32356dd23b"'
+      - '"ea4a8828790500cac1b4b4773e4086de26f73449"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:16 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c65d975f33c7244b2db28668700d0f699a20af8f"'
+      - '"f70dd5f7816c91b38d74da976ec84bc2549b8316"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9b1db5546646d26323ae8c0d641dd4b093bae6ae"'
+      - '"11903a8704412fafcbbb570440c5d74470c38774"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"75c6ba017da7ab7b621ddd22232588fda3b8c686"'
+      - '"ed601a36413ac02cda5562535a38c4b3386ee256"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t/ca/8d/cc/21/ca8dcc21-31c8-407c-a10c-c3c01fe16e9b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t/49/87/b5/f7/4987b5f7-6468-49a1-91c7-472c3d63a637
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t/ca/8d/cc/21/ca8dcc21-31c8-407c-a10c-c3c01fe16e9b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t/49/87/b5/f7/4987b5f7-6468-49a1-91c7-472c3d63a637
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f1dd8fe6ffddd8c421b55ce42da6748568031d1f"'
+      - '"c522a563f333271a6e91e835a4a2e7cd786e49db"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t/ca/8d/cc/21/ca8dcc21-31c8-407c-a10c-c3c01fe16e9b>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t/49/87/b5/f7/4987b5f7-6468-49a1-91c7-472c3d63a637>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t/ca/8d/cc/21/ca8dcc21-31c8-407c-a10c-c3c01fe16e9b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t/49/87/b5/f7/4987b5f7-6468-49a1-91c7-472c3d63a637
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"75c6ba017da7ab7b621ddd22232588fda3b8c686"'
+      - '"ed601a36413ac02cda5562535a38c4b3386ee256"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f/t/ca/8d/cc/21/ca8dcc21-31c8-407c-a10c-c3c01fe16e9b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8/t/49/87/b5/f7/4987b5f7-6468-49a1-91c7-472c3d63a637>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f</field><field
+        name="id">anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/01/59/6f/a8/01596fa8-4cae-4e7d-8bd1-08f9b06d2c2f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/fb/02/46/7f/fb02467f-366c-4dd8-b217-470a14fae3f8","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>6}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_generic/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_generic/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4fb3b86300e258dd8bb8da0739248c3ee6b68aad"'
+      - '"95ff67ce505a20307d06adefaa787e3d36648a48"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"04a4a4ce33fbcf89e6f10db5401fe4ce4eb70c82"'
+      - '"d8284b65109db3ee9ab897cc8de61c14ae826890"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"77b3fc160eb5a8796bc3a37a550c23fd248222d1"'
+      - '"0a91257b5dc67f0f86b48fe606bf596446afcee8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0ccfdfed605ed3297e1987cbfebaddfbb44e8db1"'
+      - '"04d19dc4a51d6b80f0b5fb4e37fbe8318ac131a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t/e9/45/78/78/e9457878-1f48-4788-a0a4-781451740bdd
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t/db/a0/68/1a/dba0681a-872c-412a-91c1-9caf6a01dc1f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t/e9/45/78/78/e9457878-1f48-4788-a0a4-781451740bdd
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t/db/a0/68/1a/dba0681a-872c-412a-91c1-9caf6a01dc1f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"daca79f1684de9465d46df8eb082c3d4c84db05e"'
+      - '"1032bce277a68e4c7bd707c18161d04c1bffd0ce"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t/e9/45/78/78/e9457878-1f48-4788-a0a4-781451740bdd>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t/db/a0/68/1a/dba0681a-872c-412a-91c1-9caf6a01dc1f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t/e9/45/78/78/e9457878-1f48-4788-a0a4-781451740bdd
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t/db/a0/68/1a/dba0681a-872c-412a-91c1-9caf6a01dc1f
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0ccfdfed605ed3297e1987cbfebaddfbb44e8db1"'
+      - '"04d19dc4a51d6b80f0b5fb4e37fbe8318ac131a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412/t/e9/45/78/78/e9457878-1f48-4788-a0a4-781451740bdd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5/t/db/a0/68/1a/dba0681a-872c-412a-91c1-9caf6a01dc1f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412</field><field
+        name="id">anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/12/7e/22/b4/127e22b4-f7e4-4b9f-949e-5fdd58614412","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/65/9f/86/f2/659f86f2-dbe3-43f2-b7a7-5eb4280db5f5","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>7}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_generic/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/oa_generic/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bb60789555e27234b933dd4e30113ffc78bb725a"'
+      - '"9140e5348ded1ab5c4406861c02618ef273de66f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:17 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9851bc88bd688c8f9af25ddc7408e19fa67181e4"'
+      - '"48eebf325ffceb6adab484b0be13a3cfca10e3ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1a39a7c902f43c8e92d4a16547c71358ac4b24fb"'
+      - '"3441e9d41c40ba27d808871f40ba0736438b2ddf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1e6bdd9ab6315b297eee3c1100c8c0958e9b3555"'
+      - '"36ea47be2a4ca673fc898dd26af85bd45226a461"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t/cb/d6/21/3f/cbd6213f-5fae-4346-bd1e-16d221499fa2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t/b7/e9/a2/44/b7e9a244-9db6-450f-9aa8-06833ad430a4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t/cb/d6/21/3f/cbd6213f-5fae-4346-bd1e-16d221499fa2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t/b7/e9/a2/44/b7e9a244-9db6-450f-9aa8-06833ad430a4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"488f1fb34bb05d2ef2200a6a2bdbe2664ce527ba"'
+      - '"d94d5c5f992e73f8d0042912aea0581c0c43c36e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t/cb/d6/21/3f/cbd6213f-5fae-4346-bd1e-16d221499fa2>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t/b7/e9/a2/44/b7e9a244-9db6-450f-9aa8-06833ad430a4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t/cb/d6/21/3f/cbd6213f-5fae-4346-bd1e-16d221499fa2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t/b7/e9/a2/44/b7e9a244-9db6-450f-9aa8-06833ad430a4
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1e6bdd9ab6315b297eee3c1100c8c0958e9b3555"'
+      - '"36ea47be2a4ca673fc898dd26af85bd45226a461"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0/t/cb/d6/21/3f/cbd6213f-5fae-4346-bd1e-16d221499fa2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b/t/b7/e9/a2/44/b7e9a244-9db6-450f-9aa8-06833ad430a4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0</field><field
+        name="id">anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/7d/11/5a/b3/7d115ab3-d093-4b93-994c-aa2a051c3be0","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/44/8f/e2/ae/448fe2ae-fc8b-419f-927b-ac1e1efa504b","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"424919cf798ff6b386779f21a86065e1f5042b67"'
+      - '"b2250aea1e73227f8c4f72e58b0c11ecb358028c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a27c0018d83b436eff7e11378aa1822ab6868f0a"'
+      - '"4111d34bda8084ca158e54b515dc46e5145e1062"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3e7ece4dc5f7b792022fcb0092cfc2b013221e1b"'
+      - '"e5727e3ab1c001ec39b0a9eeabe0055ff04a140d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"32d48a4f40cb692af8a4843d185ee28a18c4c0dc"'
+      - '"6103dbc986f4f28239a7fd3ffd93cb710987ea4d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t/da/d9/52/21/dad95221-97c7-48a9-827b-816bca968c54
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t/9c/3f/1e/6d/9c3f1e6d-b4f8-4dd0-a62b-fd0103662453
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t/da/d9/52/21/dad95221-97c7-48a9-827b-816bca968c54
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t/9c/3f/1e/6d/9c3f1e6d-b4f8-4dd0-a62b-fd0103662453
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"847701b68e007a13a5b20005569b7544dfe3a07f"'
+      - '"0d41ad3707c3905b30666ecbb2d20d03ad12d73b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t/da/d9/52/21/dad95221-97c7-48a9-827b-816bca968c54>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t/9c/3f/1e/6d/9c3f1e6d-b4f8-4dd0-a62b-fd0103662453>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t/da/d9/52/21/dad95221-97c7-48a9-827b-816bca968c54
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t/9c/3f/1e/6d/9c3f1e6d-b4f8-4dd0-a62b-fd0103662453
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"32d48a4f40cb692af8a4843d185ee28a18c4c0dc"'
+      - '"6103dbc986f4f28239a7fd3ffd93cb710987ea4d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9/t/da/d9/52/21/dad95221-97c7-48a9-827b-816bca968c54>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e/t/9c/3f/1e/6d/9c3f1e6d-b4f8-4dd0-a62b-fd0103662453>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9</field><field
+        name="id">anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/74/a9/f4/4d/74a9f44d-017a-4557-ac9f-da32d8eb7bf9","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/4f/8f/0a/22/4f8f0a22-114e-47f3-a82a-3b96c87bb18e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/json/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"424919cf798ff6b386779f21a86065e1f5042b67"'
+      - '"5551c56186514e63705eb15861acd9427acb3559"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:18 GMT
+      - Wed, 08 Jul 2015 18:54:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f244521042ac5e6f862a950ae4a9db34640fc0f8"'
+      - '"86c649ef5fd2e8d61e3af86d7935a0e1b76b0b34"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9134bfb7242d1bd79712553a6bfa5e4241dcac78"'
+      - '"0e39201a09a3b19f476ea64a7e3d04afc417520b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b900ec5235ca4191fbba6d45cc9f961ceb24442d"'
+      - '"1700822560a23ea7a82c57c2882957d6a6b876ac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t/37/ae/61/ad/37ae61ad-f5a1-4c15-97bc-c0a04a629aff
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t/1d/56/74/08/1d567408-13ce-4dd3-99a6-5c4e87d6b386
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t/37/ae/61/ad/37ae61ad-f5a1-4c15-97bc-c0a04a629aff
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t/1d/56/74/08/1d567408-13ce-4dd3-99a6-5c4e87d6b386
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7294acb62093ed13526ff7831fa88da93e12108a"'
+      - '"13ba8197bd414022066a9602e617332820cd605c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t/37/ae/61/ad/37ae61ad-f5a1-4c15-97bc-c0a04a629aff>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t/1d/56/74/08/1d567408-13ce-4dd3-99a6-5c4e87d6b386>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t/37/ae/61/ad/37ae61ad-f5a1-4c15-97bc-c0a04a629aff
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t/1d/56/74/08/1d567408-13ce-4dd3-99a6-5c4e87d6b386
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b900ec5235ca4191fbba6d45cc9f961ceb24442d"'
+      - '"1700822560a23ea7a82c57c2882957d6a6b876ac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165/t/37/ae/61/ad/37ae61ad-f5a1-4c15-97bc-c0a04a629aff>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260/t/1d/56/74/08/1d567408-13ce-4dd3-99a6-5c4e87d6b386>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165</field><field
+        name="id">anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/60/c0/ee/58/60c0ee58-6793-43a1-a114-0eae121cd165","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/99/b5/99/69/99b59969-aa96-438c-af99-4d3d92c7f260","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/iiif/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/iiif/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"63d99e4fe8238cc0c79f882154d82a27e072ab06"'
+      - '"13526c55900b73483a8e1e5d69876e7f7287afc2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c0d3d9a29f6226a27c000fddfcbfec47af17b3d7"'
+      - '"5f9f73ca8c3cba6d92fc3269628297bebab73d80"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c700a8687413ba70e1e383813426334a0238360a"'
+      - '"2a8d18b521d6604b231e608edddd760f0fe43bd1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e73e1ccab13d1b385d0558b55a782153eb7454c5"'
+      - '"2bc0bde95f54193ee67547622fcf892fdd8ad053"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t/c9/4d/a2/8a/c94da28a-7b06-444e-8e5c-f049b871bc9a
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t/ee/b0/ab/5b/eeb0ab5b-9d7a-4a41-8c53-41950b2e4cb7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t/c9/4d/a2/8a/c94da28a-7b06-444e-8e5c-f049b871bc9a
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t/ee/b0/ab/5b/eeb0ab5b-9d7a-4a41-8c53-41950b2e4cb7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"94fbfa90abb380d84d047b7f2012e71f3306fa75"'
+      - '"2b1dd02d66a8c21f35fa2b9d6aea4837697f3eea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t/c9/4d/a2/8a/c94da28a-7b06-444e-8e5c-f049b871bc9a>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t/ee/b0/ab/5b/eeb0ab5b-9d7a-4a41-8c53-41950b2e4cb7>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t/c9/4d/a2/8a/c94da28a-7b06-444e-8e5c-f049b871bc9a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t/ee/b0/ab/5b/eeb0ab5b-9d7a-4a41-8c53-41950b2e4cb7
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e73e1ccab13d1b385d0558b55a782153eb7454c5"'
+      - '"2bc0bde95f54193ee67547622fcf892fdd8ad053"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b/t/c9/4d/a2/8a/c94da28a-7b06-444e-8e5c-f049b871bc9a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97/t/ee/b0/ab/5b/eeb0ab5b-9d7a-4a41-8c53-41950b2e4cb7>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b</field><field
+        name="id">anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/62/27/3f/c8/62273fc8-cb34-453b-b9ea-7892876e337b","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/b4/a6/d8/f5/b4a6d8f5-e5db-4859-a477-ba8afdcc6e97","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/iiif/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/iiif/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b7b4aed6510b14a2fab650f0222c21b4f1e3b8e6"'
+      - '"9fa5e46f2c95415980186f0319d9bbe4d08b99c2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"662c8738bf39df84e7b66c85ae342f949a6556ec"'
+      - '"b8b7bf6ba8517fee84a7a6579beee8b3d2e761a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a1ebda61a1f46ac0a29b322c1b3c927350842196"'
+      - '"b9753a9db5d6e19fe64bfcea98a3b114dbe638ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ec425d496af3662d213bc29224b63858420590ee"'
+      - '"301bd2004ea972bcc1cce867b98404e0e05bdaf9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t/24/93/1e/64/24931e64-e945-4d58-acee-d6107f997386
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t/97/ac/c0/75/97acc075-122a-4622-8117-d5d092e89d4f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t/24/93/1e/64/24931e64-e945-4d58-acee-d6107f997386
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t/97/ac/c0/75/97acc075-122a-4622-8117-d5d092e89d4f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d117de9687157a191c4555443c845a0497fc7243"'
+      - '"6130a1ab5f1dd02dd4566088af321a9db52d4493"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t/24/93/1e/64/24931e64-e945-4d58-acee-d6107f997386>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t/97/ac/c0/75/97acc075-122a-4622-8117-d5d092e89d4f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t/24/93/1e/64/24931e64-e945-4d58-acee-d6107f997386
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t/97/ac/c0/75/97acc075-122a-4622-8117-d5d092e89d4f
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ec425d496af3662d213bc29224b63858420590ee"'
+      - '"301bd2004ea972bcc1cce867b98404e0e05bdaf9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8/t/24/93/1e/64/24931e64-e945-4d58-acee-d6107f997386>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa/t/97/ac/c0/75/97acc075-122a-4622-8117-d5d092e89d4f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8</field><field
+        name="id">anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/bb/85/c2/ac/bb85c2ac-0532-471d-8c31-9ee7d02959a8","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/c0/78/07/5c/c078075c-b028-4f68-a937-4e5b9b2790aa","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c9403009970e4b4ead332cd3af96f8b007b6687c"'
+      - '"c6a5c92f411523b71cd041169f0a89fa2dbe85d3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a48560a9faf74db5352546c3583ab85a6b398998"'
+      - '"c79caa34d3ee25beade08fc332a103c247f4b950"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f73b9d5ef980a3a9bf7a08bb39c44d521e9e3e09"'
+      - '"3aab96e6334f82c14665a6cbf0a1782511cc270c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a3843f1aeab025fd93781af575eb49e5dd2ad9b9"'
+      - '"7cd62c27b7030ca97854f46d5452ae9afff986d2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t/e3/e1/bf/8c/e3e1bf8c-e987-47cc-8dc2-431f68724186
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t/31/fd/71/46/31fd7146-469b-4269-9837-648bf9582d0c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t/e3/e1/bf/8c/e3e1bf8c-e987-47cc-8dc2-431f68724186
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t/31/fd/71/46/31fd7146-469b-4269-9837-648bf9582d0c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a6469603bc6d1f6ac72f88e11697d2194e35fdc9"'
+      - '"0be0a7c62a0c3add5a1b6bb9a7add2802d5843e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t/e3/e1/bf/8c/e3e1bf8c-e987-47cc-8dc2-431f68724186>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t/31/fd/71/46/31fd7146-469b-4269-9837-648bf9582d0c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t/e3/e1/bf/8c/e3e1bf8c-e987-47cc-8dc2-431f68724186
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t/31/fd/71/46/31fd7146-469b-4269-9837-648bf9582d0c
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a3843f1aeab025fd93781af575eb49e5dd2ad9b9"'
+      - '"7cd62c27b7030ca97854f46d5452ae9afff986d2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:23 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195/t/e3/e1/bf/8c/e3e1bf8c-e987-47cc-8dc2-431f68724186>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e/t/31/fd/71/46/31fd7146-469b-4269-9837-648bf9582d0c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195</field><field
+        name="id">anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/78/b7/e6/70/78b7e670-e0c1-466e-8f49-2e42814a1195","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/27/42/2c/74/27422c74-e756-4b3b-8b8b-b3fde5a5f37e","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/missing_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bb962aae21339d59d1d0b1c07c64ef886399fb9e"'
+      - '"6d0c6d28bdc9f05e26b077a2f598bbc105ea70cb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d6a12de3574e5ec9fbbb65fc37839d50cfe8e16e"'
+      - '"e4e4c1c91b7dfa7e41d08829203a1f259d35b91b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f18da9fe28b05654d95f43ca8dc0c9ad810430c"'
+      - '"f68d6accf4f2e66a154f39f4628c86910deedc87"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9247352fa09c9425ad365cfdade6fa3a4e1ce828"'
+      - '"8a1e3f890a2fa40e5177d833a5c0ab60bac391e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t/63/a4/bf/c2/63a4bfc2-fd24-462f-abea-6089c9466a4f
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t/7b/62/a5/81/7b62a581-0ba7-4702-9d1e-6ae961e7b8d2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t/63/a4/bf/c2/63a4bfc2-fd24-462f-abea-6089c9466a4f
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t/7b/62/a5/81/7b62a581-0ba7-4702-9d1e-6ae961e7b8d2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8e7dce36faef41029cdc335c72c7d5483099e8c1"'
+      - '"f3eb423991264e5808f12d2fd484c0d7f947a8ba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t/63/a4/bf/c2/63a4bfc2-fd24-462f-abea-6089c9466a4f>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t/7b/62/a5/81/7b62a581-0ba7-4702-9d1e-6ae961e7b8d2>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t/63/a4/bf/c2/63a4bfc2-fd24-462f-abea-6089c9466a4f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t/7b/62/a5/81/7b62a581-0ba7-4702-9d1e-6ae961e7b8d2
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9247352fa09c9425ad365cfdade6fa3a4e1ce828"'
+      - '"8a1e3f890a2fa40e5177d833a5c0ab60bac391e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838/t/63/a4/bf/c2/63a4bfc2-fd24-462f-abea-6089c9466a4f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67/t/7b/62/a5/81/7b62a581-0ba7-4702-9d1e-6ae961e7b8d2>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838</field><field
+        name="id">anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/5a/51/e8/5c/5a51e85c-7005-42ab-9d06-109bf3804838","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/70/f8/23/5d/70f8235d-e2ec-4266-a153-1f073d77fc67","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>12}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/no_link_header_returns_oa_dated.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/no_link_header_returns_oa_dated.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"804e2994facff20a7235edd1d26f993a224f7685"'
+      - '"ba5e80d6d08773affc7b91ba405aab2cea03a620"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:19 GMT
+      - Wed, 08 Jul 2015 18:54:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1d46acb6df3d945bfafff5918d0e36769449600a"'
+      - '"86a06ec42aa16e5bbdfc37c09df6bf4bea011c78"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fda126c8a176b56088666146b75c352c7d94bdff"'
+      - '"05a4330d276281529abc5969d1482e53f43b61c3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a80c221ff997f902c74270ce9ced9c4a51e905e9"'
+      - '"df481b05be1aef5576b41b621661ef7f32721ea5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t/b6/9b/26/b0/b69b26b0-d691-4dd4-b9c5-4ad309013739
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t/d6/12/f8/5e/d612f85e-672a-4ee7-806f-01b4ec942cfc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t/b6/9b/26/b0/b69b26b0-d691-4dd4-b9c5-4ad309013739
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t/d6/12/f8/5e/d612f85e-672a-4ee7-806f-01b4ec942cfc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"37838b6c3bed7f74d4be8acdb45e1ff3f068eff5"'
+      - '"c4fa853fbef55ecabdaa224b4ca05465a4ef57b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t/b6/9b/26/b0/b69b26b0-d691-4dd4-b9c5-4ad309013739>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t/d6/12/f8/5e/d612f85e-672a-4ee7-806f-01b4ec942cfc>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t/b6/9b/26/b0/b69b26b0-d691-4dd4-b9c5-4ad309013739
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t/d6/12/f8/5e/d612f85e-672a-4ee7-806f-01b4ec942cfc
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a80c221ff997f902c74270ce9ced9c4a51e905e9"'
+      - '"df481b05be1aef5576b41b621661ef7f32721ea5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f/t/b6/9b/26/b0/b69b26b0-d691-4dd4-b9c5-4ad309013739>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1/t/d6/12/f8/5e/d612f85e-672a-4ee7-806f-01b4ec942cfc>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f</field><field
+        name="id">anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ed/79/9b/dc/ed799bdc-3d9c-47c7-96d2-ac708099e23f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/03/37/99/c4/033799c4-863f-4886-a232-e3eec02f0ce1","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"224ba2b5637b60b744451f9affda716cb649d81b"'
+      - '"04db4c191cedb2fbb80bed2a390747e2d80db161"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6eaa6d88bacd0fefda3ae5a99ebad34d66b60993"'
+      - '"0403219630186f1c09b97c97c636cb569496c72a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6b510f3e74eb24e0dcd50fca47dc4dc7a28e56a3"'
+      - '"f5a5c244f0401aff456f3745a7e68e892ab5bb52"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"af9e0e525df24551379c5015490ce2bf6e94932b"'
+      - '"107663a5eb8a21fa836e87f9712e2ba885873aea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t/63/54/60/53/63546053-ff8c-4abc-b282-aeddb785e746
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t/67/d2/41/97/67d24197-2a75-4168-9c09-f05b7546f0f9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t/63/54/60/53/63546053-ff8c-4abc-b282-aeddb785e746
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t/67/d2/41/97/67d24197-2a75-4168-9c09-f05b7546f0f9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"95fa67d260914c2cef090b64a99b2be9f5c58e4f"'
+      - '"ca0e0fd34add2dabcf1bc3ad9eec75b54d4218f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t/63/54/60/53/63546053-ff8c-4abc-b282-aeddb785e746>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t/67/d2/41/97/67d24197-2a75-4168-9c09-f05b7546f0f9>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t/63/54/60/53/63546053-ff8c-4abc-b282-aeddb785e746
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t/67/d2/41/97/67d24197-2a75-4168-9c09-f05b7546f0f9
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"af9e0e525df24551379c5015490ce2bf6e94932b"'
+      - '"107663a5eb8a21fa836e87f9712e2ba885873aea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03/t/63/54/60/53/63546053-ff8c-4abc-b282-aeddb785e746>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7/t/67/d2/41/97/67d24197-2a75-4168-9c09-f05b7546f0f9>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03</field><field
+        name="id">anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e9/c2/5d/b4/e9c25db4-421e-4f26-9b95-3e4213134d03","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3c/19/9b/ed/3c199bed-a0c8-4615-98fa-2745beaa65f7","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"224ba2b5637b60b744451f9affda716cb649d81b"'
+      - '"04db4c191cedb2fbb80bed2a390747e2d80db161"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e658407f7b70a16743a49632bab3f244c95ab112"'
+      - '"60b6f3f57b464b2fcbd75095f8d01b57f78ce927"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"baa4752428295e06851f179231fc2aa2e1d83b61"'
+      - '"515e87340edacd080b98620209871e716fd2b501"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5989a4ee551e531a05630a8fec9b808e89db4133"'
+      - '"5edc3b1afd85b6b2ef4a492bb33e6568c83d2fc4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t/65/2a/dd/8a/652add8a-0c33-4275-913a-af0aec6060aa
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t/ae/6a/5d/00/ae6a5d00-4ad6-4872-b951-050357eb050c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t/65/2a/dd/8a/652add8a-0c33-4275-913a-af0aec6060aa
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t/ae/6a/5d/00/ae6a5d00-4ad6-4872-b951-050357eb050c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b52c1434cb67b103c335f247aceb299bfec90ef6"'
+      - '"f3d5839bad705bff2c6d32cb0ea12b8bd809f4aa"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t/65/2a/dd/8a/652add8a-0c33-4275-913a-af0aec6060aa>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t/ae/6a/5d/00/ae6a5d00-4ad6-4872-b951-050357eb050c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t/65/2a/dd/8a/652add8a-0c33-4275-913a-af0aec6060aa
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t/ae/6a/5d/00/ae6a5d00-4ad6-4872-b951-050357eb050c
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5989a4ee551e531a05630a8fec9b808e89db4133"'
+      - '"5edc3b1afd85b6b2ef4a492bb33e6568c83d2fc4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd/t/65/2a/dd/8a/652add8a-0c33-4275-913a-af0aec6060aa>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381/t/ae/6a/5d/00/ae6a5d00-4ad6-4872-b951-050357eb050c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd</field><field
+        name="id">anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ed/27/4e/25/ed274e25-5e26-40d7-a3eb-f8fb70b581fd","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/fb/ef/f0/c7/fbeff0c7-425b-4ee3-97de-24b7fca55381","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -325,5 +325,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_generic/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_generic/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"79f433b26924112fa0b1d8d6cef2b475ea539807"'
+      - '"333469f7148f7b0cfd8ac47ce63deea19cdfd526"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f49d9b4423497978afae89d99dd4b6b38144c63"'
+      - '"8b3a0471c8f57a3a1575cb38af67762ec6eeac50"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e6d807af235f2a538885ed8b7d550044bead6705"'
+      - '"7ca4fe2fff87d7879cc338bcc0a597739a21d980"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ecfea7a38ba8e810d5ab57cbc3a5d7c480893e3a"'
+      - '"4c9b8ebb39f203f74e1bfc0cde4db33331c2a3f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t/b8/12/28/3d/b812283d-41c6-4b08-964b-6556a764b83d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t/29/d5/23/b1/29d523b1-574e-47c5-8719-7f08447ed46f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t/b8/12/28/3d/b812283d-41c6-4b08-964b-6556a764b83d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t/29/d5/23/b1/29d523b1-574e-47c5-8719-7f08447ed46f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"365eff4388f03d981ef50acd1e50118b0f0b3db5"'
+      - '"fbbb3ce39126c9ba21f23b51687c752a4b006c87"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t/b8/12/28/3d/b812283d-41c6-4b08-964b-6556a764b83d>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t/29/d5/23/b1/29d523b1-574e-47c5-8719-7f08447ed46f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t/b8/12/28/3d/b812283d-41c6-4b08-964b-6556a764b83d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t/29/d5/23/b1/29d523b1-574e-47c5-8719-7f08447ed46f
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ecfea7a38ba8e810d5ab57cbc3a5d7c480893e3a"'
+      - '"4c9b8ebb39f203f74e1bfc0cde4db33331c2a3f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050/t/b8/12/28/3d/b812283d-41c6-4b08-964b-6556a764b83d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc/t/29/d5/23/b1/29d523b1-574e-47c5-8719-7f08447ed46f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050</field><field
+        name="id">anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/6b/06/36/ef/6b0636ef-838c-48c0-8373-f95c0dd70050","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ae/cc/63/3c/aecc633c-6c5d-4b6c-8ab9-de64df1981dc","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_generic/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/oa_generic/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"73a98662a35c61fcf317d5a1ef9efa0aea19aeea"'
+      - '"5aa20d2f61cace804e7c21a848353929bc637ea6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:20 GMT
+      - Wed, 08 Jul 2015 18:54:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ad182e8be7538d1684d51727b861fe244d1b617a"'
+      - '"d52c93662190f888d77236c46061f2e295f10c1c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e8c29ced18d5c428e42a0ac43d537ca63b22a44e"'
+      - '"3714feb7ac8f54ef9a35bed09382327bef10aa3e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"203289351b3ef80efcb4109d358f348f85c62a07"'
+      - '"fb713b0b70c261f92eecd3f5d9a866104fb2fe6e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t/6f/b1/30/83/6fb13083-a06c-4336-90b1-78bddc372151
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t/8e/3f/3a/a7/8e3f3aa7-658e-4d0d-8e04-7196269d93c2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t/6f/b1/30/83/6fb13083-a06c-4336-90b1-78bddc372151
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t/8e/3f/3a/a7/8e3f3aa7-658e-4d0d-8e04-7196269d93c2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"921fb94ec5aeafb286283d2abc53a5cc45404660"'
+      - '"fa977f4d2d606911031bca61fed4c0fcd277c4ab"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t/6f/b1/30/83/6fb13083-a06c-4336-90b1-78bddc372151>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t/8e/3f/3a/a7/8e3f3aa7-658e-4d0d-8e04-7196269d93c2>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t/6f/b1/30/83/6fb13083-a06c-4336-90b1-78bddc372151
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t/8e/3f/3a/a7/8e3f3aa7-658e-4d0d-8e04-7196269d93c2
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"203289351b3ef80efcb4109d358f348f85c62a07"'
+      - '"fb713b0b70c261f92eecd3f5d9a866104fb2fe6e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb/t/6f/b1/30/83/6fb13083-a06c-4336-90b1-78bddc372151>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff/t/8e/3f/3a/a7/8e3f3aa7-658e-4d0d-8e04-7196269d93c2>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb</field><field
+        name="id">anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/6e/19/7d/45/6e197d45-0a76-4173-be3a-e91996e41ddb","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/e7/33/01/a6/e73301a6-8d72-4210-87c1-9797c330fdff","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>11}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_not_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"93f0162a0ea6c456754c3c5cf71563a3f5760268"'
+      - '"fa44114d59f596b3da7c36ac4e9f164e5ff38013"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f1fc40647d37f228db23165dc128a5539199651c"'
+      - '"024df99319883c1835d785869c0ea44e42f6a303"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e1c9f85e636b59cfef2976535922e62d4e1c90e0"'
+      - '"78938acb350677ff80b2aa8cfcf2f4c269065461"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"77b389292299b37e7a3d2f233090e7de36f09f7c"'
+      - '"29dab2b2e359d24031a6ee191a721b30d05a9f4a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t/62/14/c4/30/6214c430-a44a-4d08-87f6-1faab97aa5ea
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t/fd/52/97/d5/fd5297d5-1a84-4dac-85ab-b8d3105e6966
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t/62/14/c4/30/6214c430-a44a-4d08-87f6-1faab97aa5ea
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t/fd/52/97/d5/fd5297d5-1a84-4dac-85ab-b8d3105e6966
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b4ade573312f1d4fa636cd509dad8792b3b166e4"'
+      - '"07258417f019c8870d44f33be26b544c93614332"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t/62/14/c4/30/6214c430-a44a-4d08-87f6-1faab97aa5ea>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t/fd/52/97/d5/fd5297d5-1a84-4dac-85ab-b8d3105e6966>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t/62/14/c4/30/6214c430-a44a-4d08-87f6-1faab97aa5ea
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t/fd/52/97/d5/fd5297d5-1a84-4dac-85ab-b8d3105e6966
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"77b389292299b37e7a3d2f233090e7de36f09f7c"'
+      - '"29dab2b2e359d24031a6ee191a721b30d05a9f4a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4/t/62/14/c4/30/6214c430-a44a-4d08-87f6-1faab97aa5ea>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f/t/fd/52/97/d5/fd5297d5-1a84-4dac-85ab-b8d3105e6966>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4</field><field
+        name="id">anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/05/fe/f2/79/05fef279-5192-4895-b99b-b11f8a770fe4","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/48/61/f6/16/4861f616-73c1-40ef-a632-ee9e98bede8f","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/jsonld_context/Link_header_specifies_context_URL/jsonld_be_nice_and_pay_attention_to_link_/unrecognized_context_returns_oa_dated/behaves_like_creates_anno_successfully/link_type_specified.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"93f0162a0ea6c456754c3c5cf71563a3f5760268"'
+      - '"d321cc4f93e480f16d507d92bd6d8482ecb2a27c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:21 GMT
+      - Wed, 08 Jul 2015 18:54:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e3f9591ac233f1a4c733c0e0095c6748398cd4f2"'
+      - '"39bc2c29720af15e8d80635c65dacc8c4dd71d6b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"982c2add7346aa3f0963d26b8964b6aec1ddcbf7"'
+      - '"264f7eccc8d65d95dfec9ee770f6d67d4f0abb30"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6135a60b31b1c58492177c7b6e6c6e8f96bb683c"'
+      - '"5a2c6b78a2d4800c2944b8f4c8c85e0b149444d1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t/68/53/fc/49/6853fc49-69e8-4b3b-b0bb-c0eccb3ec5aa
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t/2a/39/15/6e/2a39156e-4a92-4eeb-b91c-753d5e79b1c4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t/68/53/fc/49/6853fc49-69e8-4b3b-b0bb-c0eccb3ec5aa
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t/2a/39/15/6e/2a39156e-4a92-4eeb-b91c-753d5e79b1c4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f269917073bb45407354a26c9ec9f70a353ef5a5"'
+      - '"9cdc1b1931f3bc1a406d1cc106240a6c0a611efd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t/68/53/fc/49/6853fc49-69e8-4b3b-b0bb-c0eccb3ec5aa>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t/2a/39/15/6e/2a39156e-4a92-4eeb-b91c-753d5e79b1c4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t/68/53/fc/49/6853fc49-69e8-4b3b-b0bb-c0eccb3ec5aa
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t/2a/39/15/6e/2a39156e-4a92-4eeb-b91c-753d5e79b1c4
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6135a60b31b1c58492177c7b6e6c6e8f96bb683c"'
+      - '"5a2c6b78a2d4800c2944b8f4c8c85e0b149444d1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:22 GMT
+      - Wed, 08 Jul 2015 18:54:20 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,21 +293,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d/t/68/53/fc/49/6853fc49-69e8-4b3b-b0bb-c0eccb3ec5aa>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422/t/2a/39/15/6e/2a39156e-4a92-4eeb-b91c-753d5e79b1c4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d</field><field
+        name="id">anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">bookmarking</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
-        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/6e/a6/26/e9/6ea626e9-b6db-4e9f-a02b-2670e58f133d","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
+        name="body_type">no_body</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/cc/1a/8c/65/cc1a8c65-36f1-43d4-9dc6-a3b8b7900422","@type":"oa:Annotation","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:bookmarking"}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -323,7 +323,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/multiple_formats/uses_first_known_format.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/multiple_formats/uses_first_known_format.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b1c31f246c02d18c04d3686a1e3e7cd7fd001c03"'
+      - '"15769be28972ef6e65e005c8ac7d8d24b2913b4d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2ca75a2d9ec3fded91de9760be9f05dad0890883"'
+      - '"0280b8c3c64b45c75d7ce7a78980718d46422b1a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ab3c60c7b91a1b99c99a9131680c85b937fa18cf"'
+      - '"8c90f1da589be5237643562fbbade7122f964631"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e6f1c89c5688f90e7ec0fe9d5fa43c37173e1466"'
+      - '"0f52056dff4209f3319f7a56c75e836291db9a8d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b/8b/03/91/0a/8b03910a-9778-416b-b639-6e722e5c73e1
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b/9c/df/62/a2/9cdf62a2-882a-4b59-8ca9-8ea265fb89e6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b/8b/03/91/0a/8b03910a-9778-416b-b639-6e722e5c73e1
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b/9c/df/62/a2/9cdf62a2-882a-4b59-8ca9-8ea265fb89e6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"911f29bb08d2bec8e36ffee7e085941b135f138c"'
+      - '"bd74500259eae57284ff86cbefa0ef4271d834f1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"de0cbb5b85316488a55b9fc0376093342c40ad21"'
+      - '"af08c48b06d62cc7721562762e69bb634438d58b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t/cd/6e/c4/e6/cd6ec4e6-a993-46b6-b381-350a7c4f0130
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t/81/03/25/4c/8103254c-371a-45c8-a05d-83e6df39130f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t/cd/6e/c4/e6/cd6ec4e6-a993-46b6-b381-350a7c4f0130
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t/81/03/25/4c/8103254c-371a-45c8-a05d-83e6df39130f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0a7ee484fd2747b596a5239ed55f9d0d0eb79497"'
+      - '"9ab95a48ac7fa116760474552c6454d9fb84f9a9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b/8b/03/91/0a/8b03910a-9778-416b-b639-6e722e5c73e1>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t/cd/6e/c4/e6/cd6ec4e6-a993-46b6-b381-350a7c4f0130>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t/81/03/25/4c/8103254c-371a-45c8-a05d-83e6df39130f>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b/9c/df/62/a2/9cdf62a2-882a-4b59-8ca9-8ea265fb89e6>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b/8b/03/91/0a/8b03910a-9778-416b-b639-6e722e5c73e1
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b/9c/df/62/a2/9cdf62a2-882a-4b59-8ca9-8ea265fb89e6
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6f1c89c5688f90e7ec0fe9d5fa43c37173e1466"'
+      - '"0f52056dff4209f3319f7a56c75e836291db9a8d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/b/8b/03/91/0a/8b03910a-9778-416b-b639-6e722e5c73e1>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/b/9c/df/62/a2/9cdf62a2-882a-4b59-8ca9-8ea265fb89e6>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t/cd/6e/c4/e6/cd6ec4e6-a993-46b6-b381-350a7c4f0130
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t/81/03/25/4c/8103254c-371a-45c8-a05d-83e6df39130f
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"de0cbb5b85316488a55b9fc0376093342c40ad21"'
+      - '"af08c48b06d62cc7721562762e69bb634438d58b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:12 GMT
+      - Wed, 08 Jul 2015 18:54:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19/t/cd/6e/c4/e6/cd6ec4e6-a993-46b6-b381-350a7c4f0130>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15/t/81/03/25/4c/8103254c-371a-45c8-a05d-83e6df39130f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19</field><field
+        name="id">anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318421406040","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/80/bd/fa/f6/80bdfaf6-5a4e-4977-b542-8f649adafd19","@type":"oa:Annotation","hasBody":"_:g70318421406040","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312766799340","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/1a/86/55/07/1a865507-c917-4726-9942-ff80365f1a15","@type":"oa:Annotation","hasBody":"_:g70312766799340","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/nil_gets_json-ld.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/nil_gets_json-ld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4507f7f77a9915143c83b26719413d3addd6b3a7"'
+      - '"88723ba2faf024115eabb4eb3810fffac17d8701"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"61ce35e1431ab59c7a6cdfa11c56c8462bf8846a"'
+      - '"1815d6d61697745505e16d2b3851f3d0e9e79789"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"124387570ab0ae41f5ff1927ef28de393e0ba8e5"'
+      - '"bc87a407e5b2adf64048a679b6d21cddc704b70c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"72893175d5297baeee97710b85659fef65537030"'
+      - '"6b5103d2ba6d20d786ad28a91dcebb4765df1cea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b/ac/01/5e/dc/ac015edc-e112-4b1b-9d71-e1ede2b555e5
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b/d2/ac/42/ad/d2ac42ad-e2f8-402a-9348-7b0bebab2c7f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b/ac/01/5e/dc/ac015edc-e112-4b1b-9d71-e1ede2b555e5
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b/d2/ac/42/ad/d2ac42ad-e2f8-402a-9348-7b0bebab2c7f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6de64496d92501f95100c4a476920cce4ece0a6c"'
+      - '"0026dae0d2a55a005f78fb8d033f28edc6022597"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"83075b58c9225414776f7b0c586d028320167ce2"'
+      - '"eca36cf8d95db7cb9842b3a0d4fad4258a6d859c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t/9d/df/47/d1/9ddf47d1-4630-4efb-a8e0-ea7fb016a25a
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t/36/5f/2f/68/365f2f68-44e6-4900-b9b6-220d83f67369
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t/9d/df/47/d1/9ddf47d1-4630-4efb-a8e0-ea7fb016a25a
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t/36/5f/2f/68/365f2f68-44e6-4900-b9b6-220d83f67369
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"249c2507be8cda30e5461b26fedd651df4550ec5"'
+      - '"1a29a32286ab573bf9584c8826f00e514b6cff45"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t/9d/df/47/d1/9ddf47d1-4630-4efb-a8e0-ea7fb016a25a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b/ac/01/5e/dc/ac015edc-e112-4b1b-9d71-e1ede2b555e5>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b/d2/ac/42/ad/d2ac42ad-e2f8-402a-9348-7b0bebab2c7f>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t/36/5f/2f/68/365f2f68-44e6-4900-b9b6-220d83f67369>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:05 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b/ac/01/5e/dc/ac015edc-e112-4b1b-9d71-e1ede2b555e5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b/d2/ac/42/ad/d2ac42ad-e2f8-402a-9348-7b0bebab2c7f
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"72893175d5297baeee97710b85659fef65537030"'
+      - '"6b5103d2ba6d20d786ad28a91dcebb4765df1cea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/b/ac/01/5e/dc/ac015edc-e112-4b1b-9d71-e1ede2b555e5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/b/d2/ac/42/ad/d2ac42ad-e2f8-402a-9348-7b0bebab2c7f>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t/9d/df/47/d1/9ddf47d1-4630-4efb-a8e0-ea7fb016a25a
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t/36/5f/2f/68/365f2f68-44e6-4900-b9b6-220d83f67369
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"83075b58c9225414776f7b0c586d028320167ce2"'
+      - '"eca36cf8d95db7cb9842b3a0d4fad4258a6d859c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:05 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729/t/9d/df/47/d1/9ddf47d1-4630-4efb-a8e0-ea7fb016a25a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596/t/36/5f/2f/68/365f2f68-44e6-4900-b9b6-220d83f67369>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729</field><field
+        name="id">anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318393264440","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/02/ac/1f/6a/02ac1f6a-9a92-4871-b088-29d986e07729","@type":"oa:Annotation","hasBody":"_:g70318393264440","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312755377880","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/9f/c0/d0/34/9fc0d034-a8ab-44b1-b63e-71e39ae51596","@type":"oa:Annotation","hasBody":"_:g70312755377880","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>5}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:06 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/rdf_xml.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/rdf_xml.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b620b2fb585559a3a739df670198e63b334364eb"'
+      - '"0e7e9365e2058f7b8ca120916adcd9e1a249e651"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"80927caa862a841230bb1ab01bfb027819c1ed4a"'
+      - '"e2b2f2572c2329743be2e0c2f1461bb65cd1141e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b028579ba494083eaf2799e740d190e25729e1e5"'
+      - '"2e9ebfbad1005b4827c3da6efce0dffc35d7d4f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"da6ba77b6ef2382cf58f365dd62007dc2ab280bc"'
+      - '"53073eb9f8005ec6ba5d884f350c1d15704e6e03"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b/42/8a/ec/e0/428aece0-4a12-4dc7-85ee-52891c8008e6
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b/a9/8f/9f/cd/a98f9fcd-e792-4828-b600-0a7660ee82bc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b/42/8a/ec/e0/428aece0-4a12-4dc7-85ee-52891c8008e6
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b/a9/8f/9f/cd/a98f9fcd-e792-4828-b600-0a7660ee82bc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"84c56c785ec8dcfd28e59f5955c2dc92ccb45e26"'
+      - '"096b586d2e1e93cc480cd938b75ab6954a22f4b3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c991b1f1edbc3541622ae2bb6147ce71656c35c6"'
+      - '"6fa71c3abb5c05fb59040789ecc6dea7f23acbd5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t/b6/4b/2a/04/b64b2a04-ea6e-46c0-a2c4-d785cbf8eb27
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t/3d/49/9b/75/3d499b75-ad3b-4f51-a645-f6fb87e0a89c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t/b6/4b/2a/04/b64b2a04-ea6e-46c0-a2c4-d785cbf8eb27
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t/3d/49/9b/75/3d499b75-ad3b-4f51-a645-f6fb87e0a89c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"869e6c87f18ee5a0c182d43870be6164ca90896c"'
+      - '"d4f463a02353fbec2d329b55ab853af01d0dfb1a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t/b6/4b/2a/04/b64b2a04-ea6e-46c0-a2c4-d785cbf8eb27>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b/42/8a/ec/e0/428aece0-4a12-4dc7-85ee-52891c8008e6>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b/a9/8f/9f/cd/a98f9fcd-e792-4828-b600-0a7660ee82bc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t/3d/49/9b/75/3d499b75-ad3b-4f51-a645-f6fb87e0a89c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b/42/8a/ec/e0/428aece0-4a12-4dc7-85ee-52891c8008e6
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b/a9/8f/9f/cd/a98f9fcd-e792-4828-b600-0a7660ee82bc
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"da6ba77b6ef2382cf58f365dd62007dc2ab280bc"'
+      - '"53073eb9f8005ec6ba5d884f350c1d15704e6e03"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/b/42/8a/ec/e0/428aece0-4a12-4dc7-85ee-52891c8008e6>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/b/a9/8f/9f/cd/a98f9fcd-e792-4828-b600-0a7660ee82bc>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t/b6/4b/2a/04/b64b2a04-ea6e-46c0-a2c4-d785cbf8eb27
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t/3d/49/9b/75/3d499b75-ad3b-4f51-a645-f6fb87e0a89c
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c991b1f1edbc3541622ae2bb6147ce71656c35c6"'
+      - '"6fa71c3abb5c05fb59040789ecc6dea7f23acbd5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95/t/b6/4b/2a/04/b64b2a04-ea6e-46c0-a2c4-d785cbf8eb27>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d/t/3d/49/9b/75/3d499b75-ad3b-4f51-a645-f6fb87e0a89c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95</field><field
+        name="id">anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318376062920","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3b/d5/d0/fc/3bd5d0fc-cfa6-4b04-980f-7cd5b7c52d95","@type":"oa:Annotation","hasBody":"_:g70318376062920","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312737258000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ff/8d/34/94/ff8d3494-3b49-432c-a2e9-28e845d41b6d","@type":"oa:Annotation","hasBody":"_:g70312737258000","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/x-xml.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/x-xml.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"76df221d0db4abb4add142107790208bfb81486d"'
+      - '"4f1ef8beaff1afb1c901bc9a0c67d71f60cdd089"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"06e505b6374189a79d1941cd54899e826110f461"'
+      - '"79f32eced33c4746905e787754a827fb28972f07"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c19244b985657990632428bd0f5c4af9891c4aa0"'
+      - '"ed64acc32cead82adbd8bafc8cd0a172e78b4d06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"18da5c22da52ed0f976f5fcb83e360fa56be124a"'
+      - '"33794c217a3bfa41652ed3d36d70f479bdb51ff1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b/ae/b6/b1/5d/aeb6b15d-efc7-4b1d-8e7c-7e1defa47ccc
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b/ae/0a/60/52/ae0a6052-f5ca-4113-af1a-f80c99f672d8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b/ae/b6/b1/5d/aeb6b15d-efc7-4b1d-8e7c-7e1defa47ccc
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b/ae/0a/60/52/ae0a6052-f5ca-4113-af1a-f80c99f672d8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9b19cbd93a9596f4e25b59fb0d000a167fdb78e2"'
+      - '"5622508b8eb1046b8e4d24fa76e62ab2a57c2321"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"51c61a41b717d5681b80b9e3c17adfe5198896b4"'
+      - '"881c1db6840cc3a9b0098ba9f9d6d8c9c0dea29d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t/45/3f/b3/ab/453fb3ab-6727-4cdc-90c6-4d604cf164d2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t/9d/df/42/d0/9ddf42d0-9973-4576-9b90-abee40927222
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t/45/3f/b3/ab/453fb3ab-6727-4cdc-90c6-4d604cf164d2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t/9d/df/42/d0/9ddf42d0-9973-4576-9b90-abee40927222
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"795989241cef2949bb26518772815a386ce6f4ca"'
+      - '"e58925f591f4963021b0dadcfdfc0d7ae2cd9dba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b/ae/b6/b1/5d/aeb6b15d-efc7-4b1d-8e7c-7e1defa47ccc>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t/45/3f/b3/ab/453fb3ab-6727-4cdc-90c6-4d604cf164d2>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b/ae/0a/60/52/ae0a6052-f5ca-4113-af1a-f80c99f672d8>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t/9d/df/42/d0/9ddf42d0-9973-4576-9b90-abee40927222>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b/ae/b6/b1/5d/aeb6b15d-efc7-4b1d-8e7c-7e1defa47ccc
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b/ae/0a/60/52/ae0a6052-f5ca-4113-af1a-f80c99f672d8
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"18da5c22da52ed0f976f5fcb83e360fa56be124a"'
+      - '"33794c217a3bfa41652ed3d36d70f479bdb51ff1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/b/ae/b6/b1/5d/aeb6b15d-efc7-4b1d-8e7c-7e1defa47ccc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/b/ae/0a/60/52/ae0a6052-f5ca-4113-af1a-f80c99f672d8>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t/45/3f/b3/ab/453fb3ab-6727-4cdc-90c6-4d604cf164d2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t/9d/df/42/d0/9ddf42d0-9973-4576-9b90-abee40927222
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"51c61a41b717d5681b80b9e3c17adfe5198896b4"'
+      - '"881c1db6840cc3a9b0098ba9f9d6d8c9c0dea29d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850/t/45/3f/b3/ab/453fb3ab-6727-4cdc-90c6-4d604cf164d2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1/t/9d/df/42/d0/9ddf42d0-9973-4576-9b90-abee40927222>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850</field><field
+        name="id">anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430496160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/60/0b/91/b6/600b91b6-142a-4d9f-b73a-a13dea64f850","@type":"oa:Annotation","hasBody":"_:g70318430496160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312754878160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3f/a1/50/05/3fa15005-55a9-4387-82cd-b4fe938e13f1","@type":"oa:Annotation","hasBody":"_:g70312754878160","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/xml.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/application/xml.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"48d7115bd4d4cca4ce19a7f4c7cc305e0dd5ab93"'
+      - '"acf74747f66394672988ada52b2f3c1c570cecc1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b0f9984fce2e587b737f1256f79468936eaf1fa1"'
+      - '"f2c47d165deb94b8c4dca6054e57a0a34a69a7fe"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9c41319456255c467fb7c3dc5fa665216c02370c"'
+      - '"7de907cc8f712e025353f0b78c35b544a13ef32e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3e08d2a28dce1bc6c6784c984830fbb0f3566e67"'
+      - '"70f7d964cb3f2f3a0c9c795580d5e3e9beb4080d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b/f9/ae/22/b4/f9ae22b4-6e86-4b35-81ff-a0470078c218
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b/a4/59/52/e3/a45952e3-a14c-4675-98ef-5c7c23b710bf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b/f9/ae/22/b4/f9ae22b4-6e86-4b35-81ff-a0470078c218
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b/a4/59/52/e3/a45952e3-a14c-4675-98ef-5c7c23b710bf
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"63fe069c1b796577be36b9669084678246d6e04f"'
+      - '"2d430faa92763f777f7b0d111c837fb380cf8893"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0d3401cc34fdecc4ae58ac5dc2478485f82fc9f4"'
+      - '"97366104aaa89560786bdb9692cce4ac02eac1d1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t/c9/17/47/82/c9174782-dd1b-45dd-a398-d8830a5f8556
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t/95/36/5b/17/95365b17-eabf-4947-9185-99329d9b6607
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t/c9/17/47/82/c9174782-dd1b-45dd-a398-d8830a5f8556
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t/95/36/5b/17/95365b17-eabf-4947-9185-99329d9b6607
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"053248892c61f6800eb63b61a53a15eb75f99a8b"'
+      - '"480ef42a06fec9cf92943aefaa0e7fb5b29dd346"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t/c9/17/47/82/c9174782-dd1b-45dd-a398-d8830a5f8556>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b/f9/ae/22/b4/f9ae22b4-6e86-4b35-81ff-a0470078c218>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t/95/36/5b/17/95365b17-eabf-4947-9185-99329d9b6607>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b/a4/59/52/e3/a45952e3-a14c-4675-98ef-5c7c23b710bf>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b/f9/ae/22/b4/f9ae22b4-6e86-4b35-81ff-a0470078c218
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b/a4/59/52/e3/a45952e3-a14c-4675-98ef-5c7c23b710bf
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3e08d2a28dce1bc6c6784c984830fbb0f3566e67"'
+      - '"70f7d964cb3f2f3a0c9c795580d5e3e9beb4080d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/b/f9/ae/22/b4/f9ae22b4-6e86-4b35-81ff-a0470078c218>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/b/a4/59/52/e3/a45952e3-a14c-4675-98ef-5c7c23b710bf>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t/c9/17/47/82/c9174782-dd1b-45dd-a398-d8830a5f8556
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t/95/36/5b/17/95365b17-eabf-4947-9185-99329d9b6607
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d3401cc34fdecc4ae58ac5dc2478485f82fc9f4"'
+      - '"97366104aaa89560786bdb9692cce4ac02eac1d1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5/t/c9/17/47/82/c9174782-dd1b-45dd-a398-d8830a5f8556>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481/t/95/36/5b/17/95365b17-eabf-4947-9185-99329d9b6607>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5</field><field
+        name="id">anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318401324200","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/aa/39/bf/0d/aa39bf0d-fc23-4637-8146-af36bd63f9c5","@type":"oa:Annotation","hasBody":"_:g70318401324200","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312754116560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/4d/3e/96/fa/4d3e96fa-c433-4fbf-a292-d77f209a8481","@type":"oa:Annotation","hasBody":"_:g70312754116560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/rdf.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/rdf.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a022219e6188a4a0d85cb558f83795d671e6be4e"'
+      - '"c94a8ff8400fef4f8c2f205d8d3f757548a578c3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"afd32b5d2aecf8937c714c0d3a8e4949c968bd30"'
+      - '"cccc68c670b314ce943061c8434241cbaba863c0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5eb06e2bf03a7d0a4e85697fd66c93610e72ffc4"'
+      - '"ae8922840c72ac60690c061cec7cb56b6c8fb095"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"78564ca9daa762fe5d678289ab2f4c7e20fe629b"'
+      - '"9c0b66ce837d42c7da761541ccaea7307a1e08bf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b/5c/98/34/0b/5c98340b-6763-45a7-bf87-8c5fabe77a54
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b/dd/fa/86/47/ddfa8647-03bf-4060-8fda-c32d5d6bab2f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b/5c/98/34/0b/5c98340b-6763-45a7-bf87-8c5fabe77a54
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b/dd/fa/86/47/ddfa8647-03bf-4060-8fda-c32d5d6bab2f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ec9b5af27dbc61a48096979fb32feb1e80e4210e"'
+      - '"3fd7a5148b7ba08ea7460bf5d2b3a1843cc18af2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8b7e7d76c933f0198670ec762463cf0653bb5d2e"'
+      - '"532aaae5bd70a936238667639fcf36f1b6d4f675"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t/78/f4/19/fc/78f419fc-ce87-4c4d-9d4f-ba162962f6d0
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t/e4/a4/ce/0e/e4a4ce0e-93da-4244-b4c4-0247d87ad796
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t/78/f4/19/fc/78f419fc-ce87-4c4d-9d4f-ba162962f6d0
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t/e4/a4/ce/0e/e4a4ce0e-93da-4244-b4c4-0247d87ad796
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b4b10a1bea884ce6965e38bf253b131bbe26c1f3"'
+      - '"515eb7bde18edf95f8c3e99eb8a2df0963797249"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b/5c/98/34/0b/5c98340b-6763-45a7-bf87-8c5fabe77a54>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t/78/f4/19/fc/78f419fc-ce87-4c4d-9d4f-ba162962f6d0>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t/e4/a4/ce/0e/e4a4ce0e-93da-4244-b4c4-0247d87ad796>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b/dd/fa/86/47/ddfa8647-03bf-4060-8fda-c32d5d6bab2f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b/5c/98/34/0b/5c98340b-6763-45a7-bf87-8c5fabe77a54
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b/dd/fa/86/47/ddfa8647-03bf-4060-8fda-c32d5d6bab2f
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"78564ca9daa762fe5d678289ab2f4c7e20fe629b"'
+      - '"9c0b66ce837d42c7da761541ccaea7307a1e08bf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/b/5c/98/34/0b/5c98340b-6763-45a7-bf87-8c5fabe77a54>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/b/dd/fa/86/47/ddfa8647-03bf-4060-8fda-c32d5d6bab2f>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t/78/f4/19/fc/78f419fc-ce87-4c4d-9d4f-ba162962f6d0
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t/e4/a4/ce/0e/e4a4ce0e-93da-4244-b4c4-0247d87ad796
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8b7e7d76c933f0198670ec762463cf0653bb5d2e"'
+      - '"532aaae5bd70a936238667639fcf36f1b6d4f675"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8/t/78/f4/19/fc/78f419fc-ce87-4c4d-9d4f-ba162962f6d0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470/t/e4/a4/ce/0e/e4a4ce0e-93da-4244-b4c4-0247d87ad796>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8</field><field
+        name="id">anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318428266720","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/76/06/ce/19/7606ce19-78cd-45bf-b0b4-7240127412f8","@type":"oa:Annotation","hasBody":"_:g70318428266720","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312765077620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/2e/70/bd/c1/2e70bdc1-609e-4be4-a886-ba49bc014470","@type":"oa:Annotation","hasBody":"_:g70312765077620","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,5 +484,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/rdf_xml.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/rdf_xml.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2af2f35c8c0dd3bc4f74213a2cacaa10fe98a186"'
+      - '"9b2b3f6ad3b3126cf673166d8cbc4b151488ee31"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"59df31a907aa19de244243191b895c76a9cb2fb0"'
+      - '"1026c22953e46d52a2cf407ae6fe163afeb2e67c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"96b34183f6ac8268b335fd6c074de4f1f0f8bc4d"'
+      - '"ffae17b3f08f2fb070ba7c3337c5cac48a1ac187"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"635a6aae918c1346ef5271226167b6a3db4e9ebc"'
+      - '"2614db709cb0ca4f9a7552ad5804800d38862656"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b/16/60/5c/7d/16605c7d-e803-410a-bf21-20b62fd3280c
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b/03/f9/a1/2b/03f9a12b-6150-402f-b7c2-8ba2c05b34fd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b/16/60/5c/7d/16605c7d-e803-410a-bf21-20b62fd3280c
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b/03/f9/a1/2b/03f9a12b-6150-402f-b7c2-8ba2c05b34fd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5c33f939bca1d92660a36742a49bbaab0fd52e78"'
+      - '"7054859a12a4e7e6e51606fe8ecf74f8046d8b1c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d8c52cd798566fc3be45684b2cce212746a3c153"'
+      - '"4098c991e799ef85809436c0e794847a25f9b393"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t/63/ff/da/86/63ffda86-06ec-4477-ba58-0cb68e282716
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t/35/26/a9/76/3526a976-77d0-49f0-8798-20a4df4c680f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t/63/ff/da/86/63ffda86-06ec-4477-ba58-0cb68e282716
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t/35/26/a9/76/3526a976-77d0-49f0-8798-20a4df4c680f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2c81ac7362258aa23f6ac4325c370cef2d06c810"'
+      - '"cc79f48b1ffc2587e47419315bdf8d605fac5bf3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b/16/60/5c/7d/16605c7d-e803-410a-bf21-20b62fd3280c>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t/63/ff/da/86/63ffda86-06ec-4477-ba58-0cb68e282716>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b/03/f9/a1/2b/03f9a12b-6150-402f-b7c2-8ba2c05b34fd>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t/35/26/a9/76/3526a976-77d0-49f0-8798-20a4df4c680f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b/16/60/5c/7d/16605c7d-e803-410a-bf21-20b62fd3280c
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b/03/f9/a1/2b/03f9a12b-6150-402f-b7c2-8ba2c05b34fd
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"635a6aae918c1346ef5271226167b6a3db4e9ebc"'
+      - '"2614db709cb0ca4f9a7552ad5804800d38862656"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/b/16/60/5c/7d/16605c7d-e803-410a-bf21-20b62fd3280c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/b/03/f9/a1/2b/03f9a12b-6150-402f-b7c2-8ba2c05b34fd>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t/63/ff/da/86/63ffda86-06ec-4477-ba58-0cb68e282716
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t/35/26/a9/76/3526a976-77d0-49f0-8798-20a4df4c680f
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d8c52cd798566fc3be45684b2cce212746a3c153"'
+      - '"4098c991e799ef85809436c0e794847a25f9b393"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:08 GMT
+      - Wed, 08 Jul 2015 18:54:06 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2/t/63/ff/da/86/63ffda86-06ec-4477-ba58-0cb68e282716>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0/t/35/26/a9/76/3526a976-77d0-49f0-8798-20a4df4c680f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2</field><field
+        name="id">anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318417224940","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/a9/9d/e2/c8/a99de2c8-9ec3-4289-801e-9ce710a246d2","@type":"oa:Annotation","hasBody":"_:g70318417224940","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312681104980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/4c/5c/0e/65/4c5c0e65-d7cb-4606-be7c-8d8a30be02d0","@type":"oa:Annotation","hasBody":"_:g70312681104980","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,5 +484,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:08 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/xml.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/rdfxml/behaves_like_Accept_header_determines_media_type/text/xml.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"066db135c30a9c9f2cb3b4adbac0a636661e0de5"'
+      - '"4f1ef8beaff1afb1c901bc9a0c67d71f60cdd089"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:09 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4afcc171a6e4888866e3ad0dddc2420a49fb1ff2"'
+      - '"d7e5f0b6b87945c564c6bb6a861070f305b1a2c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:09 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0076d048d4a860d79254d42c9e358f10bcb3bfb4"'
+      - '"6fe9100535312b9e1a2304a2f6618f692a4e0343"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:07 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a68ed83e69081e9e7a19c93b088641266456dfcb"'
+      - '"bafc02be58441881d3b126f44c1fa0436c180c74"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b/46/3e/37/33/463e3733-9023-4c7b-a778-4d51c34f0720
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b/61/7a/2b/f7/617a2bf7-cc72-45d2-8538-2219361cc90d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b/46/3e/37/33/463e3733-9023-4c7b-a778-4d51c34f0720
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b/61/7a/2b/f7/617a2bf7-cc72-45d2-8538-2219361cc90d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"437b8f7b5670e43397102d3dd17e67e50da5147e"'
+      - '"854fbdeb381fa52e525c0f6b8a2eff3247c8be1b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9ab849facb31cd90890c38a5ea8604af96f713ae"'
+      - '"f8496831a6e18d1b4d2f0edee269af18c18988e0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t/ea/0e/8f/4f/ea0e8f4f-618e-4c10-acaa-ca7a035cf5b9
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t/55/90/b4/93/5590b493-bc6c-41c0-8378-5e1195982133
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t/ea/0e/8f/4f/ea0e8f4f-618e-4c10-acaa-ca7a035cf5b9
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t/55/90/b4/93/5590b493-bc6c-41c0-8378-5e1195982133
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"880e99038993079ae417d96f970d739af19e7075"'
+      - '"b7d19237144bf07407d67c2bb7e9808c31b9ef02"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b/46/3e/37/33/463e3733-9023-4c7b-a778-4d51c34f0720>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t/ea/0e/8f/4f/ea0e8f4f-618e-4c10-acaa-ca7a035cf5b9>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t/55/90/b4/93/5590b493-bc6c-41c0-8378-5e1195982133>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b/61/7a/2b/f7/617a2bf7-cc72-45d2-8538-2219361cc90d>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b/46/3e/37/33/463e3733-9023-4c7b-a778-4d51c34f0720
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b/61/7a/2b/f7/617a2bf7-cc72-45d2-8538-2219361cc90d
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a68ed83e69081e9e7a19c93b088641266456dfcb"'
+      - '"bafc02be58441881d3b126f44c1fa0436c180c74"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/b/46/3e/37/33/463e3733-9023-4c7b-a778-4d51c34f0720>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/b/61/7a/2b/f7/617a2bf7-cc72-45d2-8538-2219361cc90d>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t/ea/0e/8f/4f/ea0e8f4f-618e-4c10-acaa-ca7a035cf5b9
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t/55/90/b4/93/5590b493-bc6c-41c0-8378-5e1195982133
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9ab849facb31cd90890c38a5ea8604af96f713ae"'
+      - '"f8496831a6e18d1b4d2f0edee269af18c18988e0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:10 GMT
+      - Wed, 08 Jul 2015 18:54:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5/t/ea/0e/8f/4f/ea0e8f4f-618e-4c10-acaa-ca7a035cf5b9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45/t/55/90/b4/93/5590b493-bc6c-41c0-8378-5e1195982133>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5</field><field
+        name="id">anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318375205320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/ff/43/60/dd/ff4360dd-da84-41b7-84c3-b175bb222cd5","@type":"oa:Annotation","hasBody":"_:g70318375205320","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312728779540","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3a/88/b7/bb/3a88b7bb-9cec-477d-b9dd-e50af5666f45","@type":"oa:Annotation","hasBody":"_:g70312728779540","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:10 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/turtle/behaves_like_Accept_header_determines_media_type/application/x-turtle.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/turtle/behaves_like_Accept_header_determines_media_type/application/x-turtle.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"225e95057ad01cf947973ee18079916f90accbd4"'
+      - '"b7f802cfdcb2d0d38a2697fbef098a62ab0f9c85"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b8b2775f0fc265823dd4395547ffd59cb5f535e1"'
+      - '"c0a80795f5d1f73491ee0b5f8310d21f5506385b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f3f462e4bceb42abfb24a8b9456e1498441c1770"'
+      - '"bfa6731d98ac101dfd393d2bf84ee94aea7b0290"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fcc95951dc4de7b66f4af23d7b61cb080747bbff"'
+      - '"fbe6c6f71c6aea974c21fe28dfab912380dd3dd3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b/08/91/f8/84/0891f884-9eb2-447e-87ee-dbd93901afd4
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b/9b/5f/03/a5/9b5f03a5-851a-453d-9992-5da7a8c6db84
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b/08/91/f8/84/0891f884-9eb2-447e-87ee-dbd93901afd4
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b/9b/5f/03/a5/9b5f03a5-851a-453d-9992-5da7a8c6db84
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8c415ceba93e038362892dff0da1fbc64951246d"'
+      - '"fc7a5ab4aad14ad45b74ef8a70c7fae4fc10b77d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1016735119e61bdd4b97973dcc8d4ca67abefa42"'
+      - '"ba41765877dc2bd1dc15e3ca413be8f479106c65"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t/3b/8e/c8/4a/3b8ec84a-abdd-4de2-9c23-01059a57d9d8
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t/b8/0e/98/8f/b80e988f-d73b-415f-b9d5-3cac3bd17328
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t/3b/8e/c8/4a/3b8ec84a-abdd-4de2-9c23-01059a57d9d8
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t/b8/0e/98/8f/b80e988f-d73b-415f-b9d5-3cac3bd17328
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"65a657753e64cb0f912838d2caee6dfab754c4b9"'
+      - '"9c0c3a953b48228d56d5cf5aef53db0b363be431"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b/08/91/f8/84/0891f884-9eb2-447e-87ee-dbd93901afd4>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t/3b/8e/c8/4a/3b8ec84a-abdd-4de2-9c23-01059a57d9d8>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b/9b/5f/03/a5/9b5f03a5-851a-453d-9992-5da7a8c6db84>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t/b8/0e/98/8f/b80e988f-d73b-415f-b9d5-3cac3bd17328>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b/08/91/f8/84/0891f884-9eb2-447e-87ee-dbd93901afd4
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b/9b/5f/03/a5/9b5f03a5-851a-453d-9992-5da7a8c6db84
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fcc95951dc4de7b66f4af23d7b61cb080747bbff"'
+      - '"fbe6c6f71c6aea974c21fe28dfab912380dd3dd3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/b/08/91/f8/84/0891f884-9eb2-447e-87ee-dbd93901afd4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/b/9b/5f/03/a5/9b5f03a5-851a-453d-9992-5da7a8c6db84>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t/3b/8e/c8/4a/3b8ec84a-abdd-4de2-9c23-01059a57d9d8
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t/b8/0e/98/8f/b80e988f-d73b-415f-b9d5-3cac3bd17328
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1016735119e61bdd4b97973dcc8d4ca67abefa42"'
+      - '"ba41765877dc2bd1dc15e3ca413be8f479106c65"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940/t/3b/8e/c8/4a/3b8ec84a-abdd-4de2-9c23-01059a57d9d8>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061/t/b8/0e/98/8f/b80e988f-d73b-415f-b9d5-3cac3bd17328>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940</field><field
+        name="id">anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318401806560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/9c/0c/05/17/9c0c0517-278c-4050-8842-435500a61940","@type":"oa:Annotation","hasBody":"_:g70318401806560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312751623120","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3a/de/6e/03/3ade6e03-5c9b-4aa7-ab00-5a88a32f5061","@type":"oa:Annotation","hasBody":"_:g70312751623120","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>19}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/turtle/behaves_like_Accept_header_determines_media_type/text/turtle.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_create/response_format/turtle/behaves_like_Accept_header_determines_media_type/text/turtle.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9c4be86870374a4022d159be22b4c8540a6785a1"'
+      - '"0102a52b47b4a83dfbdb944fe114b5f5c7b7f8e2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:06 GMT
+      - Wed, 08 Jul 2015 18:54:04 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6a088c55b9b278da03472fbf5cd6052ddf5c654d"'
+      - '"72d3c5a7efdb4c5c33a7a97b3106f642fd4d8495"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '116'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8c70b18f55f20ce4aa51e559f428237994fd0ed2"'
+      - '"fe8434334e2b1d28c5244578eae6844d1202efa6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0bcb85ef72e8da5a4f074bf60f9ca571d5e6667b"'
+      - '"cbfec0c7a63d61c7f21a86944ae8c788c2ac8923"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b/f3/ba/e2/8a/f3bae28a-3810-4dc6-a06f-462841ce8240
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b/9a/7b/1c/14/9a7b1c14-30b3-4b99-96c0-d49ee475c59b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b/f3/ba/e2/8a/f3bae28a-3810-4dc6-a06f-462841ce8240
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b/9a/7b/1c/14/9a7b1c14-30b3-4b99-96c0-d49ee475c59b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fe20eaa9e52ffb935b2c5a46ac21f10e8747ff0b"'
+      - '"e4f21e2d5e6e91caf420c6e50edba9754bfda37f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9dd01bbe82a71bf7df8f5bcca346d1bdedce8090"'
+      - '"6e8f5f90a49e3384e7a6fadeee45bca9a1b96431"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Content-Length:
       - '167'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t/6e/ef/4a/ec/6eef4aec-3ada-4d2c-90b8-1a61b11fef13
+      - http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t/e4/5f/6d/96/e45f6d96-52ac-4ce6-aabf-1ebac302c350
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t/6e/ef/4a/ec/6eef4aec-3ada-4d2c-90b8-1a61b11fef13
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t/e4/5f/6d/96/e45f6d96-52ac-4ce6-aabf-1ebac302c350
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"37e918254fb07eebc6f23da90368555e8debe5df"'
+      - '"71345c548d045a0d870d23444d4cbe787a394643"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b/f3/ba/e2/8a/f3bae28a-3810-4dc6-a06f-462841ce8240>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t/6e/ef/4a/ec/6eef4aec-3ada-4d2c-90b8-1a61b11fef13>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b/9a/7b/1c/14/9a7b1c14-30b3-4b99-96c0-d49ee475c59b>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t/e4/5f/6d/96/e45f6d96-52ac-4ce6-aabf-1ebac302c350>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b/f3/ba/e2/8a/f3bae28a-3810-4dc6-a06f-462841ce8240
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b/9a/7b/1c/14/9a7b1c14-30b3-4b99-96c0-d49ee475c59b
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0bcb85ef72e8da5a4f074bf60f9ca571d5e6667b"'
+      - '"cbfec0c7a63d61c7f21a86944ae8c788c2ac8923"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/b/f3/ba/e2/8a/f3bae28a-3810-4dc6-a06f-462841ce8240>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/b/9a/7b/1c/14/9a7b1c14-30b3-4b99-96c0-d49ee475c59b>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t/6e/ef/4a/ec/6eef4aec-3ada-4d2c-90b8-1a61b11fef13
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t/e4/5f/6d/96/e45f6d96-52ac-4ce6-aabf-1ebac302c350
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9dd01bbe82a71bf7df8f5bcca346d1bdedce8090"'
+      - '"6e8f5f90a49e3384e7a6fadeee45bca9a1b96431"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:07 GMT
+      - Wed, 08 Jul 2015 18:54:05 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3/t/6e/ef/4a/ec/6eef4aec-3ada-4d2c-90b8-1a61b11fef13>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29/t/e4/5f/6d/96/e45f6d96-52ac-4ce6-aabf-1ebac302c350>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3</field><field
+        name="id">anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29</field><field
         name="root">anno_controller_create_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318421817080","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/11/94/c4/37/1194c437-049c-4e9e-9c3b-93a441f7b8a3","@type":"oa:Annotation","hasBody":"_:g70318421817080","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312769558380","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_create_specs/3b/95/f8/e8/3b95f8e8-d311-4800-b79b-8ad070560b29","@type":"oa:Annotation","hasBody":"_:g70312769558380","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:07 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3cd460a0d65736949c8b564319e219783d6707f1"'
+      - '"7abce68d6f8d1ae7155fd32a9164e09254b9e5c3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/fcr:tombstone
@@ -86,13 +86,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -110,7 +110,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -132,7 +132,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>15}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>49}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fdfce537e2d87d002412adfac7b5b33fa5c077e7"'
+      - '"4ec09eb6039bc23515833ad6c263bc1564205132"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:24 GMT
+      - Wed, 08 Jul 2015 18:54:22 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a9c9bed64ac1a87a870a3f4e26a8dcf00ea60057"'
+      - '"defa8012c83a8f9cf6177e252440c441aa3ec000"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '68'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/gives_404_resp_code.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/gives_404_resp_code.yml
@@ -43,5 +43,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/gives_html_response.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/gives_html_response.yml
@@ -43,5 +43,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/has_useful_info_in_the_response.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/non-existent_id/has_useful_info_in_the_response.yml
@@ -43,5 +43,5 @@ http_interactions:
         \                                               \n<br/>                                                \n<br/>
         \                                               \n<br/>                                                \n\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/returns_204_status_code_for_successful_delete.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_destroy/returns_204_status_code_for_successful_delete.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a9c9bed64ac1a87a870a3f4e26a8dcf00ea60057"'
+      - '"defa8012c83a8f9cf6177e252440c441aa3ec000"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d624d022670a1229945f1623a82407d9fed94139"'
+      - '"f76cfa628448819faba39a475ab173615215cd7c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fc57542d73a996bb1b1e2f150e69d4f97d50de63"'
+      - '"aa9f634bf10795fc762026424abe3e852899b60a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b
+      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4e4bce5a3267331b906dbcf9f553704d21de77a9"'
+      - '"768bbf3e8357a969954afacd1a56a4597a3325e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519
+      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"dcd597bb8cc1cd4603a0b9595119d93338f98280"'
+      - '"cebc5214904dc4256870b0bfd544bdc9f79e3414"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t
+      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fe27875e772e32b0d59699e207b42dab2749dc9a"'
+      - '"b1f88da9c5537ac6da1937a66a73a6d0cb1bad06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb
+      - http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb
+      string: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"445c05b4c83b9e4a2cfff3abf3199036569c8f01"'
+      - '"cf7ccd61b9f7b6597ffacaf395e91d9d4526b7f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4e4bce5a3267331b906dbcf9f553704d21de77a9"'
+      - '"768bbf3e8357a969954afacd1a56a4597a3325e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fe27875e772e32b0d59699e207b42dab2749dc9a"'
+      - '"b1f88da9c5537ac6da1937a66a73a6d0cb1bad06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:23 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845</field><field
+        name="id">anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe</field><field
         name="root">anno_controller_destroy_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318407073900","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845","@type":"oa:Annotation","hasBody":"_:g70318407073900","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312664794720","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe","@type":"oa:Annotation","hasBody":"_:g70312664794720","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,10 +484,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>8}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: US-ASCII
       string: ''
@@ -506,9 +506,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"445c05b4c83b9e4a2cfff3abf3199036569c8f01"'
+      - '"cf7ccd61b9f7b6597ffacaf395e91d9d4526b7f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -542,18 +542,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47
     body:
       encoding: US-ASCII
       string: ''
@@ -572,9 +572,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4e4bce5a3267331b906dbcf9f553704d21de77a9"'
+      - '"768bbf3e8357a969954afacd1a56a4597a3325e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -608,14 +608,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf
     body:
       encoding: US-ASCII
       string: ''
@@ -634,9 +634,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fe27875e772e32b0d59699e207b42dab2749dc9a"'
+      - '"b1f88da9c5537ac6da1937a66a73a6d0cb1bad06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -670,14 +670,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: US-ASCII
       string: ''
@@ -696,9 +696,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"445c05b4c83b9e4a2cfff3abf3199036569c8f01"'
+      - '"cf7ccd61b9f7b6597ffacaf395e91d9d4526b7f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -732,18 +732,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b>
-        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b>
+        , <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47
     body:
       encoding: US-ASCII
       string: ''
@@ -762,9 +762,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4e4bce5a3267331b906dbcf9f553704d21de77a9"'
+      - '"768bbf3e8357a969954afacd1a56a4597a3325e1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -798,14 +798,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/b/87/8f/65/d5/878f65d5-8d6b-45fc-91b6-d256437c0519>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/b/c0/48/15/7d/c048157d-4964-4642-a188-93d44ec0fa47>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf
     body:
       encoding: US-ASCII
       string: ''
@@ -824,9 +824,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fe27875e772e32b0d59699e207b42dab2749dc9a"'
+      - '"b1f88da9c5537ac6da1937a66a73a6d0cb1bad06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:25 GMT
+      - Wed, 08 Jul 2015 18:54:23 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -860,14 +860,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845/t/1b/ec/b5/9d/1becb59d-9306-402a-935d-90aeb0a7d2fb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe/t/43/30/a8/56/4330a856-2887-48c1-9520-4df7d2c203cf>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845
+    uri: http://localhost:8983/fedora/rest/anno/anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe
     body:
       encoding: US-ASCII
       string: ''
@@ -889,13 +889,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_destroy_specs/e6/b3/a9/b5/e6b3a9b5-5156-44f6-95ef-6cd01e248845</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>anno_controller_destroy_specs/e1/57/3d/ce/e1573dce-80f2-447d-baf5-019c3ac30ebe</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -911,9 +911,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>15}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -935,7 +935,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>31}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>104}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_index/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_index/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e7e34e5a887ed11595f5bd2b592876c72aa51b89"'
+      - '"1f0e3a65c41ede92ad8e7a84e3bd8a8b6ce20a23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_index_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_index_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_index/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_index/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7aaa99c276f01e8078ec7b1eb31699baede17c43"'
+      - '"a2dc696d0aa4fdc0b93e9146cc33d2b1c6efa591"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_index_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e7e34e5a887ed11595f5bd2b592876c72aa51b89"'
+      - '"1f0e3a65c41ede92ad8e7a84e3bd8a8b6ce20a23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Content-Length:
       - '66'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/anno_controller_index_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"323e519b01c0801083a6d7e64cd37e3c386b01ab"'
+      - '"aa4aad0bf9d7b08adf61ae622affa4e416c8dbc2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:29 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:27 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_show_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:29 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:27 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_show_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:29 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:27 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:29 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_AnnotationsController/_show/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"49000f5d52f59fd43efd42316d593375debcd932"'
+      - '"48b90ab980ab0c883cc280630a30c255111f9d96"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/anno_controller_show_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"323e519b01c0801083a6d7e64cd37e3c386b01ab"'
+      - '"aa4aad0bf9d7b08adf61ae622affa4e416c8dbc2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:26 GMT
+      - Wed, 08 Jul 2015 18:54:24 GMT
       Content-Length:
       - '65'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/anno_controller_show_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:26 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/appends_the_path_param_to_config_ldp_url_.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/appends_the_path_param_to_config_ldp_url_.yml
@@ -26,5 +26,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/avoids_double_slash_if_slash_at_beginning_of_path.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/avoids_double_slash_if_slash_at_beginning_of_path.yml
@@ -26,5 +26,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/avoids_double_slash_if_slash_at_end_of_ldp_base_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/avoids_double_slash_if_slash_at_end_of_ldp_base_url.yml
@@ -17,7 +17,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Server:
       - Apache/2.0.52 (Red Hat)
       X-Powered-By:
@@ -34,5 +34,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/false_for_non-existent_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/false_for_non-existent_container.yml
@@ -26,5 +26,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/true_for_existing_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_container_exist_/true_for_existing_container.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"988ba6be1f0711f7966afc407aee452d5fab3ac8"'
+      - '"fc9a0c8c7886b637ac09286108b6b154147801f9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,5 +38,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_base.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_base.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cff82ab12c6dfd9d2716ceaee6b8c606c2c03446"'
+      - '"35a15ea1ac9bfd11c2f930e14b550d65edab42d9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"24b3b29950d8dccbc3f95f4c79453bfb07387839"'
+      - '"07639d1296b4a5e15619c9fcec7d069a42f9be81"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"165e4332f7c7404027723065125c0af1424dd50d"'
+      - '"9619b2badd1bb268255c9831054678ad48678740"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f10e1bb422c2334229cfc6f9ba7def671fc8d73b"'
+      - '"818e40245bf867d9cfd63a0818485f60e3be3214"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/b/97/eb/d6/7c/97ebd67c-53ea-4256-9be4-e230857cf069
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/b/22/ce/14/32/22ce1432-14e6-4b32-96fe-df7e29533064
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/b/97/eb/d6/7c/97ebd67c-53ea-4256-9be4-e230857cf069
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/b/22/ce/14/32/22ce1432-14e6-4b32-96fe-df7e29533064
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"012814c57141af329c8e7c47337a115cd1a9509a"'
+      - '"a98657644595ae3e11b43df93e40cf8deba07f56"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/t
     body:
       encoding: UTF-8
       string: |
@@ -251,18 +251,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5d41101c84a43309d93ea98051d98a0e3a0363ca"'
+      - '"cac981ec7bd426c8ad97ff9d4ad3f685a0867e91"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/t/4b/ee/e1/a9/4beee1a9-fcf9-4da1-871f-0a34bbc9d3ed
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/t/43/98/cd/66/4398cd66-0da8-4b0b-91a2-a3acb0548e72
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/t/4b/ee/e1/a9/4beee1a9-fcf9-4da1-871f-0a34bbc9d3ed
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/t/43/98/cd/66/4398cd66-0da8-4b0b-91a2-a3acb0548e72
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_body_container_and_create_body_resources_if_there_are_bodies.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_body_container_and_create_body_resources_if_there_are_bodies.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"65c7a9a64b95bbb8238ea0f94fd254a3cab88760"'
+      - '"1a4157d33d1982b804537729cfec778239341a20"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e9c67effd2c0925adaa462de346ca613a6cab1b4"'
+      - '"51c3a1ec9cf06138780c32718576008e1904675d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1ae6457ca2682b2d5bfe5b9a242278c7a591cfe5"'
+      - '"f1e6c5c71cb62016c16109550e0c93a4900b26d5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
     body:
       encoding: UTF-8
       string: |
@@ -141,7 +141,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -161,23 +161,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b4661b111f6fdf97f3a266d1ed30847e3b0d454f"'
+      - '"6d60f74e998eb013721cb6a489a25b22322a4a84"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/t
     body:
       encoding: UTF-8
       string: |
@@ -204,18 +204,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"386788168c278f1d29f4a8073dec5f8950a0c587"'
+      - '"56909ee085dd9d52f7eb39eeca8d3db14922b969"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/t/75/54/c9/82/7554c982-d15e-4e52-9d99-1d139f54af7f
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/t/aa/73/86/15/aa738615-bfb7-4be4-86e0-4529d5cb8550
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/t/75/54/c9/82/7554c982-d15e-4e52-9d99-1d139f54af7f
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/t/aa/73/86/15/aa738615-bfb7-4be4-86e0-4529d5cb8550
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_target_container_and_create_target_resource.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/calls_create_target_container_and_create_target_resource.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"340b28c4ca7455594b7865cbcd700a3cfa9184cc"'
+      - '"a5595acb1a66ee5efda1c95d6fd5c868027bd064"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7570ab0f72326d2ce13793961942d2da996b494c"'
+      - '"b27309bf6e78d0d7b715a5266ce09d888bd7ea60"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"740ab2f3f1b4171bc41c5a2cba460a6d827ba737"'
+      - '"1dd9db78dbc9ec5d7a6ee3dfe1dc811229158e76"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"06d0c392a98d6f8a46883046b4690ac0f9e937be"'
+      - '"1af5da98347d0df6f61b25060828acd8ea1779c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/b/03/34/ca/58/0334ca58-0076-40a6-bfa5-2ad4bffd9335
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/b/7d/42/c4/d5/7d42c4d5-9bc1-4414-bb85-b564343c1492
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/b/03/34/ca/58/0334ca58-0076-40a6-bfa5-2ad4bffd9335
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/b/7d/42/c4/d5/7d42c4d5-9bc1-4414-bb85-b564343c1492
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,18 +208,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"53e1524e52cc8cc5ec721c5fa066f97769cab591"'
+      - '"83d914d334401e5f179d0357a26d114ab28fec06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_LDP_resource_for_bodies_ldp_container_at_id_/b.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_LDP_resource_for_bodies_ldp_container_at_id_/b.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"22b9edfffa7129b7ef0ba1f81ea2319d12fc7806"'
+      - '"d9cbcfbbaf696267d3dc8ca64649018e9a9c70cf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e029ed677b29412d3115345753065e4f39c68698"'
+      - '"366a42200c26583a98e4046eac2003cbde8119de"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b3a92bdb51f8b6eefdc95f9974406467fdac50b9"'
+      - '"63463bd151150cb825717ebe2c750e8b27ae477e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7186631ae1e4cee56075a297e2acca8113a118ca"'
+      - '"0883b781bd8e8190acf8f01f917408a5345689d8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b/50/31/ae/b9/5031aeb9-c222-4893-9259-1c7364bb9263
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b/24/de/f0/ac/24def0ac-8694-489f-93f0-69dfe6808fe2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b/50/31/ae/b9/5031aeb9-c222-4893-9259-1c7364bb9263
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b/24/de/f0/ac/24def0ac-8694-489f-93f0-69dfe6808fe2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"13a9ea7b03bfbdf73f5801400f0a627faa012f76"'
+      - '"074c7a8fc55acf1c4cb02eb0b7e10647d0d4f94a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0909ad08f232e8515a23cca31927801b9cf0a3b9"'
+      - '"658ded64d73a6565c5a7e95a6a5104652867555b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/t/b4/a8/f1/34/b4a8f134-4648-47ea-a7c3-633edaa6d92a
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/t/02/1f/71/ba/021f71ba-6bd4-4276-808e-1e98550cb6ba
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/t/b4/a8/f1/34/b4a8f134-4648-47ea-a7c3-633edaa6d92a
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/t/02/1f/71/ba/021f71ba-6bd4-4276-808e-1e98550cb6ba
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b
     body:
       encoding: US-ASCII
       string: ''
@@ -284,9 +284,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3e79350dd4e2a31fded408a58ce3150e90413c44"'
+      - '"3748ed9f75e360f2e0e479b0e96b44c70ba5c565"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -303,7 +303,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3380'
+      - '3485'
       Content-Type:
       - application/x-turtle
     body:
@@ -320,29 +320,30 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"dfc3b9c5-2e5d-4d3b-a39e-67b12e749c77\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"804379da-6f41-487f-a790-9863a0457c43\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:11.941Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:08.114Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:11.973Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:08.14Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b/50/31/ae/b9/5031aeb9-c222-4893-9259-1c7364bb9263>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b/24/de/f0/ac/24def0ac-8694-489f-93f0-69dfe6808fe2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/b/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_LDP_resource_for_targets_ldp_container_at_id_/t.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_LDP_resource_for_targets_ldp_container_at_id_/t.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"36ee5a839f5d5634fe7ba4c6ec3134627acd6b78"'
+      - '"291ff3004cf70b1c601ca6829c71c1713124cdf7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d8de10cca01b312510b388117e7444fb55756fa2"'
+      - '"5a2dd77624036844f6b2d992b79feff6cc878ae7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6f346b1cda27942f64a4ba3daab0187c247c5c7c"'
+      - '"d58dff95d1a9228d1b1ea842ca0508f7464005de"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"634a2cb16eb7f4e9b87a63822a646e052f1f34dc"'
+      - '"9654283674439350f7cfb16904cf87b76c5b02f3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/b/aa/cc/5f/19/aacc5f19-981a-494c-a8c2-5b9c98908c6c
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/b/d5/a9/36/52/d5a93652-5dae-4373-8021-514671bc4e58
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/b/aa/cc/5f/19/aacc5f19-981a-494c-a8c2-5b9c98908c6c
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/b/d5/a9/36/52/d5a93652-5dae-4373-8021-514671bc4e58
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"52bdf0b83a05edf1dfaa9c20fbb87873f5d82deb"'
+      - '"f027437106e489b27d18be86745327284880c87a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f6c26a50ecfd08d5281052a77d6282eae7a89d23"'
+      - '"5922d3c3cee2a6bef654b233d750f259b953084a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t/19/be/7b/83/19be7b83-c836-4d31-adc0-19f38538410f
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t/83/1f/af/f3/831faff3-f838-4ca2-ae2e-47811ace564d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t/19/be/7b/83/19be7b83-c836-4d31-adc0-19f38538410f
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t/83/1f/af/f3/831faff3-f838-4ca2-ae2e-47811ace564d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t
     body:
       encoding: US-ASCII
       string: ''
@@ -284,9 +284,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"de74c4edd2fbf119f3f8d76aa72be128a812e4d4"'
+      - '"59c073b06f359a4a7e9a2853d7155d5ffc2d7ccc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -303,7 +303,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3487'
+      - '3488'
       Content-Type:
       - application/x-turtle
     body:
@@ -320,30 +320,30 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"4166a3b6-79a9-4730-9750-92251ea9a30b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"433ebe42-4aa7-4382-bf87-0b8586968146\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:12.81Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:08.888Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:12.835Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:08.914Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t/19/be/7b/83/19be7b83-c836-4d31-adc0-19f38538410f>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t/83/1f/af/f3/831faff3-f838-4ca2-ae2e-47811ace564d>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/t/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/t/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_single_body_container_with_multiple_resources_if_there_are_multiple_bodies.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_single_body_container_with_multiple_resources_if_there_are_multiple_bodies.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a38b9a0a565ea06ece8024ee7b49e33a74759260"'
+      - '"6547a7015771d56fe573b64620bf61cbb6885a00"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d08dd0c8f3343c0dd2de84e028a20f08ad626e60"'
+      - '"86e510c2bd9e86320dd533aff643d4df1e06109a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e06f1e7c10416297b44740c319452e433919c922"'
+      - '"25b356c75d4fed486e876b02b35b604ea68c1e64"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"58a2366098027db4ddf375f5d3661b120515821e"'
+      - '"baf034f4763af999b82340ca3ee8cd3c6163944e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/e7/a8/93/d0/e7a893d0-31fd-48d1-920a-fe03b5a1535f
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/7d/e8/fc/52/7de8fc52-b23e-412d-9134-6a767e163e5f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/e7/a8/93/d0/e7a893d0-31fd-48d1-920a-fe03b5a1535f
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/7d/e8/fc/52/7de8fc52-b23e-412d-9134-6a767e163e5f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b
     body:
       encoding: UTF-8
       string: |
@@ -207,23 +207,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ce13732a26f039c726526b3eef7f2947d9b7b404"'
+      - '"50f8b18f37844ed77d71d508ffee2196d14ea50b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/73/6e/45/f1/736e45f1-b2eb-4986-9b7e-a2d5d27d2780
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/56/50/f8/30/5650f830-52a3-4fba-91ff-7ff78d3941a5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/73/6e/45/f1/736e45f1-b2eb-4986-9b7e-a2d5d27d2780
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/56/50/f8/30/5650f830-52a3-4fba-91ff-7ff78d3941a5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b
     body:
       encoding: US-ASCII
       string: ''
@@ -240,9 +240,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e2429f723c6c6fceaa5c9147a641828bb3d83157"'
+      - '"b1ac8e764bb0634945af3dac8de0abfd2c137dac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -259,7 +259,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3643'
+      - '3536'
       Content-Type:
       - application/x-turtle
     body:
@@ -276,31 +276,30 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"cd4833f9-7b9c-4edc-9b9a-47cbb728edba\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"2bcd4f71-33a1-4e67-87fc-7028e63abcd1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:12.377Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:08.476Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:12.431Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:08.53Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/e7/a8/93/d0/e7a893d0-31fd-48d1-920a-fe03b5a1535f>
-        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/73/6e/45/f1/736e45f1-b2eb-4986-9b7e-a2d5d27d2780>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/7d/e8/fc/52/7de8fc52-b23e-412d-9134-6a767e163e5f>
+        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/56/50/f8/30/5650f830-52a3-4fba-91ff-7ff78d3941a5>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/b/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/b/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_single_target_container_with_multiple_resources_if_there_are_multiple_targets.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/creates_a_single_target_container_with_multiple_resources_if_there_are_multiple_targets.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"caba4ad970194f25802317ffcef16305021f7460"'
+      - '"99255970fbf0283f34861241b9169fa29fd6db04"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"09a3a010c3ad78e9ee766635547e9dff3a98a9ac"'
+      - '"d1aecabe8d8f6c4472ea124e346e5c38b381707b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4b0e447aa4b5d4c375bfec4c3e68951d6fca9b8a"'
+      - '"12b152078d8102a07d9ff1b26473bd1d79beb12a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:12 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t
     body:
       encoding: UTF-8
       string: |
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c2d7427878da1453e9a853bc45282aaced991120"'
+      - '"3d6175875e66205931a136811e02e30d44ddf4ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/e7/e2/92/2a/e7e2922a-db10-469b-9a80-80815157e853
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/0f/c6/44/e0/0fc644e0-cbad-4220-b966-e5bd3368831f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/e7/e2/92/2a/e7e2922a-db10-469b-9a80-80815157e853
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/0f/c6/44/e0/0fc644e0-cbad-4220-b966-e5bd3368831f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t
     body:
       encoding: UTF-8
       string: |
@@ -200,23 +200,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9698b265db0ca424df82fd8d835368284665eb98"'
+      - '"32131a9ad21025dc58dfe94fd955548cec919b2f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/64/a0/75/a8/64a075a8-4db0-452e-b19c-92b517bf9770
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/d0/a6/f1/00/d0a6f100-8a9c-408b-a029-f3f784f836f5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/64/a0/75/a8/64a075a8-4db0-452e-b19c-92b517bf9770
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/d0/a6/f1/00/d0a6f100-8a9c-408b-a029-f3f784f836f5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t
     body:
       encoding: US-ASCII
       string: ''
@@ -233,9 +233,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9bca43b180a6c0c346f4ff74b71d6d23708de732"'
+      - '"a4e2fa3eec5a7955ed6f3abe4caf519a6cbbb7e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -252,7 +252,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3539'
+      - '3644'
       Content-Type:
       - application/x-turtle
     body:
@@ -269,30 +269,31 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"84625f2d-6392-4a51-879d-74bfa37c2938\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"c74e29db-717a-48e4-9c8d-269d576b7719\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:12.996Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:09.08Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:13.044Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:09.125Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/e7/e2/92/2a/e7e2922a-db10-469b-9a80-80815157e853>
-        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/64/a0/75/a8/64a075a8-4db0-452e-b19c-92b517bf9770>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/0f/c6/44/e0/0fc644e0-cbad-4220-b966-e5bd3368831f>
+        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/d0/a6/f1/00/d0a6f100-8a9c-408b-a029-f3f784f836f5>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/t/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/does_not_create_a_body_container_if_there_are_no_bodies.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/does_not_create_a_body_container_if_there_are_no_bodies.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"78bdb208bf00b87bbdfd9f0fd694d2ad998a8697"'
+      - '"9ba3a1b3fa032a22c0db767c1c0c7684b3de6f86"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0cc8865305aeb9825f005b5bb462d398b4ed9b7b"'
+      - '"67a4ec9178536b4274206a8cd6b5d7ef47b65868"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4dbecdead4edcc6e8210e5aa14ac1a87c8243304"'
+      - '"3196af3520dfce5f98e8b5647b1b6d04da5e64db"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/t
     body:
       encoding: UTF-8
       string: |
@@ -157,18 +157,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e9c36af079bcab39504b839d398b98042b49cfd1"'
+      - '"726bbec7beecc7134677ba11fab8aae5c117ccba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/t/6f/27/b7/b9/6f27b7b9-7064-4ef2-91d1-bf88554e5cb5
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/t/79/75/d5/fd/7975d5fd-7f16-4795-8b43-de583d3e5d73
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/t/6f/27/b7/b9/6f27b7b9-7064-4ef2-91d1-bf88554e5cb5
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/t/79/75/d5/fd/7975d5fd-7f16-4795-8b43-de583d3e5d73
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:08 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/returns_the_pid_of_the_annotation_container_in_LDP_store.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_anno/returns_the_pid_of_the_annotation_container_in_LDP_store.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4b1fab8778c4023ce5b31a400076737ca95d2bec"'
+      - '"a4c94012d0061cfb8581bd4bd43c61c1abcbfad6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"00ae379930c9f44a81f582d8350b6615efbf8ecf"'
+      - '"565d4309bae32f8e324248fa58b082a0f3d49769"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '101'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"340016a0fe0d8beab945012701df9734a02bc5a4"'
+      - '"c3f10beed1edb0f0d5b804064213ea092866ac1d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"39f20b2a16376e051c8553bf29ddb4274c07eba2"'
+      - '"fe11f1eab9cd1bd43a8c804f0f90fe80d6d87704"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b/37/73/45/2f/3773452f-c974-4839-ae37-51ca93c3aeef
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b/53/6c/79/2b/536c792b-715c-4b45-86f9-ce4f773a95dd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b/37/73/45/2f/3773452f-c974-4839-ae37-51ca93c3aeef
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b/53/6c/79/2b/536c792b-715c-4b45-86f9-ce4f773a95dd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9862499ef391d78e7051ba447cdc84d340f455a8"'
+      - '"f83a33639b36d21a1226c4a184f44f176c55b657"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '103'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"81e2357893e3b6c5c54cef22e209e1dc52da85b8"'
+      - '"a0080f656d242d6c879d7a910827a6307c086a31"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '152'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t/1e/72/2d/7c/1e722d7c-1ca4-4b4e-b743-ac3e471f3742
+      - http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t/49/85/cc/e7/4985cce7-f6f0-4ef6-a550-74bae518c8d8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t/1e/72/2d/7c/1e722d7c-1ca4-4b4e-b743-ac3e471f3742
+      string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t/49/85/cc/e7/4985cce7-f6f0-4ef6-a550-74bae518c8d8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     body:
       encoding: US-ASCII
       string: ''
@@ -284,9 +284,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bed89a32e10a47b872fc264602d50c3be98cb240"'
+      - '"d6999d0cb0f37f377089392f9e8a627cf3b54883"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -303,7 +303,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3664'
+      - '3769'
       Content-Type:
       - application/x-turtle
     body:
@@ -320,32 +320,33 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"6e977b41-3138-4d60-a060-c0a657ba9515\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"e066e601-e874-487f-b0c8-bb56ab23f42c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:11.54Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:07.729Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:11.626Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:07.803Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy oa:commenting ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b>
-        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/t/1e/72/2d/7c/1e722d7c-1ca4-4b4e-b743-ac3e471f3742>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/b/37/73/45/2f/3773452f-c974-4839-ae37-51ca93c3aeef>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/fcr:export?format=jcr/xml>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b>
+        , <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/b/53/6c/79/2b/536c792b-715c-4b45-86f9-ce4f773a95dd>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/t/49/85/cc/e7/4985cce7-f6f0-4ef6-a550-74bae518c8d8>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/avoids_double_slash_in_url/slug_starts_with_slash.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/avoids_double_slash_in_url/slug_starts_with_slash.yml
@@ -26,7 +26,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -54,9 +54,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7a247a54f18ca7356a77d11c1529103bc4ff0bc2"'
+      - '"732c93174204afa94a57c9cef1a527594b5406a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '52'
       Location:
@@ -67,7 +67,7 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/initial_slash
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: get
     uri: http://localhost:8983/fedora/rest/anno/initial_slash
@@ -87,9 +87,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7a247a54f18ca7356a77d11c1529103bc4ff0bc2"'
+      - '"732c93174204afa94a57c9cef1a527594b5406a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -130,13 +130,13 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"9385f0c0-b543-4e7e-863a-54b8a42005d5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"ee05137b-1a3f-49a3-8fd2-12e58fc851e0\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:14.174Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:09.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:14.174Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:09.866Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno> ;\n\tfedora:exportsAs
         <http://localhost:8983/fedora/rest/anno/initial_slash/fcr:export?format=jcr/xml>
@@ -145,7 +145,7 @@ http_interactions:
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno//initial_slash
@@ -172,5 +172,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"988ba6be1f0711f7966afc407aee452d5fab3ac8"'
+      - '"fc9a0c8c7886b637ac09286108b6b154147801f9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/created_before
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b36ef81e55a1b27f8574040e8e48705a96130c4e"'
+      - '"c00fdd0fc1c8b75eedd58f5952de1a36fe0cc25e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '53'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/created_before
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/creates_container_if_it_doesn_t_already_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/creates_container_if_it_doesn_t_already_exist.yml
@@ -26,7 +26,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -54,9 +54,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"df053e1aa12c5e2a9edbcfbdefac858b320c0c82"'
+      - '"2b889b7ae60554cb323f9d5f2d569e7b19fc1d83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '57'
       Location:
@@ -67,7 +67,7 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: get
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee
@@ -87,9 +87,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df053e1aa12c5e2a9edbcfbdefac858b320c0c82"'
+      - '"2b889b7ae60554cb323f9d5f2d569e7b19fc1d83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -130,13 +130,13 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"08e3c5b3-112f-43ce-aaff-804782994d4c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"dfdf47d6-79b8-46d5-b507-b328114abeee\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:13.779Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:09.495Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:13.779Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:09.495Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec>
         .\n\n<http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee/fcr:export?format=jcr/xml>
@@ -146,5 +146,5 @@ http_interactions:
         <http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/parent_path_missing_nil_or_empty_creates_container_directly_under_ldp_base_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/parent_path_missing_nil_or_empty_creates_container_directly_under_ldp_base_url.yml
@@ -26,7 +26,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest
@@ -54,9 +54,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"18ed25533531df425b3fdfad4d4f6795b0c89fd0"'
+      - '"4a7640c921ca86a41b929a2ee7f5b245d022e5db"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '53'
       Location:
@@ -67,7 +67,7 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/missing_parent_path
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: get
     uri: http://localhost:8983/fedora/rest/missing_parent_path
@@ -87,9 +87,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"18ed25533531df425b3fdfad4d4f6795b0c89fd0"'
+      - '"4a7640c921ca86a41b929a2ee7f5b245d022e5db"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -106,7 +106,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2822'
+      - '2824'
       Content-Type:
       - application/x-turtle
     body:
@@ -130,13 +130,13 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"83b3f54f-aca4-4696-86a1-15317ce49230\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"02e60835-a453-45c3-a291-98f907a73bfa\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:14.05Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:09.745Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:14.05Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:09.745Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/> ;\n\tfedora:exportsAs
         <http://localhost:8983/fedora/rest/missing_parent_path/fcr:export?format=jcr/xml>
@@ -145,7 +145,7 @@ http_interactions:
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/missing_parent_path
@@ -172,5 +172,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/returns_false_and_prints_a_message_if_container_already_exists.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/returns_false_and_prints_a_message_if_container_already_exists.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b36ef81e55a1b27f8574040e8e48705a96130c4e"'
+      - '"c00fdd0fc1c8b75eedd58f5952de1a36fe0cc25e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,5 +38,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/returns_true_and_prints_a_message_to_STDOUT_if_it_creates_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/_create_basic_container/returns_true_and_prints_a_message_to_STDOUT_if_it_creates_container.yml
@@ -26,7 +26,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -54,9 +54,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"06b95694a63522a539a39a349849f068a2326263"'
+      - '"f758376cc63b8d366789438f4d1884206da41671"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Content-Length:
       - '64'
       Location:
@@ -67,7 +67,7 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: get
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test
@@ -87,9 +87,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"06b95694a63522a539a39a349849f068a2326263"'
+      - '"f758376cc63b8d366789438f4d1884206da41671"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -130,13 +130,13 @@ http_interactions:
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"e22d3ca6-a987-41ec-9b4e-1d44c43c0658\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"50f64002-2ec9-4cac-aab9-f80753ccdca1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:13.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:09.613Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:13.889Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:09.613Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwclassspec>
         ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test/fcr:export?format=jcr/xml>
@@ -145,5 +145,5 @@ http_interactions:
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:13 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/after_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/after_ldp_writer_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
     body:
       encoding: US-ASCII
       string: ''
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ef2102c71f3862830ac3becb61abcb2c53ef193f"'
+      - '"ac2188dca4895bc0c011c114010720377b3c7583"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,10 +38,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:09 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb
     body:
       encoding: US-ASCII
       string: ''
@@ -63,10 +63,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/ac/1b/c7/cc/ac1bc7cc-f50f-4fff-88fd-b6fb74877503/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/35/66/b8/fb/3566b8fb-aac4-4413-8ec7-696547535ffb/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -86,10 +86,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     body:
       encoding: US-ASCII
       string: ''
@@ -104,9 +104,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bed89a32e10a47b872fc264602d50c3be98cb240"'
+      - '"d6999d0cb0f37f377089392f9e8a627cf3b54883"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -125,10 +125,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8
     body:
       encoding: US-ASCII
       string: ''
@@ -150,10 +150,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/1b/27/0b/49/1b270b49-e417-4b14-94dd-b9f57555e379/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d5/d8/c6/cf/d5d8c6cf-5484-4e43-a96e-3af8b85035c8/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -173,10 +173,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15
     body:
       encoding: US-ASCII
       string: ''
@@ -191,9 +191,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"13c7ecf15e0e63dcba823c6cdc6b13ece548ccba"'
+      - '"95d8f08675c91a5c6912116154b6f5618aec377d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -212,10 +212,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15
     body:
       encoding: US-ASCII
       string: ''
@@ -237,10 +237,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/9a/fb/2e/50/9afb2e50-6447-4bf5-b0e1-5ebd06924e7a/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a1/fb/f8/15/a1fbf815-a1b9-4885-bf76-1a8a8cc6bc15/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -260,10 +260,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
     body:
       encoding: US-ASCII
       string: ''
@@ -278,9 +278,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"160808087b2b3b1e9e3815312f6c57d212d20b3a"'
+      - '"36a7876c62a96ede583ecf52ae494b45d9e78221"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -299,10 +299,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1
     body:
       encoding: US-ASCII
       string: ''
@@ -324,10 +324,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a2/36/40/be/a23640be-ec90-4bf1-9259-1f786f7a00af/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/2c/2f/fa/81/2c2ffa81-0b09-4580-817a-c3be8ced03e1/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -347,10 +347,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
     body:
       encoding: US-ASCII
       string: ''
@@ -365,9 +365,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"284a2289003bfab56a402588a585b93d925d1c0f"'
+      - '"67f3f86425c500a30f2eee8bc1f5b8520449b08e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -386,10 +386,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466
     body:
       encoding: US-ASCII
       string: ''
@@ -411,10 +411,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/d8/0c/42/a9/d80c42a9-55a3-431b-95a9-5eb074d1b7ac/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/0a/44/75/1b/0a44751b-0f5c-486c-9595-a7713bdf1466/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -434,10 +434,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24
     body:
       encoding: US-ASCII
       string: ''
@@ -452,9 +452,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8c327368a49430e806f9eb2dcd8b8a70464e5361"'
+      - '"dadcbf4b1c6c00c763ba8b262d82cf47858eea6f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -473,10 +473,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24
     body:
       encoding: US-ASCII
       string: ''
@@ -498,10 +498,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/b1/45/b4/c0/b145b4c0-9c73-4022-8b20-3fadfebf4b22/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/77/f2/15/80/77f21580-5ee4-47b0-9c69-94323760bd24/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -521,10 +521,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
     body:
       encoding: US-ASCII
       string: ''
@@ -539,9 +539,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6a12345c8017ff8eabe5b10b1837971f832929ad"'
+      - '"9817e46f11cc1ebeb2bfc23b97249fce01601e06"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -560,10 +560,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725
     body:
       encoding: US-ASCII
       string: ''
@@ -585,10 +585,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/54/36/04/45/54360445-495b-46d2-ab3d-487d4847de9d/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/7f/65/6d/51/7f656d51-0916-40fa-a8cc-0707ecc72725/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -608,10 +608,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
     body:
       encoding: US-ASCII
       string: ''
@@ -626,9 +626,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"746bafc54a7d39762399e1e17619573dcec4f92d"'
+      - '"43d48ffe42c912e9af827d048bfe458f867dc8b3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:08 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -647,10 +647,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c
     body:
       encoding: US-ASCII
       string: ''
@@ -672,10 +672,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/c0/3b/01/b9/c03b01b9-209d-405d-be33-a25555262d02/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/a9/fc/67/92/a9fc6792-8ff8-4dc8-a860-9424712b1a2c/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -695,10 +695,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff
     body:
       encoding: US-ASCII
       string: ''
@@ -713,9 +713,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"892359b04a5a95b08bccbd89f64f7fb1f73cda87"'
+      - '"cf3a31622ccad76105ba9faef08139d0a41e7caf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:12 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -734,10 +734,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff
     body:
       encoding: US-ASCII
       string: ''
@@ -759,10 +759,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/83/16/9e/f6/83169ef6-76a2-482e-92e3-38e7904e76ac/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/e3/20/82/ae/e32082ae-881a-4b28-b07f-853e23ffa6ff/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -782,7 +782,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/created_before
@@ -800,9 +800,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b36ef81e55a1b27f8574040e8e48705a96130c4e"'
+      - '"c00fdd0fc1c8b75eedd58f5952de1a36fe0cc25e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -821,7 +821,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/created_before
@@ -846,7 +846,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/created_before/fcr:tombstone
@@ -869,7 +869,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee
@@ -887,9 +887,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df053e1aa12c5e2a9edbcfbdefac858b320c0c82"'
+      - '"2b889b7ae60554cb323f9d5f2d569e7b19fc1d83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -908,7 +908,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee
@@ -933,7 +933,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/whee/fcr:tombstone
@@ -956,7 +956,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test
@@ -974,9 +974,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"06b95694a63522a539a39a349849f068a2326263"'
+      - '"f758376cc63b8d366789438f4d1884206da41671"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:13 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -995,7 +995,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test
@@ -1020,7 +1020,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/stdout-test/fcr:tombstone
@@ -1043,7 +1043,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:14 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/missing_parent_path
@@ -1061,9 +1061,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"18ed25533531df425b3fdfad4d4f6795b0c89fd0"'
+      - '"4a7640c921ca86a41b929a2ee7f5b245d022e5db"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -1082,7 +1082,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/missing_parent_path
@@ -1107,7 +1107,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/missing_parent_path/fcr:tombstone
@@ -1130,7 +1130,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/initial_slash
@@ -1148,9 +1148,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7a247a54f18ca7356a77d11c1529103bc4ff0bc2"'
+      - '"732c93174204afa94a57c9cef1a527594b5406a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:09 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -1169,7 +1169,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/initial_slash
@@ -1194,7 +1194,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/initial_slash/fcr:tombstone
@@ -1217,7 +1217,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -1235,9 +1235,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"baab42a2df0b6793f6cf0e43425fab4233651401"'
+      - '"005f0fc265316d0e717bd0918796167ff1d83d23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:14 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -1256,7 +1256,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -1281,7 +1281,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec/fcr:tombstone
@@ -1304,7 +1304,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -1326,7 +1326,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/before_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/class_methods/before_ldp_writer_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5695c70fbeabc8671d79414fc9d9d293b8e2372f"'
+      - '"5801ef0e12692a86c46a1174f87bbe0ed7843dee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:06 GMT
+      - Wed, 08 Jul 2015 18:55:03 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwclassspec
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cff82ab12c6dfd9d2716ceaee6b8c606c2c03446"'
+      - '"35a15ea1ac9bfd11c2f930e14b550d65edab42d9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:11 GMT
+      - Wed, 08 Jul 2015 18:55:07 GMT
       Content-Length:
       - '52'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/ldpwclassspec
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:11 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/IIIF_anno_has_sc_painting_motivation.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/IIIF_anno_has_sc_painting_motivation.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"64c1117ec1190e870d729e901a498576323f17c9"'
+      - '"bbcb7e0657d31b2f82da70244e16c663c905e08e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"765fe9fbeeba78c1293eda6a3127852422499b62"'
+      - '"25b7eb0145a96566b406ec5305c00e6be0226151"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d
     body:
       encoding: US-ASCII
       string: ''
@@ -103,9 +103,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"765fe9fbeeba78c1293eda6a3127852422499b62"'
+      - '"25b7eb0145a96566b406ec5305c00e6be0226151"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -122,7 +122,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3160'
+      - '3267'
       Content-Type:
       - application/x-turtle
     body:
@@ -139,28 +139,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"41cbf1ba-849a-4110-98d8-b21140538a7c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"d7454c2d-636c-4ebd-b846-69897fb0fcc3\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.278Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.146Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:22.278Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:17.146Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy <http://iiif.io/api/presentation/2#painting> ;\n\tfedora:writable
         \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/LDP_store_creates_Basic_Container_for_the_annotation_and_returns_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/LDP_store_creates_Basic_Container_for_the_annotation_and_returns_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a0d213cdf54df3e8f81a04a2a97e672bf5912fa4"'
+      - '"970df21232713a5a8cc858b952d5cb5e8710f151"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"83825b338e454f3a9304c91ad71444dc5ea14080"'
+      - '"7a68d7569eae52be216b49a184968c31906b7c83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af
     body:
       encoding: US-ASCII
       string: ''
@@ -102,9 +102,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"83825b338e454f3a9304c91ad71444dc5ea14080"'
+      - '"7a68d7569eae52be216b49a184968c31906b7c83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -121,7 +121,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3129'
+      - '3236'
       Content-Type:
       - application/x-turtle
     body:
@@ -138,27 +138,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"8d283f8c-47e2-4a94-9be9-3c4b1f3bae49\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"d566e739-4267-47f1-811b-8b520388a556\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.013Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:22.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:17.013Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy oa:commenting ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/creates_new_annotation_as_a_child_of_anno_root_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/creates_new_annotation_as_a_child_of_anno_root_container.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"491f88b915d4504e4277d03c210e7f1c209d78bf"'
+      - '"802758be5609ea8c92a6365bd2de18596197a94f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,20 +69,20 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e509fc5eb9bf83d2ed928b59eff15cdfa00e3cc9"'
+      - '"6605e79223ac4aa7d819a7085b0cfdfb4e7cb930"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/36/7a/ea/b3367aea-aa1c-4747-8c56-e0c6b20eb95a
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a5/c0/98/b6/a5c098b6-9dab-436a-b8bd-86ba4a9c8561
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/36/7a/ea/b3367aea-aa1c-4747-8c56-e0c6b20eb95a
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a5/c0/98/b6/a5c098b6-9dab-436a-b8bd-86ba4a9c8561
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: get
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -102,9 +102,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a0d213cdf54df3e8f81a04a2a97e672bf5912fa4"'
+      - '"970df21232713a5a8cc858b952d5cb5e8710f151"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -145,20 +145,20 @@ http_interactions:
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"d2e46f7f-8aa0-4073-941c-e12e1ecb6ea4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"035daf7b-8d2a-4753-b534-ff8e75989713\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.949Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.813Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:22.025Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.876Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno> ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/36/7a/ea/b3367aea-aa1c-4747-8c56-e0c6b20eb95a>
+        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a5/c0/98/b6/a5c098b6-9dab-436a-b8bd-86ba4a9c8561>
         ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/keeps_multiple_motivations_if_present.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/keeps_multiple_motivations_if_present.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"468043d08e27f3873974f544150837e821c5f848"'
+      - '"3ad884a4ad6ad10a67a8d7c06f896a437196e6d3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d839b86047b124fe6ff92f672819b93be4b837a8"'
+      - '"d08ef148cb417f0952906e1a4fe563ed3b8e03f0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df
     body:
       encoding: US-ASCII
       string: ''
@@ -103,9 +103,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d839b86047b124fe6ff92f672819b93be4b837a8"'
+      - '"d08ef148cb417f0952906e1a4fe563ed3b8e03f0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -122,7 +122,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3142'
+      - '3249'
       Content-Type:
       - application/x-turtle
     body:
@@ -139,27 +139,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"88a0d420-f40e-4f30-a458-d5e9f1a02d00\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"b5927527-2a4b-451d-b3ff-548700dfbd4d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.412Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.271Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:22.412Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:17.271Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy oa:tagging , oa:moderating ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/posts_provenance_if_present.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/posts_provenance_if_present.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f65ac95b93265cdcaa42b5f6eb248f2b526d9a32"'
+      - '"9530d2cbd4958f47dd8ba2c73f9d800d7b45b94a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -82,23 +82,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e24a7976964f83d41deb3d9ec06fed631a7f62d7"'
+      - '"c0144885be015f4acb1573ca2aa6d85e4ba400ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da
     body:
       encoding: US-ASCII
       string: ''
@@ -115,9 +115,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e24a7976964f83d41deb3d9ec06fed631a7f62d7"'
+      - '"c0144885be015f4acb1573ca2aa6d85e4ba400ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -152,39 +152,39 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"33db9607-955b-49dc-8d0f-b102277ef9c0\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:serializedBy <http://localhost:8983/fedora/rest/.well-known/genid/c2/15/b2/66/c215b266-e036-4ff6-8dc2-a5ea8ec9778b>
+        ;\n\tfedora:uuid \"8f228bdf-8efc-4ce8-b6bf-529037eb0404\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:serializedBy <http://localhost:8983/fedora/rest/.well-known/genid/53/c6/cb/6a/53c6cb6a-03f8-4fd9-8170-8c74b433f7d9>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.612Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.423Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:serializedAt \"2014-09-03T17:16:13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:17.423Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:22.612Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:annotatedBy <mailto:azaroth42@gmail.com> ;\n\toa:motivatedBy oa:commenting
-        ;\n\toa:annotatedAt \"2014-09-03T17:16:13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp>
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:annotatedBy
+        <mailto:azaroth42@gmail.com> ;\n\toa:motivatedBy oa:commenting ;\n\toa:annotatedAt
+        \"2014-09-03T17:16:13Z\"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/c2/15/b2/66/c215b266-e036-4ff6-8dc2-a5ea8ec9778b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/53/c6/cb/6a/53c6cb6a-03f8-4fd9-8170-8c74b433f7d9>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , prov:SoftwareAgent , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfedora:uuid \"daa5a547-a6ee-43b5-aa30-8f4f9fa06ca4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"4fa32601-373f-4717-a24d-7a6f07885a20\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"prov:SoftwareAgent\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfoaf:name
-        \"Annotation Factory\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        \"Annotation Factory\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/raises_Triannon_MissingLDPContainerError_if_anno_root_container_doesn_t_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_base/raises_Triannon_MissingLDPContainerError_if_anno_root_container_doesn_t_exist.yml
@@ -26,5 +26,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_container/LDP_store_creates_retrievable_LDP_DirectContainer_with_correct_member_relationships.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_container/LDP_store_creates_retrievable_LDP_DirectContainer_with_correct_member_relationships.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b4f860d670f1d87b80918910f2f94ac149d3f084"'
+      - '"4784cf4774b99202099cce556df14454e15489b7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b12006240937c5d837978e20f6ce88bab27be282"'
+      - '"5c4ed21babe752deaf326a7c678fe5fcf888d0d7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"09815f52b33f0ed34dd564811bb0a3486ef8af52"'
+      - '"ea8a34d6f69dabb9b5f431c6c3f19b16ab48347b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b
     body:
       encoding: US-ASCII
       string: ''
@@ -148,9 +148,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"09815f52b33f0ed34dd564811bb0a3486ef8af52"'
+      - '"ea8a34d6f69dabb9b5f431c6c3f19b16ab48347b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -167,7 +167,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3400'
+      - '3291'
       Content-Type:
       - application/x-turtle
     body:
@@ -185,28 +185,27 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"3408be33-239c-4206-bf85-9cc1f30a418d\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"e0ade020-7215-4e58-add4-ca8c4f1d2e68\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.819Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.623Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:17.623Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:22.819Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d/b/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3/b/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/base_container_gets_oa_hasBody_statement.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/base_container_gets_oa_hasBody_statement.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"61ac123cb36687cdb03678be2905f066d9f8810c"'
+      - '"b8409ccf52d318554e6e2dbfb58a1c5463b4f055"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3470'
+      - '3578'
       Content-Type:
       - application/x-turtle
     body:
@@ -56,29 +56,30 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"45986ce1-57ff-4849-b34a-4aefcdcdd13b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"5e69d67e-67e4-454c-9e9c-e2c1c6b79141\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.18Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.964Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:23.209Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:17.989Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy oa:commenting ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/body_container_gets_ldp_contains_statement.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/body_container_gets_ldp_contains_statement.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ebbdcff1dfd4f3ffe2b8b188ff5ec44e4e17d4b6"'
+      - '"dba93baf4b8851ed160ab6d66cbec4860d8ddc76"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3465'
+      - '3574'
       Content-Type:
       - application/x-turtle
     body:
@@ -56,28 +56,29 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"3c2710fa-266a-4d97-84e7-397c21afd8df\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"94a36ea7-4036-4f82-b68d-ceb1501f7130\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.209Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.989Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:23.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:18.017Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/correct_body_content_in_new_body_child_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/after_create_resources_in_container/correct_body_content_in_new_body_child_container.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9e4be7a6a90545af497b0ea694b555ea4841830d"'
+      - '"adca8c38c4b0291fc16cd8c4c5c86772edf08377"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -56,7 +56,7 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -64,22 +64,22 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"9170448d-cf68-4346-ba48-5b1ddd859fdd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"084b5749-ea90-49c5-aafc-0d4f298ed5a4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:18.017Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:23.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:18.017Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/calls_create_resources_in_container_with_hasBody_predicate.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_body_resources/calls_create_resources_in_container_with_hasBody_predicate.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"09df05165e8671313faffb7555f7da7c027a2d68"'
+      - '"0fbe9d2f79723848a3ecedca388889c23a93e0e0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"50d94b2e07d1bb8c5603b87146469d2a2bf0db9c"'
+      - '"23ae3ee33272179e769ac2370dd08da255ef7395"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,18 +115,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5c306726a00756539cc1d87c7b49d6d5f2e4e940"'
+      - '"e66df1429d619ba821d78b044c8ad1a4f2b598ea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2/b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_container/LDP_store_creates_retrievable_LDP_DirectContainer_with_correct_member_relationships.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_container/LDP_store_creates_retrievable_LDP_DirectContainer_with_correct_member_relationships.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2afb3c894290748d001002d80eac84b585d20dce"'
+      - '"2b46b9c348406082b2dabc4b75ea6f8b65ffff90"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"638a0d7c69c84beffbfd00f602acff39be4fd074"'
+      - '"e0f2a0e2c0bf2b13147fb0977626a48379086776"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a52de6d7c1af0b6c74b67a351009cc41f0ded2e0"'
+      - '"516f2261daee35ef2f6356a0a8115e30444780ae"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:22 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t
     body:
       encoding: US-ASCII
       string: ''
@@ -148,9 +148,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a52de6d7c1af0b6c74b67a351009cc41f0ded2e0"'
+      - '"516f2261daee35ef2f6356a0a8115e30444780ae"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -167,7 +167,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3293'
+      - '3402'
       Content-Type:
       - application/x-turtle
     body:
@@ -185,27 +185,28 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"acb0e171-a295-46b6-b3e6-9f6b3fdbadbf\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"f25cc598-9305-46c1-9ae6-c4ca26dfa0f0\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:22.973Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:17.779Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:22.973Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:17.779Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad/t/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49/t/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/base_container_gets_oa_hasTarget_statement.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/base_container_gets_oa_hasTarget_statement.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7f6a5da98f5433461bbbdbc8de9d204641ac335c"'
+      - '"f2d5af473292cd11a4467ae9d3f21618d2003674"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -56,30 +56,30 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:Annotation
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"e8d572c9-54af-421b-9727-6e3d92f13567\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"f93c93d4-6552-4f09-82ed-58e316ceb63a\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.637Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:18.382Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:Annotation\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:23.666Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:18.408Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\toa:motivatedBy oa:commenting ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/correct_target_content_in_new_target_child_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/correct_target_content_in_new_target_child_container.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c7807bdf1c389cbbd04e71172adc1e8bfeecbea3"'
+      - '"c7fb369b34f1792db696aa5c042acf1bcf03d485"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -56,28 +56,28 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"a631eb37-a1c7-4005-8dc6-8e64368f87a6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"9bb18e54-0a67-4a52-b20a-eb19c14e161d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.691Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq666cs7229> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:23.691Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:created \"2015-07-08T18:55:18.431Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq666cs7229> ;\n\tfedora:mixinTypes
+        \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
+        \"2015-07-08T18:55:18.431Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/target_container_gets_ldp_contains_statement.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/after_create_resources_in_container/target_container_gets_ldp_contains_statement.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t
     body:
       encoding: US-ASCII
       string: ''
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d469a319dc085295105f86633c7a667338a2b76"'
+      - '"ba56088322a322e4a1ba42445344dd040caa9509"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -56,29 +56,29 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"0c7babfe-8c4c-4368-af71-caa09b14d7b6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"c82977d8-bd56-443f-ac6c-2fc0110f69a6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:23.666Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:18.408Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:23.691Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:18.431Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/calls_create_resources_in_container_with_hasTarget_predicate.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_create_target_resources/calls_create_resources_in_container_with_hasTarget_predicate.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c53ede93ce149ed40f4f5b258bd81340c3c90056"'
+      - '"27b496e7f848dcb10eaf50e2193429105048c19a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"563e7e52327850dda326a1e3b86c0da5f5706858"'
+      - '"7aca1d866938baf7b6acc865811b216f1cf0bd17"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,18 +115,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"88404c117af260f74b88dcd657d1da24d2a41510"'
+      - '"dd78210aebf7de1d8042f618bbec070849091cde"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de/t
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/deletes_all_child_containers_recursively.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/deletes_all_child_containers_recursively.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e2b3363ad9655f4d0e40f8cab1f0e9d83faedae2"'
+      - '"f247895f6ecd34fa14354c57952e899c7ebc34fb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8501405f53329ec482b942eb839676dad40952fd"'
+      - '"1d1e746281a505fe3716cf61d07a15699910320c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"889e339137d4682585220be6c9efd77b760c388f"'
+      - '"1c1027a4a4d2eaa7b15b28ff3f00ffb6a79b9742"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2d068935c4c0a7877df015a31e64a8d9cbaa443e"'
+      - '"0df572947b3d16524f9ffe65e3a7ed3067fe5a17"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b/48/6f/25/df/486f25df-ff45-4a57-aa8e-cc76ae4e24fb
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b/9a/3a/81/52/9a3a8152-d951-448c-9220-1661b8f1b744
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b/48/6f/25/df/486f25df-ff45-4a57-aa8e-cc76ae4e24fb
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b/9a/3a/81/52/9a3a8152-d951-448c-9220-1661b8f1b744
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8cb00388828079ae7094b28482cdf05b8b6eede3"'
+      - '"702768f673c499188ed840f031692d097a9254ca"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d2c2a910ed947ee794a7b929e9b6c061d891cc86"'
+      - '"836be3097c1c339db8d267bd25ee1b7bc8ed0f4b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t/62/9f/5a/b5/629f5ab5-39bb-4e25-97d9-18924dcf7b3a
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t/a1/ad/03/84/a1ad0384-25b6-4842-a116-c64530a1db92
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t/62/9f/5a/b5/629f5ab5-39bb-4e25-97d9-18924dcf7b3a
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t/a1/ad/03/84/a1ad0384-25b6-4842-a116-c64530a1db92
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"68ddd2860a4b5809bdfed14b8c0486fd8f0dcd6f"'
+      - '"d98b3e71c29bbc717d4e398a2c2e20fba756c3c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -323,18 +323,18 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b>
-        , <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/t/62/9f/5a/b5/629f5ab5-39bb-4e25-97d9-18924dcf7b3a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b/48/6f/25/df/486f25df-ff45-4a57-aa8e-cc76ae4e24fb>
+        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b>
+        , <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b/9a/3a/81/52/9a3a8152-d951-448c-9220-1661b8f1b744>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/t/a1/ad/03/84/a1ad0384-25b6-4842-a116-c64530a1db92>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b
     body:
       encoding: US-ASCII
       string: ''
@@ -356,10 +356,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b/48/6f/25/df/486f25df-ff45-4a57-aa8e-cc76ae4e24fb
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b/9a/3a/81/52/9a3a8152-d951-448c-9220-1661b8f1b744
     body:
       encoding: US-ASCII
       string: ''
@@ -381,8 +381,8 @@ http_interactions:
       - text/turtle
     body:
       encoding: UTF-8
-      string: Discovered tombstone resource at /anno/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc/b
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-06-26T15:21:24.836-07:00}
+      string: Discovered tombstone resource at /anno/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269/b
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-07-08T11:55:19.365-07:00}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/deletes_the_resource_from_the_LDP_store_when_id_is_full_url.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/deletes_the_resource_from_the_LDP_store_when_id_is_full_url.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"488be319d237139ced275f57507c38d8a3cdf9ac"'
+      - '"8d46ac029d4a6c83f206b13439c2e13e5f50f0ff"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c4de0e256d4ef57dee14e14dcd2480e09c98615e"'
+      - '"f730f86f704db7a19ccbdffc2129ee4a111d972f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
     body:
       encoding: US-ASCII
       string: ''
@@ -107,10 +107,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
     body:
       encoding: US-ASCII
       string: ''
@@ -129,14 +129,14 @@ http_interactions:
       Content-Length:
       - '209'
       Link:
-      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0/fcr:tombstone>;
+      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc/fcr:tombstone>;
         rel="hasTombstone"
       Content-Type:
       - text/turtle
     body:
       encoding: UTF-8
-      string: Discovered tombstone resource at /anno/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-06-26T15:21:24.016-07:00}
+      string: Discovered tombstone resource at /anno/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-07-08T11:55:18.728-07:00}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/doesn_t_delete_the_parent_container.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/doesn_t_delete_the_parent_container.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0e591f603b5fe3eedae6e325c4cd8c3f46da2e9a"'
+      - '"4f4aeeb5806bfffb94a86edb77c97bb6313c4df4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"507e51a92c4674d3d64e67ded345fdb016c25cad"'
+      - '"c58770c34b75b894f2383fd9af87a1015e8cef4b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e01fa680574938d5b89753abb901da8d6a89c4bb"'
+      - '"604ca32e48e5ead7b8b63ad5a75d16cb2525ee99"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e9c2e89e022a7374227c17a79bd33509fdc9921b"'
+      - '"9d01bd72663a1761b2faac58356bd3afda037e5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/c1/c7/3d/a5/c1c73da5-74ed-4ec4-ae44-0e5e6a745847
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/d7/73/49/5c/d773495c-8f9c-4271-abe0-6f7bc2755aca
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/c1/c7/3d/a5/c1c73da5-74ed-4ec4-ae44-0e5e6a745847
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/d7/73/49/5c/d773495c-8f9c-4271-abe0-6f7bc2755aca
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fb16f709d43c2304892a8e358697c3895c916547"'
+      - '"ac364998244c182db997a76940bfb0e2d48eaebf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f767e7ee4e9d9d36bee906cb2dcf33d0faf2bff8"'
+      - '"a791329475ad9971fca05397ef4ca0f3ecd0ec1f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t/b7/66/d7/b8/b766d7b8-fa11-4470-b8f5-042c3dee885b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t/c9/7a/e4/0d/c97ae40d-fd75-4ae5-9d2b-6fea92663609
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t/b7/66/d7/b8/b766d7b8-fa11-4470-b8f5-042c3dee885b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t/c9/7a/e4/0d/c97ae40d-fd75-4ae5-9d2b-6fea92663609
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5283e8496ab0637d42a47594bdef3e4302c5c8ed"'
+      - '"02e814ee2ab6ec592a56274bb5c50a65570f05b1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -323,18 +323,18 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b>
-        , <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/t/b7/66/d7/b8/b766d7b8-fa11-4470-b8f5-042c3dee885b>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/c1/c7/3d/a5/c1c73da5-74ed-4ec4-ae44-0e5e6a745847>
+        <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b>
+        , <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/t/c9/7a/e4/0d/c97ae40d-fd75-4ae5-9d2b-6fea92663609>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/d7/73/49/5c/d773495c-8f9c-4271-abe0-6f7bc2755aca>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/c1/c7/3d/a5/c1c73da5-74ed-4ec4-ae44-0e5e6a745847
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/d7/73/49/5c/d773495c-8f9c-4271-abe0-6f7bc2755aca
     body:
       encoding: US-ASCII
       string: ''
@@ -356,10 +356,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b
     body:
       encoding: US-ASCII
       string: ''
@@ -376,9 +376,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"175bf982731859a3dcc3dc14271bd848745278f4"'
+      - '"ba292c2b051a53773b1f9913afde7cbb0e38bbc1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -395,7 +395,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3400'
+      - '3291'
       Content-Type:
       - text/turtle
     body:
@@ -413,28 +413,27 @@ http_interactions:
         .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
         <http://fedora.info/definitions/v4/repository#> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"c963f42c-272f-4cb8-9d90-7aec6cd91131\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"694c0b6e-7c30-4a4d-b3be-40f7af9af479\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:24.283Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:18.976Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:24.312Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:19.005Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112/b/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5/b/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/works_when_id_is_anno_root_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/works_when_id_is_anno_root_anno_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"05100e57f11cc178f8abc90301be6c396d8e5d8d"'
+      - '"cee5841f4cb5537cc3f9d75471aac51e62723054"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0245bd559880162e38708d2b07a9b1063c9574d8"'
+      - '"443a25b0dc81a3686826078a8f6226d39e348e4c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
     body:
       encoding: US-ASCII
       string: ''
@@ -107,10 +107,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
     body:
       encoding: US-ASCII
       string: ''
@@ -129,14 +129,14 @@ http_interactions:
       Content-Length:
       - '209'
       Link:
-      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d/fcr:tombstone>;
+      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33/fcr:tombstone>;
         rel="hasTombstone"
       Content-Type:
       - text/turtle
     body:
       encoding: UTF-8
-      string: Discovered tombstone resource at /anno/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-06-26T15:21:24.187-07:00}
+      string: Discovered tombstone resource at /anno/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-07-08T11:55:18.885-07:00}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/works_when_id_is_just_anno_id.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/_delete_containers/works_when_id_is_just_anno_id.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8ce9369a83f0614c566481a4ef62ca64c0a00daa"'
+      - '"e5ab71fd0c234c8a340eea93e3c4be499825de55"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5eb408df0ff7ae03993d494fb4831180b35e70b2"'
+      - '"9c80bcdd295fa65feac137f2bff2a296064535fe"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
     body:
       encoding: US-ASCII
       string: ''
@@ -107,10 +107,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
     body:
       encoding: US-ASCII
       string: ''
@@ -129,14 +129,14 @@ http_interactions:
       Content-Length:
       - '209'
       Link:
-      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45/fcr:tombstone>;
+      - <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3/fcr:tombstone>;
         rel="hasTombstone"
       Content-Type:
       - text/turtle
     body:
       encoding: UTF-8
-      string: Discovered tombstone resource at /anno/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
-        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-06-26T15:21:24.101-07:00}
+      string: Discovered tombstone resource at /anno/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
+        {jcr:createdBy=bypassAdmin, jcr:primaryType=fedora:Tombstone, jcr:created=2015-07-08T11:55:18.807-07:00}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_create_body_resources.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_create_body_resources.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"09df05165e8671313faffb7555f7da7c027a2d68"'
+      - '"71271ea195c7bf35443bfda1884777457aa4eac2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:22 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d4dbaaab30b2dc3b6fa0937f001e7c6d4e2699a5"'
+      - '"4be302ca92215584c9e0a0dc16c81940412cdfa4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a3a058688ab171be0e7ad3434741a46c77e4b539"'
+      - '"96c06f2878dd47e208df10ab474fa0680dff88fb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:17 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:17 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b
     body:
       encoding: UTF-8
       string: |
@@ -162,18 +162,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9e4be7a6a90545af497b0ea694b555ea4841830d"'
+      - '"adca8c38c4b0291fc16cd8c4c5c86772edf08377"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089/b/0a/3f/69/72/0a3f6972-b847-4c7a-a10c-e4823a7b2357
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e/b/8e/59/d6/b4/8e59d6b4-4dcc-43b8-81e7-fd4bcc007332
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_create_target_resources.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_create_target_resources.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7664e2f305c2744156e91237d091db85891580bf"'
+      - '"47fefa63ff51a586db14a9e2b0143b0b05cd150a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"940feffb0684f4bc05586cd98cef0ee98b0c7ea2"'
+      - '"41b2cf64ba765c84bf731f2a7c7c038213c6bc3c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b552da83c1f82dc76a38b9001e110c8fb173013c"'
+      - '"60a87f5b388e2921d061e4cd5074b4b59ad025d4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t
     body:
       encoding: UTF-8
       string: |
@@ -158,18 +158,18 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c7807bdf1c389cbbd04e71172adc1e8bfeecbea3"'
+      - '"c7fb369b34f1792db696aa5c042acf1bcf03d485"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:23 GMT
+      - Wed, 08 Jul 2015 18:55:18 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c
+      - http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040/t/66/05/d8/3d/6605d83d-186d-40bf-ac66-1fd73b76d92c
+      string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929/t/cf/48/9c/9f/cf489c9f-fa44-4bfc-a81d-e57f2df8a722
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:23 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/after_ldp_writer_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/b3/36/7a/ea/b3367aea-aa1c-4747-8c56-e0c6b20eb95a
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/a5/c0/98/b6/a5c098b6-9dab-436a-b8bd-86ba4a9c8561
     body:
       encoding: US-ASCII
       string: ''
@@ -26,10 +26,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/3c/0a/90/5a/3c0a905a-d8f2-4da9-b86b-63a865e08613
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/aa/b9/d9/aa/aab9d9aa-f937-42ed-910b-59fe12d1d8af
     body:
       encoding: US-ASCII
       string: ''
@@ -53,10 +53,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/ef/c0/57/3f/efc0573f-8e5f-49e8-b12a-736e94d148b0
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/77/3b/c7/1a/773bc71a-cf20-435e-98b9-6fcbe764990d
     body:
       encoding: US-ASCII
       string: ''
@@ -80,10 +80,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/b8/61/51/5d/b861515d-9a13-4821-8e97-b708fdf18c68
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/4d/7f/68/2a/4d7f682a-a518-4f2d-939f-5d0cf8b2e5df
     body:
       encoding: US-ASCII
       string: ''
@@ -107,10 +107,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/65/13/1c/27/65131c27-0e9f-4f69-bd00-ea12771c244d
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/48/b6/97/c1/48b697c1-d902-4a54-a0d6-c7a9f8d7b2da
     body:
       encoding: US-ASCII
       string: ''
@@ -134,10 +134,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/30/ca/d4/08/30cad408-e5cc-41fc-9c2a-65473558582d
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/61/51/bd/fd/6151bdfd-42c5-4e75-a2fc-57ddf54be7b3
     body:
       encoding: US-ASCII
       string: ''
@@ -161,10 +161,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/f1/a7/10/97/f1a71097-4dea-408d-bf89-514fb77079ad
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/af/f9/e7/b0/aff9e7b0-8186-4ebb-a589-6526bd0e2a49
     body:
       encoding: US-ASCII
       string: ''
@@ -188,10 +188,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:24 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/b3/cb/96/4d/b3cb964d-819b-4b60-baad-1930c6c04aa2
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/32/18/4a/a1/32184aa1-8e51-4d74-85e4-e617feb88f03
     body:
       encoding: US-ASCII
       string: ''
@@ -215,10 +215,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/07/66/25/cc/076625cc-cec7-45a4-9e8b-11659c656089
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/4f/7e/c7/bf/4f7ec7bf-9a94-4471-888f-955f17c41f5e
     body:
       encoding: US-ASCII
       string: ''
@@ -242,10 +242,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/c2/2f/49/05/c22f4905-be7f-40f6-bae9-5dce24f8c3de
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/c3/db/7f/03/c3db7f03-4663-48ba-830d-906f95f50c1c
     body:
       encoding: US-ASCII
       string: ''
@@ -269,10 +269,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/44/20/d5/47/4420d547-15fb-42fe-9bdf-041851733040
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/35/b5/08/5f/35b5085f-e119-43df-b4b3-37024755a929
     body:
       encoding: US-ASCII
       string: ''
@@ -296,10 +296,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/88/a2/1a/db/88a21adb-226e-466f-9385-b9424ba603a0
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/56/6d/79/27/566d7927-e75c-446e-b143-465581c76bfc
     body:
       encoding: US-ASCII
       string: ''
@@ -323,10 +323,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/16/be/74/57/16be7457-6d71-4f4e-aa60-f4f736203a45
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/6b/c8/6d/7c/6bc86d7c-6213-47cd-8825-59907823bba3
     body:
       encoding: US-ASCII
       string: ''
@@ -350,10 +350,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/1a/1c/89/39/1a1c8939-de4f-4cd8-91db-13ccd56a8c4d
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/cd/95/57/77/cd955777-cfe6-4249-83db-24788b85de33
     body:
       encoding: US-ASCII
       string: ''
@@ -377,10 +377,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/3d/a4/c5/77/3da4c577-1c2a-4697-b657-abda3054a7a5
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/c5/04/cf/a4/c504cfa4-ec56-4e03-bcfd-c96e44772112
     body:
       encoding: US-ASCII
       string: ''
@@ -404,10 +404,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/a2/95/8e/f3/a2958ef3-cfd4-4985-a0ba-667f0874d5cc
+    uri: http://localhost:8983/fedora/rest/ldpwinstancespec/ea/81/89/67/ea818967-96a7-49cd-99e1-129b42425269
     body:
       encoding: US-ASCII
       string: ''
@@ -431,7 +431,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -449,9 +449,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1c3535660d257fca8b6e5ec96f321c355e77e8bd"'
+      - '"7b6995ba12a1496a4d83f72c07ae958db1b77ce4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:24 GMT
+      - Wed, 08 Jul 2015 18:55:19 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -470,7 +470,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -495,7 +495,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec/fcr:tombstone
@@ -518,7 +518,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -540,7 +540,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/before_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/instance_methods/before_ldp_writer_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ab94a9a9f0e194062cc2f81be10423f58ed36857"'
+      - '"89e81cba12d81a3d70d4b8258d1032fda32437b1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"491f88b915d4504e4277d03c210e7f1c209d78bf"'
+      - '"802758be5609ea8c92a6365bd2de18596197a94f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '55'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/ldpwinstancespec
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_direct_container/LDP_store_creates_retrievable_empty_LDP_DirectContainer_with_expected_id_and_LDP_member_relationships.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_direct_container/LDP_store_creates_retrievable_empty_LDP_DirectContainer_with_expected_id_and_LDP_member_relationships.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"23f3768d3998196c2357d12990bc4470a42291cb"'
+      - '"3a67020e5edee8c88c579a7cb28a60097b422002"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7102d73e441bf67b42aaa4991f2c97d97df7d174"'
+      - '"777a03f0259ad512a6db503ffdbab82abd6e448d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"13aa38dfcb5aac331aa0b6d498a2ea3174e79887"'
+      - '"46f6bc5d1ae7dd027c238236fbabb22bef319f8a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t
     body:
       encoding: US-ASCII
       string: ''
@@ -148,9 +148,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"13aa38dfcb5aac331aa0b6d498a2ea3174e79887"'
+      - '"46f6bc5d1ae7dd027c238236fbabb22bef319f8a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -167,7 +167,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3206'
+      - '3311'
       Content-Type:
       - application/x-turtle
     body:
@@ -184,28 +184,29 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"85061b8b-a636-4e40-8db4-add7b9ef16de\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"9f524f15-e9e7-4045-b769-72c7865083bc\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:15.344Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:15.344Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:10.942Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:10.942Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/6f/a4/fd/4c/6fa4fd4c-a80c-4683-ad7e-3c86630373dc/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d0/1f/43/aa/d01f43aa-cf8b-4c8b-823d-a9f64dd32dac/t/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_direct_container/has_the_correct_ldp_memberRelation_and_id_for_hasBody.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_direct_container/has_the_correct_ldp_memberRelation_and_id_for_hasBody.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"92a434c54555a9b070f44a75e47eb4d3bc4c9be1"'
+      - '"593f1a9f775c5876ac341771c3a9811a6b953d97"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"afd49f724891e2a1c6456048717d2d198714edc1"'
+      - '"432735285f75dc7d27a06005943889c091dd2e09"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"492ff378a3216f3f2cce30173037ef5d20969f57"'
+      - '"35ce5fbe8fca44c0d02c45b74a02d2adfead0535"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b
     body:
       encoding: US-ASCII
       string: ''
@@ -148,9 +148,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"492ff378a3216f3f2cce30173037ef5d20969f57"'
+      - '"35ce5fbe8fca44c0d02c45b74a02d2adfead0535"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -184,28 +184,28 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"ef502f08-77aa-45ec-ba6f-fd5a9a28b0f1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"7f180539-6451-44c8-9340-06fd3f46dad4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:15.521Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:15.521Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.089Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:11.089Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/08/bb/f4/de/08bbf4de-241c-4863-8b21-d0483e469ec0/b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4f/43/f2/45/4f43f245-c0e1-4eed-b5d7-2834bbf3bc94/b/fcr:export?format=jcr/xml>
         <http://purl.org/dc/elements/1.1/format> <http://fedora.info/definitions/v4/repository#jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/Choice/contains_all_appropriate_statements_for_blank_nodes_recursively.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/Choice/contains_all_appropriate_statements_for_blank_nodes_recursively.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ce7d25c56db113888b724f4045c7743312ae4ca4"'
+      - '"4685179ccbcf0ca174c892ce607ab9092be5176d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4c90b5349b889ff94e3a9ed656aa5755c1db711c"'
+      - '"07bbe2d560a83df9dac971ea1de0ab4612aee78e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"adfd3ae45da56fa0fda7e348fddc772ede258cc7"'
+      - '"c6e69affbe8c1ba90a666f61bb8d34487634265d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b
     body:
       encoding: UTF-8
       string: |
@@ -174,23 +174,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7151e7113b7adc6eab3d2008e6caf482ef1c7e3e"'
+      - '"5ba655cf60e7c58664954dea0f6aac85e7436457"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797
     body:
       encoding: US-ASCII
       string: ''
@@ -207,9 +207,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7151e7113b7adc6eab3d2008e6caf482ef1c7e3e"'
+      - '"5ba655cf60e7c58664954dea0f6aac85e7436457"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -226,7 +226,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '5318'
+      - '5316'
       Content-Type:
       - application/x-turtle
     body:
@@ -243,53 +243,53 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , oa:Choice , fedora:Container ,
         fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"b4b4b871-fac0-4af9-8616-a9c6da7dfcc1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"33fd837e-fdc4-4372-a8bd-79ec6e050159\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.814Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.75Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073>
         ;\n\tfedora:mixinTypes \"oa:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:20.814Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1>
+        \"2015-07-08T18:55:15.75Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfedora:writable
+        \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
+        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:Blanknode , cnt:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tdc11:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"d78fea35-8886-4ea6-8fe1-14f99a5dbf39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"2c4e6592-fea4-4afe-a41b-7d43947b3f35\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , dcmitype:Text , fedora:Blanknode , cnt:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tdc11:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"1f058fea-b2d4-4448-9423-7e29d97f87e2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"9fffe09d-da6b-4e86-8615-d5192fad4b09\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c3/37/75/d6/c33775d6-0484-4e79-a524-64fd10cb6b0c/b/1f/e5/ab/32/1fe5ab32-f34c-45f1-b265-2e97c901a797/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a3/35/bc/52/a335bc52-2d7e-4134-8c36-643500704a38/b/a6/d0/b9/35/a6d0b935-4162-45ca-89d1-fa788206488c/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073
     body:
       encoding: US-ASCII
       string: ''
@@ -338,26 +338,26 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , dcmitype:Text , fedora:Blanknode ,
         cnt:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tdc11:language
-        \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid \"1f058fea-b2d4-4448-9423-7e29d97f87e2\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid \"9fffe09d-da6b-4e86-8615-d5192fad4b09\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/.well-known/genid>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e1/04/8c/55/e1048c55-e970-4445-b1df-635127bd53d3/fcr:export?format=jcr/xml>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f6/ba/d1/9f/f6bad19f-22cc-48a7-85e9-4b4da27f7073/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3
     body:
       encoding: US-ASCII
       string: ''
@@ -406,22 +406,22 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , dcmitype:Text , fedora:Blanknode ,
         cnt:ContentAsText , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tdc11:language
-        \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid \"d78fea35-8886-4ea6-8fe1-14f99a5dbf39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"fr\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid \"2c4e6592-fea4-4afe-a41b-7d43947b3f35\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/.well-known/genid>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/8d/76/37/90/8d763790-0f64-4f16-a1a5-613588c4d0f1/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/6b/bb/89/c5/6bbb89c5-015e-41bf-9944-fbf7b7ad3da3/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/Choice/three_images.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/Choice/three_images.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8c0a946c8d6910970ee78d24f392f6943dd7949a"'
+      - '"822cc1245bff7784eedd38de7fcb041855ef4572"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b68ef5fcb0f914a115062c4d8e02286d7a792451"'
+      - '"fb040981a08420e6df994761b4e55cfcd540fc12"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1cdaebe88bb1d69468b5169fa2075cc89ef393f3"'
+      - '"cc15ec7d832ecf39798ec428d075ed1804f3819b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t
     body:
       encoding: UTF-8
       string: |
@@ -172,23 +172,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5c730d72dd33e5f1bade7b2fa1a6f91766d21e3f"'
+      - '"cf33da391f9ef85cf24cfc8c54309c0fbf42e4c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4
     body:
       encoding: US-ASCII
       string: ''
@@ -205,9 +205,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5c730d72dd33e5f1bade7b2fa1a6f91766d21e3f"'
+      - '"cf33da391f9ef85cf24cfc8c54309c0fbf42e4c9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -241,70 +241,70 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , oa:Choice , fedora:Container ,
         fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"4ed74c9a-1da2-4c45-a833-afa5144d2312\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"1d451b7a-a54d-4b8d-825e-febe2a697d68\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:item <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#item2>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#default>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:item <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#item2>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#default>
         ;\n\tfedora:mixinTypes \"oa:Choice\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#item2>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#item2>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Image , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"a10deae9-6f57-44fc-a636-41271384f321\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"f5037f99-f535-45d9-8ee1-4c589325383e\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/huge> ;\n\tfedora:mixinTypes
         \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#default>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#default>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Image , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"7f03b7c3-8a0a-4e09-b8e9-112cb7ae6e26\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"3c69f288-ef2f-4b20-b6e4-590a97814ee1\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/small> ;\n\tfedora:mixinTypes
         \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f#item1>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4#item1>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Image , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"756b07b8-0fbc-4693-b65e-d0520e1dc7bf\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"4972d1fd-a580-473a-bafa-a7befb098d87\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://images.com/large> ;\n\tfedora:mixinTypes
         \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.212Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/67/34/f5/75/6734f575-bb43-4a3b-afcf-f16a7fd06d50/t/ce/a0/fc/d7/cea0fcd7-247d-4937-96b6-0fb5bf9f727f/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.137Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/bf/39/44/c8/bf3944c8-85f1-4a51-99f3-5cec97ff4bee/t/34/14/50/f3/341450f3-9229-4829-a219-ed6a7a2de3b4/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/IIIF_context_flavor.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/IIIF_context_flavor.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9ed01359f5d5d08afd1bb5e5e962cc85c9b2ead0"'
+      - '"7311859fbb93b012886b1e01d13f58c3ec97bbf3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"594ceccbc52059a49b050e2d47c07155f4408af4"'
+      - '"e782a52cc614e9dcdf48db8caa8920e06131e0d8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6a01fe6220beb6b614e1efaee0c4f4314d52365a"'
+      - '"d727493688ba709d8988c366c97ec7b0610df796"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2c19e1302878f426626bf64e6cbffc46ce659ba7"'
+      - '"b5ba4ad6a78ccd593f303d2cfeefe64d92199f45"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8
     body:
       encoding: US-ASCII
       string: ''
@@ -195,9 +195,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2c19e1302878f426626bf64e6cbffc46ce659ba7"'
+      - '"b5ba4ad6a78ccd593f303d2cfeefe64d92199f45"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -231,29 +231,29 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , cnt:ContentAsText , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"60a5166a-26c2-401a-918d-0dfcee0d2a39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"b440c4f8-2623-4141-b4e2-3f0431252779\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:15.963Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.512Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:15.963Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:11.512Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tdc11:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this line!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/b1/30/47/87/b1304787-359a-4c9d-bbcf-56abbddca2a0/b/74/d0/d1/f5/74d0d1f5-403c-4afd-a342-fe469bf6ad2b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/4c/c3/6f/824cc36f-2e0f-45a9-a439-b1eedea6a1d4/b/70/ee/1b/56/70ee1b56-7caf-4843-9ed8-837a206d6dc8/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/creates_all_appropriate_statements_for_blank_nodes_recursively.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/creates_all_appropriate_statements_for_blank_nodes_recursively.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"94fc1656c2f67a88051b904b4e8937eb7e5e9287"'
+      - '"62d26d6e976e3353bf6a00f86262c8f5cc0ae7f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"749e7f3314244836a0d13b33b832e9bb42b63ad1"'
+      - '"1ddd1601c193410bfe605fbf627aac02931e317b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0f35b15a83c4a319da2661d36649a71ad0d73461"'
+      - '"44d62d462116c7b078cf9f900eb7c9bccf76153f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b
     body:
       encoding: UTF-8
       string: |
@@ -164,23 +164,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"063c809843e6ac9416caeda97cbdfef045197522"'
+      - '"715f8730c31c84bd09bf471e2a85ffa1ef16e18f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3
     body:
       encoding: US-ASCII
       string: ''
@@ -197,9 +197,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"063c809843e6ac9416caeda97cbdfef045197522"'
+      - '"715f8730c31c84bd09bf471e2a85ffa1ef16e18f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -216,7 +216,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3506'
+      - '3660'
       Content-Type:
       - application/x-turtle
     body:
@@ -233,7 +233,7 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -242,21 +242,22 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tdc11:language
         \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"933c97ee-a262-4869-bca2-85fe6ba2698c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6247e20d-d763-46aa-82b0-2c51fab5f5fe\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:15.752Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.312Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:15.752Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:11.312Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a7/78/9a/bb/a7789abb-7511-41be-9aeb-13f6ef8549cb/b/d1/83/31/98/d1833198-6fc2-469b-8942-16d697e78361/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/82/ab/c2/96/82abc296-33d0-4e80-bb21-3a09ebb0b12c/b/ca/5c/1c/be/ca5c1cbe-a199-43ca-95cc-70a9d640eee3/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/multiple_resources.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/ContentAsText/multiple_resources.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ed8d5581395607721c4f318e92f20b88ad52156"'
+      - '"7311859fbb93b012886b1e01d13f58c3ec97bbf3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"499d63f2f9309b667afdd72a2a23b96d9d83a28e"'
+      - '"2475bcda275a4f33e333000dde5736bef7ceb1d3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"943b74993db7fa2da53ca58909dcf4cdc261e1bd"'
+      - '"c7f8b3d464c3981cb9eb90ddf2ee8d43e546fb69"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b23990a1940260a7cf1687815a7cbd2fe722c819"'
+      - '"5056fd20cb86cc8606f0a049de2db1d8ba796073"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b
     body:
       encoding: UTF-8
       string: |
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1e9f0b3c5e7691615e52ec0f9f8e213516666994"'
+      - '"7a18e1584e0e73b04c9d2ed05922d75e87735fc4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b
     body:
       encoding: US-ASCII
       string: ''
@@ -242,9 +242,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df45c4bb20fec821f6e633778c4acb70a2294329"'
+      - '"cb65c8c6323d817a300ff2b93acf20b10b749977"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -261,7 +261,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3552'
+      - '3657'
       Content-Type:
       - application/x-turtle
     body:
@@ -278,34 +278,35 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"8db53b06-2309-482c-9093-de8972dcefe0\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"1802f8aa-378f-4d6e-ab27-937f7679705c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:16.179Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.685Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:16.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:11.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424
     body:
       encoding: US-ASCII
       string: ''
@@ -322,9 +323,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b23990a1940260a7cf1687815a7cbd2fe722c819"'
+      - '"5056fd20cb86cc8606f0a049de2db1d8ba796073"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -358,7 +359,7 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -366,27 +367,27 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"a7a632e2-81fa-4a79-b2f1-3922f400cfd4\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e368450f-06e0-4362-9162-0ca095b144a0\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:16.208Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.714Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:11.714Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:16.208Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/4a/a3/a7/42/4aa3a742-6781-4785-a812-79137fb82dec/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/60/5f/f4/3a/605ff43a-048e-4a3a-a78b-f5b8bd71e424/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4
     body:
       encoding: US-ASCII
       string: ''
@@ -403,9 +404,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1e9f0b3c5e7691615e52ec0f9f8e213516666994"'
+      - '"7a18e1584e0e73b04c9d2ed05922d75e87735fc4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -439,7 +440,7 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -447,21 +448,21 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"1ed36161-7bcf-4b68-9143-c1f8cac2f796\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"ebc9de14-585c-4050-a5d9-d73887656455\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:16.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:11.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:11.746Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:16.237Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tcnt:chars \"I hate this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/49/34/49/7c/4934497c-3718-473e-a9dd-db891a6a8904/b/ec/b0/c5/83/ecb0c583-6c7e-4bb4-9bf4-1f68821e0d08/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d3/61/16/1e/d361161e-6018-41d5-9ccd-dbe29c4c334a/b/75/30/7b/e6/75307be6-7684-45c7-ad1f-4ce827ea3fc4/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/FragmentSelector_with_Source_having_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/FragmentSelector_with_Source_having_addl_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d9203680a88b38ca27b56f0c97222db2998c6fb"'
+      - '"b201e26f683ddad01550bd7e33c9f57ed681ffee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"adff222a1d89cb66a7d0ea0f607d4e694d1893e0"'
+      - '"7abd5eb005e9541369d7bcce074f77f2f31c5745"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fbfcbfe45d0295a73b6b2d18b7e09c4db223e505"'
+      - '"d54183466224e76c47c6de426d83fe06aeaa6714"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t
     body:
       encoding: UTF-8
       string: |
@@ -170,23 +170,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"090de8695eadda2aab3f5cfcfb6340a1324d2267"'
+      - '"cf4a755dbb30f890c39f0cfb51756c5fee0cd931"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d
     body:
       encoding: US-ASCII
       string: ''
@@ -203,9 +203,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"090de8695eadda2aab3f5cfcfb6340a1324d2267"'
+      - '"cf4a755dbb30f890c39f0cfb51756c5fee0cd931"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -239,57 +239,57 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SpecificResource
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc>
-        ;\n\tfedora:uuid \"4ddeb66d-8a08-4dc9-9f35-4bd9e8801d86\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f>
+        ;\n\tfedora:uuid \"22f6fae9-baf3-4315-bd6e-3f01600013b6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:19.671Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:19.671Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.719Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:hasSource
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7#source>
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
+        \"2015-07-08T18:55:14.719Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d#source>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7#source>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Image , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"ed5bb0d0-d4cd-46c4-bb46-411bf4ca9601\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"e4178f05-d34e-483e-8898-a86becb90a7c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:19.671Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.719Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfedora:mixinTypes \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:19.671Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc>
+        \"2015-07-08T18:55:14.719Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , oa:FragmentSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"86c479fe-f726-4245-b0c0-dbf5bc9a11ef\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"1fbbb7e5-eff5-4de5-8454-b7e338af7099\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3b/d4/60/34/3bd46034-b075-432c-936d-9ce731b036d9/t/d6/6a/b0/c5/d66ab0c5-9125-496a-9253-9801ab4589e7/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/3d/7a/3b/93/3d7a3b93-0d20-429d-a867-6db36bd0f469/t/ce/8a/da/8b/ce8ada8b-1092-4733-9f28-e17e6acb840d/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f
     body:
       encoding: US-ASCII
       string: ''
@@ -338,21 +338,21 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , fedora:Blanknode , oa:FragmentSelector
         , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"86c479fe-f726-4245-b0c0-dbf5bc9a11ef\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"1fbbb7e5-eff5-4de5-8454-b7e338af7099\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
         <http://www.w3.org/TR/media-frags/> ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/.well-known/genid>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/69/c8/1b/01/69c81b01-6f55-4601-b150-8ce0701c68fc/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/36/61/22/9d/3661229d-55a6-4c1a-bd27-adaf288d8a3f/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/TextPositionSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5cc00b39187588017aee97085ac782df0adcd898"'
+      - '"3d78a08fac0738b75a2ad0e097dc07baff261181"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b313d1901bd423e56216be225bb33bbdbff03b91"'
+      - '"d87f122b668a60d0520bdbbc4ff2d8502ed06d21"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"542b1a0742bc1cfa77d6128c83a69c6b9778b4f9"'
+      - '"e6e37bad2954290a0c8099034ecc54ba28e11d2f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t
     body:
       encoding: UTF-8
       string: |
@@ -167,23 +167,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c46ea9ea14784ce91c64988a9ab8753b12dcc67d"'
+      - '"2b36f68bd06cbec66deb86e306205344745a4886"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67
     body:
       encoding: US-ASCII
       string: ''
@@ -200,9 +200,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c46ea9ea14784ce91c64988a9ab8753b12dcc67d"'
+      - '"2b36f68bd06cbec66deb86e306205344745a4886"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -219,7 +219,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '5663'
+      - '5667'
       Content-Type:
       - application/x-turtle
     body:
@@ -236,56 +236,56 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SpecificResource
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be>
-        ;\n\tfedora:uuid \"90a26ff6-131a-4900-879b-20cc15af713b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9>
+        ;\n\tfedora:uuid \"9f7a4273-bcd4-41eb-984a-7d6717c8eedb\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:18.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.065Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:18.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\toa:hasSource
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6#source>
+        \"2015-07-08T18:55:14.065Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67#source>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6#source>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"8116a8fb-7129-46f5-b0f9-ba675c83f56f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6c03b827-2a21-4afd-bcd8-8df1d7615fb9\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:18.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.065Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229.html>
         ;\n\tfedora:mixinTypes \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:18.79Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:14.065Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , oa:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfedora:uuid \"b8306a66-7590-4631-8e19-4779a5ce7e6c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"e0a79ea5-3000-434e-982f-0a2871ede807\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:end
         \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\toa:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6/fcr:export?format=jcr/xml>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/46/1d/1c/44/461d1c44-a219-4d55-9343-e60d5f322b7c/t/07/ad/bf/5b/07adbf5b-0cf5-47a3-b97f-00c197a8dfe6/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ee/55/b2/d9/ee55b2d9-d3db-4bb3-8845-9c6587aa1070/t/2e/dc/e6/3e/2edce63e-3daa-4a84-81ff-4caa9d142c67/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9
     body:
       encoding: US-ASCII
       string: ''
@@ -317,7 +317,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2548'
+      - '2651'
       Content-Type:
       - application/x-turtle
     body:
@@ -334,21 +334,21 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , fedora:Blanknode , oa:TextPositionSelector
-        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"b8306a66-7590-4631-8e19-4779a5ce7e6c\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"e0a79ea5-3000-434e-982f-0a2871ede807\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:end
         \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\toa:start
         \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\tfedora:writable
         \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/.well-known/genid> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/27/3e/21/19/273e2119-e916-4f32-ad55-b0b2ec5a71be/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        <http://localhost:8983/fedora/rest/.well-known/genid> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/72/7d/79/8c/727d798c-5cdc-4176-bace-122f358405b9/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/TextQuoteSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e094f69525392d1d4a7d356af150e3b46fd9861b"'
+      - '"ac01ada677cdfbb7d81a2abe1baef6f95efdb62c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"39a5451dc1bc15d87fc51740492a6a33ddf82333"'
+      - '"e47ba9be88726f5ba4e6a86abc6330c0927f5b37"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7ff31a9e8e5c51e26e8093c080f594f24e57d614"'
+      - '"869827988eacc555f583c4563bf29886bdb309c5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t
     body:
       encoding: UTF-8
       string: |
@@ -168,23 +168,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"79404fb8d271ec0a61bda5865b44fbe20010cafb"'
+      - '"a97c103ac00270cbff8cf6766933df23f983adba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5
     body:
       encoding: US-ASCII
       string: ''
@@ -201,9 +201,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"79404fb8d271ec0a61bda5865b44fbe20010cafb"'
+      - '"a97c103ac00270cbff8cf6766933df23f983adba"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -237,58 +237,58 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SpecificResource
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3>
-        ;\n\tfedora:uuid \"1d9b6c63-a981-41b8-a90f-62662df60166\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b>
+        ;\n\tfedora:uuid \"bf42ed1f-4254-459f-a515-2e10b3774b91\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:19.217Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.386Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:19.217Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e#source>
+        \"2015-07-08T18:55:14.386Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5#source>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e#source>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"62bbfe0d-b7a5-4865-b445-4166f872bc2b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"d4354bfc-4a38-439a-8539-f91db8956955\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:19.217Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.386Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229.html>
         ;\n\tfedora:mixinTypes \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:19.217Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:14.386Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , oa:TextQuoteSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfedora:uuid \"af74cd3d-3080-4418-9d28-56ab9f773bc5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"92646e01-4bc9-4710-ba56-99ea802585a8\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:TextQuoteSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:prefix
         \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f1/a2/38/9c/f1a2389c-0206-4706-88f8-1a2cdadfa778/t/6b/19/41/70/6b194170-9dfa-40a9-ac87-ab2a69347d8e/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/21/ec/96/4e/21ec964e-88ce-401e-a179-10dd4ecb5001/t/44/b0/ac/e0/44b0ace0-c20d-44b7-83e1-92e8e19025e5/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b
     body:
       encoding: US-ASCII
       string: ''
@@ -337,10 +337,10 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , fedora:Blanknode , oa:TextQuoteSelector
-        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"af74cd3d-3080-4418-9d28-56ab9f773bc5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"92646e01-4bc9-4710-ba56-99ea802585a8\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
@@ -349,11 +349,11 @@ http_interactions:
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/.well-known/genid>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/13/46/93/f5/134693f5-9740-45cb-9cbf-4fbcf2766db3/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/ba/27/5b/64/ba275b64-6b13-4185-87db-95211491d71b/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/multiple_SpecificResources.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/SpecificResource/multiple_SpecificResources.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"26d2af0d9b82962f179585deab23936758d56775"'
+      - '"6ef3c984c5549cb8972b09aafcd04c8eafd012a6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:19 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:19 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"483f209b9fc079f93c95d4c3443d325572212d91"'
+      - '"707282462036f32ace20d42088647d963e91858f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:14 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3950cf366f9d35fc574e59cb05cd8b076e54d199"'
+      - '"c2f2f54fe5936c00a59c0e59ad81eb3011d43111"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:14 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
     body:
       encoding: UTF-8
       string: |
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"10089d782b62af9ab662ec0212bca26e69a35f3e"'
+      - '"fa4e6dca4a331d673172b69ec9b59c3993dd5efb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
     body:
       encoding: UTF-8
       string: |
@@ -210,23 +210,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"aaca97239510e304214e129006d8cc617aa8d956"'
+      - '"574728a785d128ada0a02c59a77e21edb5a34b44"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
     body:
       encoding: UTF-8
       string: |
@@ -266,23 +266,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"47fcf9fcacb94e36f505a2cef193d23d4dc7bbf8"'
+      - '"8aa57754c17ce98fd2edba55ef4713c0b8e92719"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t
     body:
       encoding: US-ASCII
       string: ''
@@ -299,9 +299,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9d522c0b6590b125a81608dfafd25202e1f28d99"'
+      - '"404fe07d18b2b6791ae311b359710da9e45f515f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -318,7 +318,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3709'
+      - '3710'
       Content-Type:
       - application/x-turtle
     body:
@@ -335,35 +335,35 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"e410532b-b3a1-4e40-aab9-96554c5f285a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"564cfa7d-e43b-4e06-9c8d-9e8aafd8ca59\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.04Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:14.997Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:20.132Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:15.135Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a
     body:
       encoding: US-ASCII
       string: ''
@@ -380,9 +380,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"10089d782b62af9ab662ec0212bca26e69a35f3e"'
+      - '"fa4e6dca4a331d673172b69ec9b59c3993dd5efb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -416,32 +416,32 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"6d6146a9-5100-4c2b-9b76-c7b8ad9730f8\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"1f240db1-5fb7-40f7-ab71-619fdc68a472\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.063Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfedora:mixinTypes
-        \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:20.063Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.058Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfedora:lastModified
+        \"2015-07-08T18:55:15.058Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/53/52/bf/7c/5352bf7c-3a10-4593-9504-eac15572abbb/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/50/02/25/b8/500225b8-b979-4144-960f-201de003131a/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca
     body:
       encoding: US-ASCII
       string: ''
@@ -458,9 +458,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"aaca97239510e304214e129006d8cc617aa8d956"'
+      - '"574728a785d128ada0a02c59a77e21edb5a34b44"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -494,56 +494,56 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SpecificResource
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b>
-        ;\n\tfedora:uuid \"2cab2882-dfe6-412a-b863-01717b2dd0dd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41>
+        ;\n\tfedora:uuid \"8497a10e-4109-4ceb-ad60-3a0d6949d086\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.094Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.098Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:20.094Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5#source>
+        \"2015-07-08T18:55:15.098Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca#source>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5#source>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"293e5b9e-f5e3-4fd7-ba1a-30452b9c7885\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"6d0575f0-02bd-4278-ae9f-8ed064d39039\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.094Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.098Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq666cs6666.html>
         ;\n\tfedora:mixinTypes \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:20.094Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:15.098Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , oa:TextPositionSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        ;\n\tfedora:uuid \"608b63ec-a262-441f-890e-6a39f27096e6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"f5dbcc40-129b-40fe-af22-fcd95b71cdb8\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:end
         \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\toa:start
-        \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5/fcr:export?format=jcr/xml>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/4b/4d/67/7a/4b4d677a-4694-48ae-8018-27b548183eca/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/7a/53/19/7c/7a53197c-24e2-4c26-b304-fc99e31e90b5/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41
     body:
       encoding: US-ASCII
       string: ''
@@ -575,7 +575,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2548'
+      - '2651'
       Content-Type:
       - application/x-turtle
     body:
@@ -592,26 +592,26 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , fedora:Blanknode , oa:TextPositionSelector
-        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"608b63ec-a262-441f-890e-6a39f27096e6\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\tfedora:uuid \"f5dbcc40-129b-40fe-af22-fcd95b71cdb8\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:TextPositionSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:end
         \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\toa:start
         \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger> ;\n\tfedora:writable
         \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/.well-known/genid> ;\n\tfedora:exportsAs
-        <http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/e8/d4/e0/b2/e8d4e0b2-8be9-4a7b-8f30-9cb3b1ef5d2b/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        <http://localhost:8983/fedora/rest/.well-known/genid> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/10/6e/a8/26/106ea826-66c2-4292-8d02-df28273f5d41/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8
     body:
       encoding: US-ASCII
       string: ''
@@ -628,9 +628,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"47fcf9fcacb94e36f505a2cef193d23d4dc7bbf8"'
+      - '"8aa57754c17ce98fd2edba55ef4713c0b8e92719"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:20 GMT
+      - Wed, 08 Jul 2015 18:55:15 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -664,57 +664,57 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SpecificResource
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749>
-        ;\n\tfedora:uuid \"a0ddb074-ed8f-45f6-bfaf-24d122363f1a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709>
+        ;\n\tfedora:uuid \"22894e91-ad94-4e49-9167-afaedc3827cf\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.132Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.135Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:15.135Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:SpecificResource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:20.132Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07#source>
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\toa:hasSource
+        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8#source>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07#source>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8#source>
         a <http://www.jcp.org/jcr/nt/1.0folder> , <http://www.jcp.org/jcr/nt/1.0hierarchyNode>
         , <http://www.jcp.org/jcr/nt/1.0base> , <http://www.jcp.org/jcr/mix/1.0created>
         , dcmitype:Image , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"f92aa7b7-aaf6-4a91-8dd8-b468d67a269e\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"fdecc065-ebee-4e38-8fe0-1fcb91440c4b\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:20.132Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:15.135Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfedora:mixinTypes \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:20.132Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749>
+        \"2015-07-08T18:55:15.135Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709>
         a <http://www.jcp.org/jcr/nt/1.0unstructured> , <http://www.jcp.org/jcr/nt/1.0base>
         , fedora:Blanknode , oa:FragmentSelector , <http://www.jcp.org/jcr/mix/1.0referenceable>
         ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"f0555812-f03f-48cd-856c-dffefc614e32\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"0a48489e-def2-4590-8ca4-7aeb073fbbc4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
-        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/d6/2b/36/01/d62b3601-79d8-41c8-ac59-91ff04d679e4/t/6c/91/d8/ec/6c91d8ec-3e03-4fba-8ecc-bbdd2cacaa07/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        <http://www.w3.org/TR/media-frags/> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/80/eb/57/53/80eb5753-9e36-41c8-8ebc-ebf6a675fa2a/t/eb/8e/73/c5/eb8e73c5-5172-4fdb-9469-97f3686db0f8/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749
+    uri: http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709
     body:
       encoding: US-ASCII
       string: ''
@@ -746,7 +746,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2527'
+      - '2630'
       Content-Type:
       - application/x-turtle
     body:
@@ -763,20 +763,21 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709>
         a ldp:RDFSource , ldp:Container , ldp:BasicContainer , <http://www.jcp.org/jcr/nt/1.0unstructured>
         , <http://www.jcp.org/jcr/nt/1.0base> , fedora:Blanknode , oa:FragmentSelector
         , <http://www.jcp.org/jcr/mix/1.0referenceable> ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"f0555812-f03f-48cd-856c-dffefc614e32\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"0a48489e-def2-4590-8ca4-7aeb073fbbc4\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:unstructured\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:mixinTypes \"fedora:Blanknode\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"oa:FragmentSelector\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:conformsTo
         <http://www.w3.org/TR/media-frags/> ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
         ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/.well-known/genid>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ed/9d/5a/0a/ed9d5a0a-a050-43c3-ab8d-98fc67c80749/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n"
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/.well-known/genid/6a/32/e9/e7/6a32e9e7-4717-4f36-a902-1e24377f7709/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:20 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/IIIF_context_has_additional_properties.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/IIIF_context_has_additional_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2b224c4fc585977ebfc056897a0960d2fca71072"'
+      - '"64448d1c9e68d9af2bdaad65a95e3993ead7f65b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -70,23 +70,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fa876badfa25e328e76fa23da49dd831255b28c5"'
+      - '"5b285edc54711c0c82c3d1cabbf29ca2f95eb55a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21
     body:
       encoding: UTF-8
       string: |
@@ -96,7 +96,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -116,23 +116,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0b819d9462b44cc1c25b49a8eb090e6de692e923"'
+      - '"98cd06a29d98efa2d0d466b9193c4ebbe895e09e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b
     body:
       encoding: UTF-8
       string: |
@@ -165,23 +165,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b107e7a966a99a85a7a3e86a7d38860132c5c3ad"'
+      - '"224ee5badeee45d0e2e747a1e43cfa34d1dba4a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83
     body:
       encoding: US-ASCII
       string: ''
@@ -198,9 +198,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b107e7a966a99a85a7a3e86a7d38860132c5c3ad"'
+      - '"224ee5badeee45d0e2e747a1e43cfa34d1dba4a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -234,7 +234,7 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -242,22 +242,22 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tdc11:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"89b2ad62-b0f1-43e0-90eb-1a5159e7d70a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"ec919ae4-6c0c-40a8-aee3-ae08dcf654c6\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.286Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.642Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://example.org/alto/p1.xml#xpointer(/alto/line[1])>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.286Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:12.642Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tdc11:format \"text/xml\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:writable
         \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/9d/3f/0c/1c/9d3f0c1c-c108-4d06-9553-30b1c4e87780/b/cf/b3/8e/26/cfb38e26-9d08-40e6-8942-5faadf8e8eb6/fcr:export?format=jcr/xml>
+        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/a5/4e/5a/d1/a54e5ad1-30cc-4365-bbde-f6fad88c9e21/b/cf/91/32/20/cf913220-dd82-4ecc-b8be-e36117073e83/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/URI_has_additional_properties.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/URI_has_additional_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9693f70578b6a8a1df9f17e16ccfbb1b0c953fef"'
+      - '"de4528458d298e2ba073d20a8032f59f668c3702"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9a947fd64ec1ea24384addd7ef90b6ab42657e3d"'
+      - '"ab1ee1eed39d1b259bc5036bc3845ff2bd3e1af8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1716b4c88553cd5ae935c8210938123f1e8b8ba0"'
+      - '"fc18d5a7101050699992320ede26db65cb723562"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t
     body:
       encoding: UTF-8
       string: |
@@ -159,23 +159,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5784069d0e37cf0fe82b36b199d3b7d0cc54f1d9"'
+      - '"17c3735caaa4487940bf2f2711cfe650ad44568b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8
     body:
       encoding: US-ASCII
       string: ''
@@ -192,9 +192,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5784069d0e37cf0fe82b36b199d3b7d0cc54f1d9"'
+      - '"17c3735caaa4487940bf2f2711cfe650ad44568b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -211,7 +211,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3412'
+      - '3566'
       Content-Type:
       - application/x-turtle
     body:
@@ -228,28 +228,29 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Image
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"b0e97625-cf5b-4f32-a8f2-be78969487fd\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"f994452e-bd17-4411-98cb-b89fd90a07fa\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:16.851Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.266Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg#xywh=0,0,200,200>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:16.851Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:12.266Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/0a/13/93/84/0a139384-ea28-4c79-a856-c6fa52358dbf/t/81/e0/d9/15/81e0d915-3cf8-4651-a761-820311dd2e80/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/27/3a/40/7a/273a407a-47c9-456e-a97c-5ec45bd1e9a0/t/d7/05/6c/ff/d7056cff-e8f0-40cb-bbc8-f976cb55dab8/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/URI_has_semantic_tag.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/URI_has_semantic_tag.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6020361277fb87e02800d5cfaf0a0f5b5826b56e"'
+      - '"eebe3ddaa5d0f5ca6b1af692df4d0eab6bc72a96"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d0cd4d443849f18e07e53b49784cfa7e5d772dfc"'
+      - '"60c88b4a2254133010ddf9d8502701aee725c32b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f91305e6ab8163022ad9ae4f737332249f3220d"'
+      - '"936ece754e236d83a31ad4e1975af54d00f01b96"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b
     body:
       encoding: UTF-8
       string: |
@@ -160,23 +160,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cf7b7b7b46de34359e328ec0fcfe1a62b9f62ad0"'
+      - '"dc1b820dbed17221c28116008619f717dec60e57"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cf7b7b7b46de34359e328ec0fcfe1a62b9f62ad0"'
+      - '"dc1b820dbed17221c28116008619f717dec60e57"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -212,7 +212,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3352'
+      - '3504'
       Content-Type:
       - application/x-turtle
     body:
@@ -229,27 +229,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SemanticTag
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"a0bf3a5f-1981-47a8-a593-764f0961451f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"b9eef24d-4e91-4380-9f3d-7ef277dec568\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.074Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.45Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"oa:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:17.074Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:12.45Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/63/c4/94/af/63c494af-838c-4490-a593-2d73783bfb92/b/de/20/84/6a/de20846a-3997-4556-8c05-cf437999d582/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2e/e3/55/4b/2ee3554b-6768-437b-99e6-a789641a33dd/b/15/d9/a9/51/15d9a951-f4a0-40cb-a723-a8f39a3babbd/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/mult_URIs_with_addl_properties.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/mult_URIs_with_addl_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd251a329b0407c6356370611aefece5881106d9"'
+      - '"b64b108c8d1695a6e2f48da5f84265bdf0b77f76"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bc29d483f574e590be160824299e56a91e8bc77e"'
+      - '"f046939eb39d619d2ca173f8bf83a848f2370fca"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f4358be9c44a02a8e4ac2a213cb5f99b2cd176bb"'
+      - '"b64fb8d0572bdb511f5b142bf188ecddd28c364c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
     body:
       encoding: UTF-8
       string: |
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"16fe11bc1c8c9362603486d244065c05ecd85102"'
+      - '"51bc938bf98b58fdf8d6cf42ef7bcc6cddb81370"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
     body:
       encoding: UTF-8
       string: |
@@ -202,23 +202,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9e394692d23b4307e0c56666fe0048a8cc1f1f9c"'
+      - '"fc548a1ee29a1a34dc708a9548d9d6dbf0a93dbf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
     body:
       encoding: UTF-8
       string: |
@@ -247,23 +247,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2ffdab1f671b1df5939f8864cc3811a29ae9db29"'
+      - '"72c931920f43965483aabc8d3f6a872ef8bf1786"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t
     body:
       encoding: US-ASCII
       string: ''
@@ -280,9 +280,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2a53ca5d152bd05cf65f5d1bb3e7aa8494b64099"'
+      - '"8917322d9d67212c2244f3cadd337337d344a92a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -299,7 +299,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3709'
+      - '3815'
       Content-Type:
       - application/x-turtle
     body:
@@ -316,35 +316,36 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"24da0e38-6d8e-464c-a790-07791260da70\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"7f5524de-b2b1-4e9a-9e05-3bac9e2ed958\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.85Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.173Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:17.924Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:13.241Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd
     body:
       encoding: US-ASCII
       string: ''
@@ -361,9 +362,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"16fe11bc1c8c9362603486d244065c05ecd85102"'
+      - '"51bc938bf98b58fdf8d6cf42ef7bcc6cddb81370"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -380,7 +381,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3431'
+      - '3277'
       Content-Type:
       - application/x-turtle
     body:
@@ -397,33 +398,32 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"e39e57a2-7df9-49fd-b97b-f89bcf32f8eb\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"b2064cf0-9692-4378-8437-9490748ae401\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.874Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.195Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.874Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:13.195Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/74/ec/e5/48/74ece548-b08e-498e-8b06-3c22e0d1d3fd/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/35/ec/00/d1/35ec00d1-c6ab-45c8-bc58-d8be0ce8c66a/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda
     body:
       encoding: US-ASCII
       string: ''
@@ -440,89 +440,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9e394692d23b4307e0c56666fe0048a8cc1f1f9c"'
+      - '"fc548a1ee29a1a34dc708a9548d9d6dbf0a93dbf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
-      Link:
-      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
-      - <http://www.w3.org/ns/ldp#Container>;rel="type"
-      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
-      Accept-Patch:
-      - application/sparql-update
-      Accept-Post:
-      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
-      Allow:
-      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
-      Preference-Applied:
-      - return=representation
-      Vary:
-      - Accept, Range, Accept-Encoding, Accept-Language
-      - Prefer
-      Content-Length:
-      - '3549'
-      Content-Type:
-      - application/x-turtle
-    body:
-      encoding: UTF-8
-      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix image:
-        <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
-        .\n@prefix test: <info:fedora/test/> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
-        .\n@prefix cnt: <http://www.w3.org/2011/content#> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
-        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
-        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix dc11: <http://purl.org/dc/elements/1.1/>
-        .\n@prefix oa: <http://www.w3.org/ns/oa#> .\n@prefix triannon: <http://triannon.stanford.edu/ns/>
-        .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
-        <http://fedora.info/definitions/v4/repository#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
-        .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
-        .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
-        mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8>
-        a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
-        <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
-        , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Image
-        , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
-        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
-        , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"b2f0dcfb-84a2-4f3c-ac67-c27f3b55671a\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.899Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_thumb.jpg>
-        ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.899Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/5c/a5/e0/3f/5ca5e03f-180b-4012-90c9-f9f686009ff8/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
-    http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
-- request:
-    method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Accept:
-      - application/x-turtle
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Etag:
-      - '"2ffdab1f671b1df5939f8864cc3811a29ae9db29"'
-      Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -556,28 +476,108 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Image
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"befca6ac-f0e1-48ef-b4ad-23926e784b9b\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"04a5fb15-8586-4ba2-b059-cbb11a5c2e74\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.924Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.218Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_thumb.jpg>
+        ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
+        \"2015-07-08T18:55:13.218Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/6a/1c/38/28/6a1c3828-2ab3-441d-82db-d3aaa5a7adda/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+    http_version: 
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
+- request:
+    method: get
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept:
+      - application/x-turtle
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Etag:
+      - '"72c931920f43965483aabc8d3f6a872ef8bf1786"'
+      Last-Modified:
+      - Wed, 08 Jul 2015 18:55:13 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Length:
+      - '3549'
+      Content-Type:
+      - application/x-turtle
+    body:
+      encoding: UTF-8
+      string: "@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .\n@prefix image:
+        <http://www.modeshape.org/images/1.0> .\n@prefix sv: <http://www.jcp.org/jcr/sv/1.0>
+        .\n@prefix test: <info:fedora/test/> .\n@prefix nt: <http://www.jcp.org/jcr/nt/1.0>
+        .\n@prefix cnt: <http://www.w3.org/2011/content#> .\n@prefix dcmitype: <http://purl.org/dc/dcmitype/>
+        .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance>
+        .\n@prefix mode: <http://www.modeshape.org/1.0> .\n@prefix dc11: <http://purl.org/dc/elements/1.1/>
+        .\n@prefix oa: <http://www.w3.org/ns/oa#> .\n@prefix triannon: <http://triannon.stanford.edu/ns/>
+        .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix fedora:
+        <http://fedora.info/definitions/v4/repository#> .\n@prefix xml: <http://www.w3.org/XML/1998/namespace>
+        .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
+        .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
+        mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0>
+        a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
+        <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
+        , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Image
+        , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
+        , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
+        , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"198a237e-e0be-46e7-b07b-235102bbc491\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.241Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Image\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.924Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:13.241Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/2f/51/53/71/2f515371-4c29-47e7-90e9-5cbc48bd9e46/t/63/cd/c3/3a/63cdc33a-5812-439e-89f2-fc0171fa3ddc/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/06/fa/58/69/06fa5869-80a2-482d-aabe-7b4692f4f334/t/01/85/1e/1b/01851e1b-9931-40c8-9213-76d4d58ccdf0/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/mult_plain_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/mult_plain_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"94bfebd3f739da389968934f5a2e970e30f7e91c"'
+      - '"ed6bff6dd04cb25930fec229cea1dfc8f4775392"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -68,23 +68,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a1d67f6741c4891392cd1ded15741939980ed08e"'
+      - '"e330d7d3727f3908b1f19205e28c0b4ca164072d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa
     body:
       encoding: UTF-8
       string: |
@@ -94,7 +94,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -114,23 +114,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6e979b9696ddb2d08ea9d4d2f46657647ea743d1"'
+      - '"ca34ac2b66b56fd1ff26b519aab77c5ced5ff8a7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t
     body:
       encoding: UTF-8
       string: |
@@ -157,23 +157,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a31766b9c4c30506b5ef3d0fd46cc9fe574a3f65"'
+      - '"112efa1ceb3daad3bc1138f8b701ad8ee163d9eb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t
     body:
       encoding: UTF-8
       string: |
@@ -200,23 +200,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"81d9ec0c1be391ef6602af5e3c44e4d289ea8079"'
+      - '"281daea5fcf9be38b2dc51df2280d3bcf82bdda7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t
     body:
       encoding: US-ASCII
       string: ''
@@ -233,9 +233,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0c778975daefc2271359da6078a5c8f3af1e4ef6"'
+      - '"0ae10031dc6a184ff18d5794860035fb6ba62077"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -252,7 +252,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3659'
+      - '3554'
       Content-Type:
       - application/x-turtle
     body:
@@ -269,35 +269,34 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"367fa51a-8c02-438c-b0ee-da09280ea13a\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"7f77bda9-e76a-4c8d-a016-544f3b60d682\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.456Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.807Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:17.502Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:12.852Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa>
         ;\n\tldp:hasMemberRelation oa:hasTarget ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3
     body:
       encoding: US-ASCII
       string: ''
@@ -314,9 +313,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a31766b9c4c30506b5ef3d0fd46cc9fe574a3f65"'
+      - '"112efa1ceb3daad3bc1138f8b701ad8ee163d9eb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -333,7 +332,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3275'
+      - '3429'
       Content-Type:
       - application/x-turtle
     body:
@@ -350,32 +349,33 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"2e42fae5-8808-42c9-b3ad-f3aa522ecd39\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"97c24305-0760-44df-975c-e000b9a2779d\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.48Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.83Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.48Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfedora:writable
+        \"2015-07-08T18:55:12.83Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfedora:writable
         \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/77/c0/23/73/77c02373-e17b-469d-b2ae-4de7f29a744c/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/54/b6/fe/fd/54b6fefd-3f50-4971-85d8-73d94063d2e3/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e
     body:
       encoding: US-ASCII
       string: ''
@@ -392,9 +392,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"81d9ec0c1be391ef6602af5e3c44e4d289ea8079"'
+      - '"281daea5fcf9be38b2dc51df2280d3bcf82bdda7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -428,28 +428,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"031d02b5-4fbc-457e-bda6-d3c6e350a840\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"a1dc6b62-087c-446c-add2-8711ce6c68f7\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:17.502Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:12.852Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://purl.stanford.edu/oo000oo1234> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:17.502Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        \"2015-07-08T18:55:12.852Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/53/f9/c2/73/53f9c273-bb57-4a5a-9adb-88041e443807/t/2f/ea/26/48/2fea2648-d2f6-4323-a398-37f7f6c1ee33/fcr:export?format=jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/c0/42/9b/a1/c0429ba1-93ec-4e80-9504-ac6d9cbed6aa/t/d6/a6/f5/53/d6a6f553-125b-463e-bbc8-6f77411ac43e/fcr:export?format=jcr/xml>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:17 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/multiple_URI_resources_with_addl_properties.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/multiple_URI_resources_with_addl_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ef15a035107d8b663225f36d3bd4e661f75d4d18"'
+      - '"3770f7b6544b3f0b84ba2ce98f4db7e7b628b6f1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:17 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f245786618e63cf3a16f8eaac263fd802289bb71"'
+      - '"598a04535282c17c1f5f4bcd7f665b10dfa3ea1a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8c301ca5552d112f9d1ddab2186d844a74ed0831"'
+      - '"e177adaad0289c08f2f15124e7b11a8ffb3e5d9d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b
     body:
       encoding: UTF-8
       string: |
@@ -160,23 +160,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"71a67f70ec5935a93455c4cdf2322eddc6cb9960"'
+      - '"5d2a2c0d749fb67f194895577982ac6ad55e8656"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b
     body:
       encoding: UTF-8
       string: |
@@ -205,23 +205,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9894af95227cfe952a024e8a43399b11adf48a57"'
+      - '"3ec722a336c1b8e085369ccda13ff2d1ae865ae4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b
     body:
       encoding: US-ASCII
       string: ''
@@ -238,9 +238,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"16b9217307bb8fae3368606760d234abb7839341"'
+      - '"4d7f9e388873c06e4f0016379ae3c0ea86bbcb61"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -257,7 +257,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3657'
+      - '3551'
       Content-Type:
       - application/x-turtle
     body:
@@ -274,35 +274,34 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"a6b81c5f-ef6e-4d3e-a6e2-b2a7c97651ca\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"8c4ef087-63ca-4dba-bc95-a1861d78551f\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:18.356Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.623Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:18.405Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:13.67Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +318,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"71a67f70ec5935a93455c4cdf2322eddc6cb9960"'
+      - '"5d2a2c0d749fb67f194895577982ac6ad55e8656"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -355,32 +354,32 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SemanticTag
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"56739147-8d20-436b-b29b-ced7b4864b98\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"6ea2a7d6-177d-42b0-a73d-666cbd81b7e7\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:18.382Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.646Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"oa:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:18.382Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:13.646Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/b5/0f/89/9d/b50f899d-e026-4932-b008-e69659dd7095/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d/fcr:export?format=jcr/xml>
+        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/4d/8c/6d/e0/4d8c6de0-00da-46ab-9721-b610d6a20a0d/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1
     body:
       encoding: US-ASCII
       string: ''
@@ -397,9 +396,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9894af95227cfe952a024e8a43399b11adf48a57"'
+      - '"3ec722a336c1b8e085369ccda13ff2d1ae865ae4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:18 GMT
+      - Wed, 08 Jul 2015 18:55:13 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -416,7 +415,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3508'
+      - '3506'
       Content-Type:
       - application/x-turtle
     body:
@@ -433,29 +432,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , dcmitype:Sound , fedora:Container
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"242bdb5e-77dc-49b8-82e9-84397d01fe91\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"4baebb21-97a6-4f69-a255-f76f957e2e8c\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:18.405Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://www.example.org/comment.mp3> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:18.405Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tfedora:mixinTypes \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:writable
-        \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/79/75/f3/20/7975f320-9823-4bb4-b69f-e78482a0021c/b/e6/1d/02/e3/e61d02e3-942f-45d1-8cb5-0af071b141b0/fcr:export?format=jcr/xml>
+        ;\n\tfedora:created \"2015-07-08T18:55:13.67Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://www.example.org/comment.mp3> ;\n\tfedora:mixinTypes
+        \"dcmitype:Sound\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
+        , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:13.67Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/4d/20/e7/2c/4d20e72c-c70b-469a-9f38-dcc45cfa8df6/b/71/dc/d2/ea/71dcd2ea-057c-43ef-b084-d71f921872a1/fcr:export?format=jcr/xml>
         .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:18 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/plain_URI.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/external_URI/plain_URI.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9756b9af0688674d1706268b4cb8457b5e5cea54"'
+      - '"99086b5c01525c1b5f0329117e289bae6e09e6a0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:11 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fd4b1c24f92ac002815cbe6f09d61acc3e85a036"'
+      - '"10a61823f362b7b7dd66c1c5fe40db84f23a613e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f05d51feaf04b88b1a81aecd9e096a0432e51437"'
+      - '"cc0e029955893e7287170ec840efbe4c79f42e32"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"de1f770bfb6952b648210993b78484051c55dfe0"'
+      - '"ad5f4fdfb1239a5aacbb5f29b3ff92092e573c68"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708
     body:
       encoding: US-ASCII
       string: ''
@@ -191,9 +191,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"de1f770bfb6952b648210993b78484051c55dfe0"'
+      - '"ad5f4fdfb1239a5aacbb5f29b3ff92092e573c68"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:16 GMT
+      - Wed, 08 Jul 2015 18:55:12 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -210,7 +210,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3275'
+      - '3431'
       Content-Type:
       - application/x-turtle
     body:
@@ -227,27 +227,28 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"76eeb6bb-4ea0-4bfe-9a40-2ee39431446f\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"39c8f75b-4fb5-4a17-9575-111888ae29c5\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:16.62Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfedora:lastModified
-        \"2015-06-26T22:21:16.62Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;\n\tfedora:mixinTypes
+        ;\n\tfedora:created \"2015-07-08T18:55:12.083Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
-        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:writable
-        \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ;\n\tfedora:hasParent
-        <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/f2/d2/0e/a1/f2d20ea1-3cd7-4b63-ac0f-11069cee8dbc/b/31/cf/7e/f3/31cf7ef3-84fa-460c-9cf6-e7799c2819ac/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n"
+        , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:lastModified
+        \"2015-07-08T18:55:12.083Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708>
+        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/ab/c9/df/8c/abc9df8c-9716-457d-946e-5d22e4428ddd/b/e6/f9/c7/8b/e6f9c78b-6757-4359-ba26-6b90df4c7708/fcr:export?format=jcr/xml>
+        .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:16 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/multiple_resources_of_different_types/multiple_resources_one_URI_.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/_create_resources_in_container/multiple_resources_of_different_types/multiple_resources_one_URI_.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7907ae888fd45ed244b702f388b528b1fdf9ff2e"'
+      - '"a238ffa685dd04841974cdcd0f353f72df3c74ec"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c5f3a6897a1b4d60df56f65c4beb5fa899bf04ca"'
+      - '"6ada674c9bc83d90b36c944f9f51661074a9a0bf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '100'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7816bf883156314a8e2dc422e3503ef84d15a7d2"'
+      - '"b1df78092e02a9180baaca5508918da80f1398ea"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '102'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"51fe748b9dd16def8996bf6b230e9267e8a1b3e9"'
+      - '"61b74542f91b70e3282b1f6c6c6c9dd2a9678e8a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b
     body:
       encoding: UTF-8
       string: |
@@ -207,23 +207,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6808a64bd7658c52c7b75cab7ac851ffe8beda79"'
+      - '"da14c8d5c2ca871c2862fa0d7accfc21a71f9be6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Content-Length:
       - '151'
       Location:
-      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92
+      - http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92
+      string: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b
     body:
       encoding: US-ASCII
       string: ''
@@ -240,9 +240,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d2fb864bb33653cb5c06255f047344181f0d0c67"'
+      - '"156a0566ac79022a5a70e0a7dc18bfe42eb71b6f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
       - <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"
@@ -259,7 +259,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3656'
+      - '3551'
       Content-Type:
       - application/x-turtle
     body:
@@ -276,35 +276,34 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , fedora:Resource
         , ldp:DirectContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"126da9b7-c2fb-4a8f-9440-379e192d9b43\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"7ad17d9d-799f-478b-9779-6176d80263ca\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.48Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.397Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:DirectContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
-        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.45Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tldp:membershipResource <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e>
         ;\n\tldp:hasMemberRelation oa:hasBody ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302>
-        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81>
-        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e>
+        ;\n\tldp:contains <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21>
+        , <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
-        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/fcr:export?format=jcr/xml>
-        .\n"
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21
     body:
       encoding: US-ASCII
       string: ''
@@ -321,9 +320,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"51fe748b9dd16def8996bf6b230e9267e8a1b3e9"'
+      - '"61b74542f91b70e3282b1f6c6c6c9dd2a9678e8a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -357,7 +356,7 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , dcmitype:Text
@@ -365,26 +364,26 @@ http_interactions:
         , <http://www.jcp.org/jcr/mix/1.0created> , <http://www.jcp.org/jcr/mix/1.0lastModified>
         , <http://www.jcp.org/jcr/mix/1.0referenceable> , fedora:Container ;\n\tfedora:lastModifiedBy
         \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tfedora:uuid
-        \"d13c3d9e-6fbe-4d09-b07b-79fe9bfe41f5\"^^<http://www.w3.org/2001/XMLSchema#string>
+        \"e06bbc03-6921-495a-ab23-7edef5ea1638\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.507Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.425Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:mixinTypes \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"dcmitype:Text\"^^<http://www.w3.org/2001/XMLSchema#string> , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string> , \"cnt:ContentAsText\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.507Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.425Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b>
-        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81/fcr:export?format=jcr/xml>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/43/d3/16/bf/43d316bf-b01e-4f84-8e5e-ed18aac77a81/fcr:export?format=jcr/xml>
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/79/d3/d7/dd/79d3d7dd-31ca-4f6b-9e8b-99bce4c43e21/fcr:export?format=jcr/xml>
         dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
         rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92
+    uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f
     body:
       encoding: US-ASCII
       string: ''
@@ -401,9 +400,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6808a64bd7658c52c7b75cab7ac851ffe8beda79"'
+      - '"da14c8d5c2ca871c2862fa0d7accfc21a71f9be6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -420,7 +419,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '3506'
+      - '3350'
       Content-Type:
       - application/x-turtle
     body:
@@ -437,28 +436,27 @@ http_interactions:
         .\n@prefix ldp: <http://www.w3.org/ns/ldp#> .\n@prefix xs: <http://www.w3.org/2001/XMLSchema>
         .\n@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .\n@prefix
         mix: <http://www.jcp.org/jcr/mix/1.0> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
-        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f>
         a ldp:RDFSource , ldp:Container , <http://www.jcp.org/jcr/nt/1.0folder> ,
         <http://www.jcp.org/jcr/nt/1.0hierarchyNode> , <http://www.jcp.org/jcr/nt/1.0base>
         , <http://www.jcp.org/jcr/mix/1.0created> , fedora:Container , oa:SemanticTag
         , fedora:Resource , ldp:BasicContainer , fedora:Resource , <http://www.jcp.org/jcr/mix/1.0created>
         , <http://www.jcp.org/jcr/mix/1.0lastModified> , <http://www.jcp.org/jcr/mix/1.0referenceable>
         , fedora:Container ;\n\tfedora:lastModifiedBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:uuid \"9bdb9788-3a54-4151-a339-c76e39e146e1\"^^<http://www.w3.org/2001/XMLSchema#string>
+        ;\n\tfedora:uuid \"5a181f6c-cafd-4534-873c-91ea9ef15398\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:createdBy \"bypassAdmin\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tfedora:primaryType \"nt:folder\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:created \"2015-06-26T22:21:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:created \"2015-07-08T18:55:16.45Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love> ;\n\tfedora:mixinTypes
         \"fedora:Container\"^^<http://www.w3.org/2001/XMLSchema#string> , \"oa:SemanticTag\"^^<http://www.w3.org/2001/XMLSchema#string>
         , \"fedora:Resource\"^^<http://www.w3.org/2001/XMLSchema#string> , \"ldp:BasicContainer\"^^<http://www.w3.org/2001/XMLSchema#string>
-        ;\n\tfedora:lastModified \"2015-06-26T22:21:21.542Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+        ;\n\tfedora:lastModified \"2015-07-08T18:55:16.45Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>
         ;\n\tfedora:writable \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>
-        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b>
-        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92/fcr:export?format=jcr/xml>
-        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92>
-        fedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/1e/b0/02/ae/1eb002ae-da1d-421b-9007-ec7845f40302/b/56/f4/d1/f2/56f4d1f2-2d20-4b30-b587-1b588883ad92/fcr:export?format=jcr/xml>
-        .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml> rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        ;\n\tfedora:hasParent <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b>
+        ;\n\tfedora:exportsAs <http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f/fcr:export?format=jcr/xml>
+        .\n\n<http://localhost:8983/fedora/rest/anno/ldpwprotspec/65/05/9b/14/65059b14-bd03-4845-b49a-5038f8027b7e/b/6b/21/14/c8/6b2114c8-3762-45f5-967d-65c7b884c57f/fcr:export?format=jcr/xml>
+        dc11:format <http://fedora.info/definitions/v4/repository#jcr/xml> .\n\n<http://fedora.info/definitions/v4/repository#jcr/xml>
+        rdfs:label \"jcr/xml\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/after_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/after_ldp_writer_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"da313127beb164c683af3a6be89ada5f40ad7212"'
+      - '"7158c520aeeed3bd8faab0be583ef946e160cb5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:21 GMT
+      - Wed, 08 Jul 2015 18:55:16 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:21 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/before_ldp_writer_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_LdpWriter/protected_methods/before_ldp_writer_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0b0febf06240cb46ed4edf9c1ccdbaa097e15706"'
+      - '"5523bbf1626fb0817ffba0e6630a119c4ef52259"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/ldpwprotspec
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"23f3768d3998196c2357d12990bc4470a42291cb"'
+      - '"3a67020e5edee8c88c579a7cb28a60097b422002"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:15 GMT
+      - Wed, 08 Jul 2015 18:55:10 GMT
       Content-Length:
       - '51'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/ldpwprotspec
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:15 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SearchController/GET_find/returns_http_success.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SearchController/GET_find/returns_http_success.yml
@@ -39,5 +39,5 @@ http_interactions:
             'facet_ranges'=>{},
             'facet_intervals'=>{}}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:31 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_find/calls_anno_graphs_array.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_find/calls_anno_graphs_array.yml
@@ -22,7 +22,7 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>4,
+            'QTime'=>3,
             'params'=>{
               'q'=>'target_url:some.url.org AND target_url:some.url.org#* AND body_chars_exact:"foo"',
               'defType'=>'lucene',
@@ -41,5 +41,5 @@ http_interactions:
             'facet_ranges'=>{},
             'facet_intervals'=>{}}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_search/returns_a_solr_response_object_with_docs_with_anno_jsonld_field.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_search/returns_a_solr_response_object_with_docs_with_anno_jsonld_field.yml
@@ -35,8 +35,8 @@ http_interactions:
                 'target_type'=>['external_URI'],
                 'body_type'=>['no_body'],
                 'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/my_root/81/4b/02/25/814b0225-bd48-4de9-a724-a72a9fa86c18","@type":"oa:Annotation","hasTarget":"http://my.favorite.org","motivatedBy":"oa:bookmarking"}',
-                '_version_'=>1505081200751935488,
-                'timestamp'=>'2015-06-26T22:21:25.263Z',
+                '_version_'=>1506155398323765248,
+                'timestamp'=>'2015-07-08T18:55:19.898Z',
                 'score'=>1.0}]
           },
           'facet_counts'=>{
@@ -55,5 +55,5 @@ http_interactions:
             'facet_ranges'=>{},
             'facet_intervals'=>{}}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:28 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_search/works_with_no_params.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/_search/works_with_no_params.yml
@@ -27,16 +27,16 @@ http_interactions:
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>2,'start'=>0,'maxScore'=>1.0,'docs'=>[
               {
-                'id'=>'new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405',
+                'id'=>'new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861',
                 'root'=>'new_anno_feature',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://purl.stanford.edu/kq131cs7229'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['I love this!'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318416652060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I love this!"},{"@id":"http://your.triannon-server.com/annotations/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405","@type":"oa:Annotation","hasBody":"_:g70318416652060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1505081154478276608,
-                'timestamp'=>'2015-06-26T22:20:41.133Z',
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312784715560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I love this!"},{"@id":"http://your.triannon-server.com/annotations/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861","@type":"oa:Annotation","hasBody":"_:g70312784715560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506155356285304832,
+                'timestamp'=>'2015-07-08T18:54:39.806Z',
                 'score'=>1.0},
               {
                 'id'=>'my_root/81/4b/02/25/814b0225-bd48-4de9-a724-a72a9fa86c18',
@@ -46,8 +46,8 @@ http_interactions:
                 'target_type'=>['external_URI'],
                 'body_type'=>['no_body'],
                 'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@id":"http://your.triannon-server.com/annotations/my_root/81/4b/02/25/814b0225-bd48-4de9-a724-a72a9fa86c18","@type":"oa:Annotation","hasTarget":"http://my.favorite.org","motivatedBy":"oa:bookmarking"}',
-                '_version_'=>1505081200751935488,
-                'timestamp'=>'2015-06-26T22:21:25.263Z',
+                '_version_'=>1506155398323765248,
+                'timestamp'=>'2015-07-08T18:55:19.898Z',
                 'score'=>1.0}]
           },
           'facet_counts'=>{
@@ -69,5 +69,5 @@ http_interactions:
             'facet_ranges'=>{},
             'facet_intervals'=>{}}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:28 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/after_search_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/after_search_spec.yml
@@ -23,7 +23,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:28 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:22 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -45,7 +45,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>12}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>22}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:28 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/before_search_spec.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SolrSearcher/before_search_spec.yml
@@ -25,7 +25,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:25 GMT
+  recorded_at: Wed, 08 Jul 2015 18:55:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/creating_an_annotation/creating_root_container.yml
+++ b/spec/fixtures/vcr_cassettes/creating_an_annotation/creating_root_container.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5cefbc48dfa3120f0edad468ed30d9ff62cabd31"'
+      - '"3d2d9b80d0a4b5e3317ee92ddb6084498f8d80f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:29 GMT
+      - Wed, 08 Jul 2015 18:54:27 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/new_anno_feature
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5e447fab2bb6755e07ca4f1de0d390672e9e7d7e"'
+      - '"e5cfffd92616fea688d12ce897b16ae7dab8f33d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '55'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/new_anno_feature
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/creating_an_annotation/deleting_root_container.yml
+++ b/spec/fixtures/vcr_cassettes/creating_an_annotation/deleting_root_container.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"31cae94e4460a18a0904e5c4a0acf6f277e6650b"'
+      - '"4f68827cef33319aa1f2465eb55c8d3e7cc2dd14"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/new_anno_feature
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>35}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>40}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/creating_an_annotation/html/redirects_to_show_after_anno_created.yml
+++ b/spec/fixtures/vcr_cassettes/creating_an_annotation/html/redirects_to_show_after_anno_created.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5e447fab2bb6755e07ca4f1de0d390672e9e7d7e"'
+      - '"e5cfffd92616fea688d12ce897b16ae7dab8f33d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/new_anno_feature
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9462b432546ec7a62f9cd42419b4b6850f11f35e"'
+      - '"106f783a33fd444f4aba7ace6e2bf09f18c0f150"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '104'
       Location:
-      - http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405
+      - http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405
+      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"782567c4a7a729eb717ec0294210c084bd0c0d3d"'
+      - '"6d1d83a408818fbb94e5b465321fba5d968b9c64"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b
+      - http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b
+      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"09eef318b66935058d0e9bb5b318c6c325347bfe"'
+      - '"122dd608ab6b934b01ead9cae955b3b44f53de03"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b/52/40/1f/db/52401fdb-55fc-4ce3-aecd-927072332379
+      - http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b/66/15/fc/15/6615fc15-0a32-4e8f-8e97-3c92dba2d8d8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b/52/40/1f/db/52401fdb-55fc-4ce3-aecd-927072332379
+      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b/66/15/fc/15/6615fc15-0a32-4e8f-8e97-3c92dba2d8d8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"da266323152cf8cd3398e304fa586933adedd24f"'
+      - '"62bb4d374d5b9e9b5527ae9532dab4abd9e43d47"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t
+      - http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t
+      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"96bce4c04d77e4558228fc85498d7f40f73675de"'
+      - '"cd8cb8ec08878b71e85730e15e3ec3ce7822b627"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Content-Length:
       - '155'
       Location:
-      - http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t/cd/47/99/e3/cd4799e3-7ea5-42b6-bfde-9a541d297a50
+      - http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t/8f/d8/8a/8d/8fd88a8d-e7d1-4b98-ab64-ca027d5d4a43
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t/cd/47/99/e3/cd4799e3-7ea5-42b6-bfde-9a541d297a50
+      string: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t/8f/d8/8a/8d/8fd88a8d-e7d1-4b98-ab64-ca027d5d4a43
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e63259fabec40b730d6b32b6c0654f6efcaa61a4"'
+      - '"52a800cfcee8249584802d504917090ff3f5885d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b>
-        , <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b/52/40/1f/db/52401fdb-55fc-4ce3-aecd-927072332379>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t/cd/47/99/e3/cd4799e3-7ea5-42b6-bfde-9a541d297a50>
+        <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b>
+        , <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t/8f/d8/8a/8d/8fd88a8d-e7d1-4b98-ab64-ca027d5d4a43>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b/66/15/fc/15/6615fc15-0a32-4e8f-8e97-3c92dba2d8d8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:40 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b/52/40/1f/db/52401fdb-55fc-4ce3-aecd-927072332379
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b/66/15/fc/15/6615fc15-0a32-4e8f-8e97-3c92dba2d8d8
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"09eef318b66935058d0e9bb5b318c6c325347bfe"'
+      - '"122dd608ab6b934b01ead9cae955b3b44f53de03"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/b/52/40/1f/db/52401fdb-55fc-4ce3-aecd-927072332379>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/b/66/15/fc/15/6615fc15-0a32-4e8f-8e97-3c92dba2d8d8>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t/cd/47/99/e3/cd4799e3-7ea5-42b6-bfde-9a541d297a50
+    uri: http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t/8f/d8/8a/8d/8fd88a8d-e7d1-4b98-ab64-ca027d5d4a43
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"96bce4c04d77e4558228fc85498d7f40f73675de"'
+      - '"cd8cb8ec08878b71e85730e15e3ec3ce7822b627"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:40 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405/t/cd/47/99/e3/cd4799e3-7ea5-42b6-bfde-9a541d297a50>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861/t/8f/d8/8a/8d/8fd88a8d-e7d1-4b98-ab64-ca027d5d4a43>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405</field><field
+        name="id">new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861</field><field
         name="root">new_anno_feature</field><field name="motivation">commenting</field><field
         name="target_url">http://purl.stanford.edu/kq131cs7229</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">I love
-        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318416652060","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
-        love this!"},{"@id":"http://your.triannon-server.com/annotations/new_anno_feature/b8/18/34/3c/b818343c-27d5-47a7-83df-15b5605eb405","@type":"oa:Annotation","hasBody":"_:g70318416652060","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        this!</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312784715560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"I
+        love this!"},{"@id":"http://your.triannon-server.com/annotations/new_anno_feature/f9/ce/40/27/f9ce4027-0042-4755-b9d2-434a754a0861","@type":"oa:Annotation","hasBody":"_:g70312784715560","hasTarget":"http://purl.stanford.edu/kq131cs7229","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,7 +482,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e1e67051a21f73033d1818fd5682e221ee968079"'
+      - '"e5c027f6c5bdb995ae016b6079e57c2b99882bd8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"94de7d5762ab8e5f4563c5ba23a22e03812733f2"'
+      - '"ac3bb9df737fa187a25531206537377a61467b12"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:39 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b66197482c7fbad72a5f0452266985f84bc1cee8"'
+      - '"4a6b5bd7004d2d452508a6ccc9798f32a76428e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '63'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/choice_integration_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b66197482c7fbad72a5f0452266985f84bc1cee8"'
+      - '"4a6b5bd7004d2d452508a6ccc9798f32a76428e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"63d4642a40aba2be9afb00332df07681fcd30ac4"'
+      - '"3e901f1bb4e3cca0506be9e3e5070ad1d8aaf7d7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"320c1cd8d79380672989fad92784f17c08b5c524"'
+      - '"84478572a2064d550f5a499332130c07f74e55dd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b
     body:
       encoding: UTF-8
       string: |
@@ -174,23 +174,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7fe4d830486e73dca231274ed1a614c9ab157c67"'
+      - '"26b92669f93944475d46bc2a78ebe0e343dd7660"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
     body:
       encoding: UTF-8
       string: |
@@ -200,7 +200,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -220,23 +220,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d84e0a93066313e3485eba8e3c1ed951f183caef"'
+      - '"856b4e546a09f76bec2dd1468645e31c3ab2fe23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:41 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t
     body:
       encoding: UTF-8
       string: |
@@ -263,23 +263,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"701b95a23b4266fc457685c8d678672e72deb48f"'
+      - '"a925f4839a27a712938e9e6a58abcfdd2577c2e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
     body:
       encoding: US-ASCII
       string: ''
@@ -298,9 +298,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"175b426f55e342ea771a24d762a91d5378d455c4"'
+      - '"477396bb0ef78f711522928bda1d5824ba58f7e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -334,18 +334,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7
     body:
       encoding: US-ASCII
       string: ''
@@ -364,9 +364,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7fe4d830486e73dca231274ed1a614c9ab157c67"'
+      - '"26b92669f93944475d46bc2a78ebe0e343dd7660"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -400,21 +400,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/ac/9d/fb/b8/ac9dfbb8-f9ef-4cc7-a793-e483a104ca0b>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/43/41/16/3f/4341163f-73ca-4a57-b22e-01a45d447d7c>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ac/9d/fb/b8/ac9dfbb8-f9ef-4cc7-a793-e483a104ca0b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/aa/89/39/77/aa893977-248f-4773-9717-f1ad33d56387>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/d1/a4/95/e9/d1a495e9-45d5-4a91-97f6-c4b17770304e>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/aa/89/39/77/aa893977-248f-4773-9717-f1ad33d56387>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/43/41/16/3f/4341163f-73ca-4a57-b22e-01a45d447d7c>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/d1/a4/95/e9/d1a495e9-45d5-4a91-97f6-c4b17770304e>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653
     body:
       encoding: US-ASCII
       string: ''
@@ -433,9 +433,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"701b95a23b4266fc457685c8d678672e72deb48f"'
+      - '"a925f4839a27a712938e9e6a58abcfdd2577c2e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -469,14 +469,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331
     body:
       encoding: US-ASCII
       string: ''
@@ -495,9 +495,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"175b426f55e342ea771a24d762a91d5378d455c4"'
+      - '"477396bb0ef78f711522928bda1d5824ba58f7e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -531,18 +531,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7
     body:
       encoding: US-ASCII
       string: ''
@@ -561,9 +561,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7fe4d830486e73dca231274ed1a614c9ab157c67"'
+      - '"26b92669f93944475d46bc2a78ebe0e343dd7660"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -597,21 +597,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/b/cb/6e/9d/f6/cb6e9df6-daca-465c-b693-bda881f2a71c>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/ac/9d/fb/b8/ac9dfbb8-f9ef-4cc7-a793-e483a104ca0b>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/43/41/16/3f/4341163f-73ca-4a57-b22e-01a45d447d7c>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ac/9d/fb/b8/ac9dfbb8-f9ef-4cc7-a793-e483a104ca0b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/b/9c/66/e6/d3/9c66e6d3-ad2c-4df4-86eb-e853ba87d9e7>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/aa/89/39/77/aa893977-248f-4773-9717-f1ad33d56387>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/d1/a4/95/e9/d1a495e9-45d5-4a91-97f6-c4b17770304e>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/aa/89/39/77/aa893977-248f-4773-9717-f1ad33d56387>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/43/41/16/3f/4341163f-73ca-4a57-b22e-01a45d447d7c>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/d1/a4/95/e9/d1a495e9-45d5-4a91-97f6-c4b17770304e>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653
     body:
       encoding: US-ASCII
       string: ''
@@ -630,9 +630,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"701b95a23b4266fc457685c8d678672e72deb48f"'
+      - '"a925f4839a27a712938e9e6a58abcfdd2577c2e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -666,9 +666,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8b/f0/b0/c4/8bf0b0c4-eea1-4bbc-80b2-7f6ba57ac330/t/16/d7/f7/c1/16d7f7c1-635e-4ea7-9d65-1453190360fc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e6/52/ff/ff/e652ffff-c14c-48fc-99cc-4a89ce5fb331/t/c3/85/6b/84/c3856b84-3e00-4d0e-885a-400710b5b653>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c70f5b80a2000e1f72389ee9f2adece1c2d5c9ec"'
+      - '"2fd8eeef948168bfa94dde477a202c46680ca90c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:41 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"90023560d59e3f6f9fe3737b91d92e3cc62af110"'
+      - '"13f39e831f9b43dd07553e693222f2371553ff93"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3a9e6595d6719b77e851b8ec9e5d59d957723f4e"'
+      - '"86fbc6e95437ef2f07531204ad7b147193774097"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:40 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b
     body:
       encoding: UTF-8
       string: |
@@ -172,23 +172,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d4b3d11f69905e3f086f32c9cded5ffbd62348dc"'
+      - '"8bb73ab372943a05c62538af64c236c1670ba915"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
     body:
       encoding: UTF-8
       string: |
@@ -198,7 +198,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -218,23 +218,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8677d02fff1b3b8dfcba870e8fc7dbb99f24b059"'
+      - '"2d9305efd2dd3392839731ace6902c8ca6b51515"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t
     body:
       encoding: UTF-8
       string: |
@@ -261,23 +261,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"638a6a2658da68f691eb2836e5d8395bf450b79e"'
+      - '"c94761f04e51dc9aa02e75389a21e4b3e796cf8e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
     body:
       encoding: US-ASCII
       string: ''
@@ -296,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eafbce0263781aa77ccae50451e645f2ab305efd"'
+      - '"a58ff176ab5299cbbffe3ebaaa019c4e00e2f8dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -332,18 +332,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0
     body:
       encoding: US-ASCII
       string: ''
@@ -362,9 +362,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d4b3d11f69905e3f086f32c9cded5ffbd62348dc"'
+      - '"8bb73ab372943a05c62538af64c236c1670ba915"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -398,20 +398,20 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#item1>
-        a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
-        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#default>
         a dcmitype:Sound ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#item1>
+        a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8
     body:
       encoding: US-ASCII
       string: ''
@@ -430,9 +430,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"638a6a2658da68f691eb2836e5d8395bf450b79e"'
+      - '"c94761f04e51dc9aa02e75389a21e4b3e796cf8e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -466,14 +466,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c
     body:
       encoding: US-ASCII
       string: ''
@@ -492,9 +492,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eafbce0263781aa77ccae50451e645f2ab305efd"'
+      - '"a58ff176ab5299cbbffe3ebaaa019c4e00e2f8dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -528,18 +528,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0
     body:
       encoding: US-ASCII
       string: ''
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d4b3d11f69905e3f086f32c9cded5ffbd62348dc"'
+      - '"8bb73ab372943a05c62538af64c236c1670ba915"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -594,20 +594,20 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#item1>
-        a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
-        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/b/04/74/d6/ff/0474d6ff-acb5-4b72-8b75-2002fe63e9a8#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#default>
         a dcmitype:Sound ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n"
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/b/52/94/d0/e0/5294d0e0-0f25-4433-b6e7-a062e2bf52d0#item1>
+        a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8
     body:
       encoding: US-ASCII
       string: ''
@@ -626,9 +626,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"638a6a2658da68f691eb2836e5d8395bf450b79e"'
+      - '"c94761f04e51dc9aa02e75389a21e4b3e796cf8e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -662,9 +662,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/cc/f8/af/54/ccf8af54-1c61-4ccb-ad31-25cfe8cdd7b2/t/59/12/39/4d/5912394d-ab6e-4825-9784-8e7386e08a9f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/7c/ea/42/b4/7cea42b4-6eb4-4b68-8685-99c55559192c/t/6c/67/1f/c3/6c671fc3-8d3d-4552-a6d7-bfcc448d64c8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:42 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"71a4cb5bda7acb48c959438fc847de15bb977e55"'
+      - '"c5934ed391768122b2e0a23950b7183e4cba7e69"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:42 GMT
+      - Wed, 08 Jul 2015 18:54:40 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6916b3711e721d9a90311a32356343f7fd789ddc"'
+      - '"99d00da03344e0c77d4712e7e5bd2e7082959623"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"160901c41ce0a56fe8cf99582ca291486ecaee77"'
+      - '"050dda85e2f569b4cabab95413f8d0c969d04ac9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"96e35b101a3abd27fa56f88c562efc1c285458ac"'
+      - '"08d4bd15350cd77e3cee7e965c2a88a3cef6e7d0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4e31ea00338ced92067416bab5637cb781b63ef0"'
+      - '"f6159ccffea5a39bdbe3ba006b67441d94bb9e57"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t
     body:
       encoding: UTF-8
       string: |
@@ -256,23 +256,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0d5804cc35a3deb66abfb966891dd70a34285d58"'
+      - '"bb376c67b5d816a6981bc06f5b0d80c1ee3d63f2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
     body:
       encoding: US-ASCII
       string: ''
@@ -291,9 +291,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8eb8771ea56b8fdf4033a3467e4259bfc788b952"'
+      - '"f77f59125d6974acabe8ca9a30fbdf0b2b890ea0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -327,18 +327,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0
     body:
       encoding: US-ASCII
       string: ''
@@ -357,9 +357,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"96e35b101a3abd27fa56f88c562efc1c285458ac"'
+      - '"08d4bd15350cd77e3cee7e965c2a88a3cef6e7d0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -393,14 +393,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba
     body:
       encoding: US-ASCII
       string: ''
@@ -419,9 +419,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d5804cc35a3deb66abfb966891dd70a34285d58"'
+      - '"bb376c67b5d816a6981bc06f5b0d80c1ee3d63f2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -455,18 +455,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#item1>
-        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#item1>
+        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#default>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://some.external.ref/default>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab
     body:
       encoding: US-ASCII
       string: ''
@@ -485,9 +485,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8eb8771ea56b8fdf4033a3467e4259bfc788b952"'
+      - '"f77f59125d6974acabe8ca9a30fbdf0b2b890ea0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -521,18 +521,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0
     body:
       encoding: US-ASCII
       string: ''
@@ -551,9 +551,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"96e35b101a3abd27fa56f88c562efc1c285458ac"'
+      - '"08d4bd15350cd77e3cee7e965c2a88a3cef6e7d0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -587,14 +587,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/b/5e/0a/0c/2c/5e0a0c2c-aee7-4fb4-88b9-fe6436670a4b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/b/98/92/d8/e1/9892d8e1-ebd7-4f99-9453-6fa7d49415d0>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba
     body:
       encoding: US-ASCII
       string: ''
@@ -613,9 +613,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0d5804cc35a3deb66abfb966891dd70a34285d58"'
+      - '"bb376c67b5d816a6981bc06f5b0d80c1ee3d63f2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -649,13 +649,13 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#item1>
-        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/8f/5e/e0/2c/8f5ee02c-4066-430c-97b6-3568c49a7f28/t/a5/58/e5/51/a558e551-7373-4893-bf8b-e55ad70716cb#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#item1>
+        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/e3/e5/54/2d/e3e5542d-cdc6-4582-acfe-cc6b55af42ab/t/08/2f/56/17/082f5617-dbe8-4b47-8881-29174e03ffba#default>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://some.external.ref/default>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a2be82d021aecbd6502c4cbd60b50f6d2e5a6c0a"'
+      - '"93e010162e7d3d1ef9f03fa27957248c341882a7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d777661b1dce322de8aacfeae49d726cb1a2408b"'
+      - '"cf9836c3ef091d85446058c6e5f743c21e5543f5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"caba8f81775f36b5855c92845d09c7dbf7d3eb28"'
+      - '"c2cbc360ba7d4bbc4743410783653a251afd1efb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:41 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:41 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"99702defeee374c51e256df525c65cd682d2500d"'
+      - '"bdfd998565355763e9d777a21ba43e00d447a811"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d052d9c08936bdcef3d22aed322daaba05278b55"'
+      - '"88b2e34366c04ded67ef356f10e2d58466bbafd7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t
     body:
       encoding: UTF-8
       string: |
@@ -261,23 +261,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1daaf9bb9235ac62801504970e57f1af5f52510d"'
+      - '"06dfcb0db88b52844ddcce6d5835b40f5bb11a5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
     body:
       encoding: US-ASCII
       string: ''
@@ -296,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"20a31e52c97d114ca57366b3b994b762fbe62409"'
+      - '"2e4e0b680b30ed0d95e1764a5711df9064677633"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -332,18 +332,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca
     body:
       encoding: US-ASCII
       string: ''
@@ -362,9 +362,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"99702defeee374c51e256df525c65cd682d2500d"'
+      - '"bdfd998565355763e9d777a21ba43e00d447a811"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -398,14 +398,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e
     body:
       encoding: US-ASCII
       string: ''
@@ -424,9 +424,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1daaf9bb9235ac62801504970e57f1af5f52510d"'
+      - '"06dfcb0db88b52844ddcce6d5835b40f5bb11a5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -460,22 +460,22 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item2>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item2>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#default>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/small>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item1>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item2>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item1>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398
     body:
       encoding: US-ASCII
       string: ''
@@ -494,9 +494,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"20a31e52c97d114ca57366b3b994b762fbe62409"'
+      - '"2e4e0b680b30ed0d95e1764a5711df9064677633"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -530,18 +530,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca
     body:
       encoding: US-ASCII
       string: ''
@@ -560,9 +560,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"99702defeee374c51e256df525c65cd682d2500d"'
+      - '"bdfd998565355763e9d777a21ba43e00d447a811"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -596,14 +596,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/b/48/c4/61/41/48c46141-5e57-4e78-a0c3-d8d88664bc9a>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/b/fe/fd/ba/e3/fefdbae3-d7d3-4c90-a9b4-96ae5efd87ca>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e
     body:
       encoding: US-ASCII
       string: ''
@@ -622,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1daaf9bb9235ac62801504970e57f1af5f52510d"'
+      - '"06dfcb0db88b52844ddcce6d5835b40f5bb11a5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:43 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -658,17 +658,17 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item2>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#default>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item2>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#default>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/small>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item1>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/31/11/59/79/31115979-a56d-44cf-b1d3-2ffdd9faa2a9/t/88/94/31/51/88943151-5047-4b17-94c1-09c4fd4bbedd#item2>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item2>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/77/2f/1b/5d/772f1b5d-2ec3-4744-9ece-eedd6d733398/t/81/5a/f6/4c/815af64c-00fe-4767-a064-3f4140e2623e#item1>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:43 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/after_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       message: Gone
     headers:
       Link:
-      - <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/fcr:tombstone>;
+      - <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/fcr:tombstone>;
         rel="hasTombstone"
       Content-Type:
       - text/html;charset=ISO-8859-1
@@ -29,10 +29,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     body:
       encoding: US-ASCII
       string: ''
@@ -47,9 +47,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2852941cf098f6236bb78ac7956af13eab43da67"'
+      - '"3dfe7322c960ffa43b56882765a4809a552f255d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -68,10 +68,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     body:
       encoding: US-ASCII
       string: ''
@@ -93,10 +93,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -116,10 +116,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     body:
       encoding: US-ASCII
       string: ''
@@ -134,9 +134,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6711a4dda921829b205129df298266f947ae646"'
+      - '"d176b14e1ae392651b0cdb20ce2abae24f6785b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -155,10 +155,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     body:
       encoding: US-ASCII
       string: ''
@@ -180,10 +180,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -203,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -221,9 +221,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"aaf921362fa89b87d7d511c49d8b07f73dc693e2"'
+      - '"acb46e30b9f1ddc7f96510109bde6c8abaa3fe48"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -242,7 +242,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -267,7 +267,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/fcr:tombstone
@@ -290,13 +290,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -312,15 +312,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>7}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -336,9 +336,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -360,7 +360,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>26}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>23}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0e6efed4ef789a531905e596d401a66dbb6bb752"'
+      - '"e4daa48e4e0cab0924151d26d8423e77d3952bb4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8538b30a5310e107d88021a68ad14024d7b26708"'
+      - '"d4214b5096ec59b6655700d50b862c343c96f3a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '61'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/solr_integration_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8538b30a5310e107d88021a68ad14024d7b26708"'
+      - '"d4214b5096ec59b6655700d50b862c343c96f3a4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b96c549979188a416f6ec1f29ab194e7c7187f0c"'
+      - '"b9048d5012435935a892d44f6ebe32f04bf2b392"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d799ee97d1a614bffb1d04beb1fbbd96b7d906d8"'
+      - '"e085b6b62ddd002f8c8ee73fd74377214490a3bd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"feb45e4f0d77f56c3a7ea3f6b724cad1ca16e03c"'
+      - '"e9419959056559a3be72440e61cf491101974a60"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b/18/da/a4/a6/18daa4a6-6a1c-43fc-a34e-4bb5a72c5e93
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b/76/22/7b/63/76227b63-a51a-4e53-af07-fdb977dd39a0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b/18/da/a4/a6/18daa4a6-6a1c-43fc-a34e-4bb5a72c5e93
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b/76/22/7b/63/76227b63-a51a-4e53-af07-fdb977dd39a0
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5becc78226b13d8b7c769b9f482225aef6be1678"'
+      - '"a9bf4c83c2d78bbfeeed733b322baf4380a021e8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8de12c4ba4e1d675187fd92fd2331ce3c29c40e9"'
+      - '"d67f7b1c89500d8547f1c1ec2f7666c51c69c292"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t/ed/cb/0e/61/edcb0e61-287d-448c-852d-5e362c49d63b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t/9e/7b/a8/0c/9e7ba80c-134d-445e-9991-6d2167c8d9a3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t/ed/cb/0e/61/edcb0e61-287d-448c-852d-5e362c49d63b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t/9e/7b/a8/0c/9e7ba80c-134d-445e-9991-6d2167c8d9a3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ed662743b2c69596e40ece18f114ff4177ad202c"'
+      - '"7ab7f008eb5b3d1b1f2f21c3eb949de326b55417"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t/ed/cb/0e/61/edcb0e61-287d-448c-852d-5e362c49d63b>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b/18/da/a4/a6/18daa4a6-6a1c-43fc-a34e-4bb5a72c5e93>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b/76/22/7b/63/76227b63-a51a-4e53-af07-fdb977dd39a0>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t/9e/7b/a8/0c/9e7ba80c-134d-445e-9991-6d2167c8d9a3>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b/18/da/a4/a6/18daa4a6-6a1c-43fc-a34e-4bb5a72c5e93
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b/76/22/7b/63/76227b63-a51a-4e53-af07-fdb977dd39a0
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"feb45e4f0d77f56c3a7ea3f6b724cad1ca16e03c"'
+      - '"e9419959056559a3be72440e61cf491101974a60"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/b/18/da/a4/a6/18daa4a6-6a1c-43fc-a34e-4bb5a72c5e93>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/b/76/22/7b/63/76227b63-a51a-4e53-af07-fdb977dd39a0>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t/ed/cb/0e/61/edcb0e61-287d-448c-852d-5e362c49d63b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t/9e/7b/a8/0c/9e7ba80c-134d-445e-9991-6d2167c8d9a3
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8de12c4ba4e1d675187fd92fd2331ce3c29c40e9"'
+      - '"d67f7b1c89500d8547f1c1ec2f7666c51c69c292"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f/t/ed/cb/0e/61/edcb0e61-287d-448c-852d-5e362c49d63b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7/t/9e/7b/a8/0c/9e7ba80c-134d-445e-9991-6d2167c8d9a3>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f</field><field
+        name="id">solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430814380","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f","@type":"oa:Annotation","hasBody":"_:g70318430814380","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312790178980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7","@type":"oa:Annotation","hasBody":"_:g70312790178980","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,12 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:50 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:50 GMT
+      - Wed, 08 Jul 2015 18:54:48 GMT
       Etag:
-      - '"YTAwMDAwMDAwMDAwMDAwU29scg=="'
+      - '"MmEwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -511,28 +511,28 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>8,
+            'QTime'=>17,
             'params'=>{
-              'id'=>'solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f',
+              'id'=>'solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f',
+                'id'=>'solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430814380","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f","@type":"oa:Annotation","hasBody":"_:g70318430814380","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1505081164072747008,
-                'timestamp'=>'2015-06-26T22:20:50.282Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312790178980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7","@type":"oa:Annotation","hasBody":"_:g70312790178980","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506155364838539264,
+                'timestamp'=>'2015-07-08T18:54:47.964Z'}]
           }}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:51 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:49 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7
     body:
       encoding: US-ASCII
       string: ''
@@ -554,13 +554,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:51 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:49 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -576,9 +576,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>16}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:51 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:49 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -600,12 +600,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>15}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>33}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:51 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:51 GMT
+      - Wed, 08 Jul 2015 18:54:49 GMT
       Etag:
-      - '"NGEwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"NmEwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -629,12 +629,12 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>2,
+            'QTime'=>1,
             'params'=>{
-              'id'=>'solr_integration_specs/36/56/38/ec/365638ec-1578-49b1-9a20-2a0044b08d4f',
+              'id'=>'solr_integration_specs/da/12/13/f8/da1213f8-87b7-48b7-bb6b-497ae081fec7',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]
           }}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"070fd7cca79ba8f7523b8b01267f53899600f6ad"'
+      - '"ba3db50ebcfa23c14574bad0a1b5c24298d46ea8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a4b9536993c7c58eed09d7d4db8788cec4791f5f"'
+      - '"eb5df505308ec0e3f343b2d8bc8f7946866d9e8d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"724ee5f319510f67e3619875711663872e1864a3"'
+      - '"2bb7a438b1175221722c3e922560c6e03f49b1bb"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"77a47454fd4ee0f0282e3d906398c345ea7c41c0"'
+      - '"d360506db39acb6c3cd175cb17f1aa9cdcba115d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b/10/1b/85/94/101b8594-839a-4bad-ba2c-2314e0f4f8f9
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b/9a/0d/2c/b4/9a0d2cb4-1fc5-44b4-9a5a-2149f9fb00d9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b/10/1b/85/94/101b8594-839a-4bad-ba2c-2314e0f4f8f9
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b/9a/0d/2c/b4/9a0d2cb4-1fc5-44b4-9a5a-2149f9fb00d9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"07346c68fb282ace65967f4633c0eefdc08685e6"'
+      - '"d929c5d90b6750869c33557a8a8585ec50888680"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6901412e6efb0550a8e7274e7e2d8f80d5ebcf98"'
+      - '"84b52546a453432cd67284547c8dc31e9028a8b9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t/f6/ee/a6/b4/f6eea6b4-142b-4250-8092-981caa42c02d
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t/b0/3c/e0/51/b03ce051-5108-424a-bfd7-87778d8446d4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t/f6/ee/a6/b4/f6eea6b4-142b-4250-8092-981caa42c02d
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t/b0/3c/e0/51/b03ce051-5108-424a-bfd7-87778d8446d4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2852941cf098f6236bb78ac7956af13eab43da67"'
+      - '"3dfe7322c960ffa43b56882765a4809a552f255d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b/10/1b/85/94/101b8594-839a-4bad-ba2c-2314e0f4f8f9>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t/f6/ee/a6/b4/f6eea6b4-142b-4250-8092-981caa42c02d>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t/b0/3c/e0/51/b03ce051-5108-424a-bfd7-87778d8446d4>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b/9a/0d/2c/b4/9a0d2cb4-1fc5-44b4-9a5a-2149f9fb00d9>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b/10/1b/85/94/101b8594-839a-4bad-ba2c-2314e0f4f8f9
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b/9a/0d/2c/b4/9a0d2cb4-1fc5-44b4-9a5a-2149f9fb00d9
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"77a47454fd4ee0f0282e3d906398c345ea7c41c0"'
+      - '"d360506db39acb6c3cd175cb17f1aa9cdcba115d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/b/10/1b/85/94/101b8594-839a-4bad-ba2c-2314e0f4f8f9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/b/9a/0d/2c/b4/9a0d2cb4-1fc5-44b4-9a5a-2149f9fb00d9>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t/f6/ee/a6/b4/f6eea6b4-142b-4250-8092-981caa42c02d
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t/b0/3c/e0/51/b03ce051-5108-424a-bfd7-87778d8446d4
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6901412e6efb0550a8e7274e7e2d8f80d5ebcf98"'
+      - '"84b52546a453432cd67284547c8dc31e9028a8b9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2/t/f6/ee/a6/b4/f6eea6b4-142b-4250-8092-981caa42c02d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307/t/b0/3c/e0/51/b03ce051-5108-424a-bfd7-87778d8446d4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2</field><field
+        name="id">solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318391444320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2","@type":"oa:Annotation","hasBody":"_:g70318391444320","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312793736160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307","@type":"oa:Annotation","hasBody":"_:g70312793736160","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,10 +484,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:54 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:52 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Etag:
-      - '"MmEwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MWEwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -513,21 +513,21 @@ http_interactions:
             'status'=>0,
             'QTime'=>1,
             'params'=>{
-              'id'=>'solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2',
+              'id'=>'solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2',
+                'id'=>'solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318391444320","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a4/b5/b7/c0/a4b5b7c0-47db-4804-bc56-19e0dd7887f2","@type":"oa:Annotation","hasBody":"_:g70318391444320","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1505081168699064320,
-                'timestamp'=>'2015-06-26T22:20:54.694Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312793736160","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/7b/e2/63/9f/7be2639f-bcb0-43bd-84f9-a3bc39798307","@type":"oa:Annotation","hasBody":"_:g70312793736160","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506155369460662272,
+                'timestamp'=>'2015-07-08T18:54:52.371Z'}]
           }}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7bf263c37b1e0329eebeaac8110d8f07e92d4a8c"'
+      - '"a6e02d78cd337c0ed2132642f3f3f299e32af28b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:54 GMT
+      - Wed, 08 Jul 2015 18:54:52 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c4cc149a53b1830fde461c8ca0b047ca366ce86f"'
+      - '"0c028cb98d9037778827c7f76c703824c752346d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5befe96d8ad2d0d5b7621a45fc5cf7b96a5bf142"'
+      - '"8535e23cc0c1bbafbff3e421b51844362e68ec80"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f0a951f2df18ecb9e635de6e42c56a814dae7864"'
+      - '"89650abc5f598d500ec4fe58b6f1a913dc001e0a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b/d5/50/12/01/d5501201-0d24-48dd-93aa-c612b400a9ad
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b/f8/99/38/fa/f89938fa-bc37-4c26-9f0a-f5ab6b67d099
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b/d5/50/12/01/d5501201-0d24-48dd-93aa-c612b400a9ad
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b/f8/99/38/fa/f89938fa-bc37-4c26-9f0a-f5ab6b67d099
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e6cb60e409b91ca5145cf29dbbf726b51678e4c7"'
+      - '"b59927f039515df54a129c6a06c6c6a3e41bc78c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"43472daa573211a321df45274ae728fa978aea60"'
+      - '"f9ce6cd8b7e96b545c9940ba532ad0e58baf45f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t/a0/70/cd/d6/a070cdd6-dd18-40fc-a5ab-306972946612
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t/b9/1b/6d/cc/b91b6dcc-add0-44d5-9755-9ddd00204f94
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t/a0/70/cd/d6/a070cdd6-dd18-40fc-a5ab-306972946612
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t/b9/1b/6d/cc/b91b6dcc-add0-44d5-9755-9ddd00204f94
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6711a4dda921829b205129df298266f947ae646"'
+      - '"d176b14e1ae392651b0cdb20ce2abae24f6785b2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b/d5/50/12/01/d5501201-0d24-48dd-93aa-c612b400a9ad>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t/a0/70/cd/d6/a070cdd6-dd18-40fc-a5ab-306972946612>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b/f8/99/38/fa/f89938fa-bc37-4c26-9f0a-f5ab6b67d099>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t/b9/1b/6d/cc/b91b6dcc-add0-44d5-9755-9ddd00204f94>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b/d5/50/12/01/d5501201-0d24-48dd-93aa-c612b400a9ad
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b/f8/99/38/fa/f89938fa-bc37-4c26-9f0a-f5ab6b67d099
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f0a951f2df18ecb9e635de6e42c56a814dae7864"'
+      - '"89650abc5f598d500ec4fe58b6f1a913dc001e0a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/b/d5/50/12/01/d5501201-0d24-48dd-93aa-c612b400a9ad>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/b/f8/99/38/fa/f89938fa-bc37-4c26-9f0a-f5ab6b67d099>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:55 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t/a0/70/cd/d6/a070cdd6-dd18-40fc-a5ab-306972946612
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t/b9/1b/6d/cc/b91b6dcc-add0-44d5-9755-9ddd00204f94
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"43472daa573211a321df45274ae728fa978aea60"'
+      - '"f9ce6cd8b7e96b545c9940ba532ad0e58baf45f4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:55 GMT
+      - Wed, 08 Jul 2015 18:54:53 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,23 +450,23 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe/t/a0/70/cd/d6/a070cdd6-dd18-40fc-a5ab-306972946612>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626/t/b9/1b/6d/cc/b91b6dcc-add0-44d5-9755-9ddd00204f94>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:56 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe</field><field
+        name="id">solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430121620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe","@type":"oa:Annotation","hasBody":"_:g70318430121620","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312797901580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626","@type":"oa:Annotation","hasBody":"_:g70312797901580","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -484,10 +484,10 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:56 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:53 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:56 GMT
+      - Wed, 08 Jul 2015 18:54:54 GMT
       Etag:
-      - '"NmEwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"NWEwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -511,23 +511,23 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>2,
+            'QTime'=>1,
             'params'=>{
-              'id'=>'solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe',
+              'id'=>'solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe',
+                'id'=>'solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70318430121620","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/e2/47/22/e1/e24722e1-3268-43da-b5a8-e8ee532adcbe","@type":"oa:Annotation","hasBody":"_:g70318430121620","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1505081170162876416,
-                'timestamp'=>'2015-06-26T22:20:56.091Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70312797901580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/2a/41/82/0d/2a41820d-6271-4292-93d0-9e66b028d626","@type":"oa:Annotation","hasBody":"_:g70312797901580","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506155370867851264,
+                'timestamp'=>'2015-07-08T18:54:53.713Z'}]
           }}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:54 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9bbc3cc941b6075c7932539cea5618acc8f6daa4"'
+      - '"cc44e232ffda2f63f8d9c832d42d6fa84e2bef0b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:01 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:01 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"27d4d1238ec5850672464ea3e07e952fe0d6ad75"'
+      - '"b91ccbf59e91c7b804332515b4eac35170b29f60"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:54 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d220dbd083b37ab3ee9e9aac33e74f94152254d2"'
+      - '"5ff686f9e5766fc73dabae155bfdfabd61a2cb23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '69'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b21e9435476efc584393ecfd125e4460c84fca33"'
+      - '"2d538f7a09c6ae9ff93ebfca199271d3fa24ed8d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"04a4affcdbcf4f08b8e4a2b641219d75a3a61bdf"'
+      - '"c168a4917f696740093cfa703e819c67021f89a1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"df5bda63ec416dc9ed2723a890340dbb4388379b"'
+      - '"011969f06f063d987cb09dd70ccd471bdfeb33a8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b
     body:
       encoding: UTF-8
       string: |
@@ -169,23 +169,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"078673107d9e2a9275ff449995ce4d9b14a6c297"'
+      - '"5da1f514f9462db911e96a0b8611e6b5097717c0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
     body:
       encoding: UTF-8
       string: |
@@ -195,7 +195,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -215,23 +215,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"df4850e07541875630a6616c0a86a8e51f64e99c"'
+      - '"8224843e11f86382f7bb5ea449b53954298aaa94"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"578e6fc4b834680e5a862a1514173dccb1445d6f"'
+      - '"33afe0bf7b2a689cf4497e630b2d286e484ee638"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4fd08ab8be430341c18a692ab21b16fee6798a43"'
+      - '"af7551aeb398d8f7258e8f8830281c8bfe12516e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -329,18 +329,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"078673107d9e2a9275ff449995ce4d9b14a6c297"'
+      - '"5da1f514f9462db911e96a0b8611e6b5097717c0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -395,19 +395,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/c3/ca/e4/37/c3cae437-6635-4c43-877f-439f558eaa48>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/2e/6c/6d/aa/2e6c6daa-866f-4cbf-89bf-d5dea301b1d1>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/c3/ca/e4/37/c3cae437-6635-4c43-877f-439f558eaa48>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/2e/6c/6d/aa/2e6c6daa-866f-4cbf-89bf-d5dea301b1d1>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"578e6fc4b834680e5a862a1514173dccb1445d6f"'
+      - '"33afe0bf7b2a689cf4497e630b2d286e484ee638"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -462,14 +462,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4fd08ab8be430341c18a692ab21b16fee6798a43"'
+      - '"af7551aeb398d8f7258e8f8830281c8bfe12516e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -524,18 +524,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"078673107d9e2a9275ff449995ce4d9b14a6c297"'
+      - '"5da1f514f9462db911e96a0b8611e6b5097717c0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -590,19 +590,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/c3/ca/e4/37/c3cae437-6635-4c43-877f-439f558eaa48>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/b/d0/3a/1d/29/d03a1d29-a93a-439e-8ad5-5e73723585b5#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/2e/6c/6d/aa/2e6c6daa-866f-4cbf-89bf-d5dea301b1d1>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/b/75/87/89/64/75878964-2d28-4f99-a937-054ed200e08c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/c3/ca/e4/37/c3cae437-6635-4c43-877f-439f558eaa48>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/2e/6c/6d/aa/2e6c6daa-866f-4cbf-89bf-d5dea301b1d1>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843
     body:
       encoding: US-ASCII
       string: ''
@@ -621,9 +621,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"578e6fc4b834680e5a862a1514173dccb1445d6f"'
+      - '"33afe0bf7b2a689cf4497e630b2d286e484ee638"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -657,9 +657,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9d/ca/89/5f/9dca895f-87e5-4bdb-a69a-f388b8be7fef/t/d3/0c/ea/3b/d30cea3b-5c02-41b7-b9e9-be27d6a2d44f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fe/ff/8f/22/feff8f22-f32d-49a8-a936-15864ad13722/t/d2/8c/5e/3f/d28c5e3f-ba18-4a2d-a2d5-ca15d416f843>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"66f8d927de24a1a37eca6ab14337b009ffd0c10c"'
+      - '"82afe79e58afde499c12c3947994f7987a0f7e6d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"705aec95f936a0d65cbb62b72b07905ed884b4fb"'
+      - '"df27dc2d779f6ccb6813af43ad68cc1ace8d18c0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5a440c37b5cebc4309fc45f7edc8746c4f766456"'
+      - '"e538cb05eaf15b5f3ce341c6d573c5123efdc838"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b
     body:
       encoding: UTF-8
       string: |
@@ -168,23 +168,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"57978e18cd264285f50093246ade4f1ebdc7a289"'
+      - '"48e5fc0eb5b04aeb3dd79a25b941f287c4adbfb9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
     body:
       encoding: UTF-8
       string: |
@@ -194,7 +194,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -214,23 +214,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"456fd4eaa35d082e097e9a2a719876f630af4e7e"'
+      - '"16d9c7733c9d089e97db0c71a17128efcb906f81"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t
     body:
       encoding: UTF-8
       string: |
@@ -257,23 +257,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a6cdc19aba77f02a91e61bf6a454dca8de1690ba"'
+      - '"11b911c9e8768b001ac73a1aa29cda25bcd05a41"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
     body:
       encoding: US-ASCII
       string: ''
@@ -292,9 +292,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2af4911a9667cc700465a33ec022bbbc18eb84f"'
+      - '"3d0deb8613c220e353811da71aeeb48d42805271"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -328,18 +328,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6
     body:
       encoding: US-ASCII
       string: ''
@@ -358,9 +358,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"57978e18cd264285f50093246ade4f1ebdc7a289"'
+      - '"48e5fc0eb5b04aeb3dd79a25b941f287c4adbfb9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -394,20 +394,20 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/23/69/f1/0a/2369f10a-bf1b-4f27-be33-538b17596a45>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/64/d1/33/f9/64d133f9-abea-4441-8590-b6467cd41876>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/23/69/f1/0a/2369f10a-bf1b-4f27-be33-538b17596a45>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/64/d1/33/f9/64d133f9-abea-4441-8590-b6467cd41876>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a6cdc19aba77f02a91e61bf6a454dca8de1690ba"'
+      - '"11b911c9e8768b001ac73a1aa29cda25bcd05a41"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -462,14 +462,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2af4911a9667cc700465a33ec022bbbc18eb84f"'
+      - '"3d0deb8613c220e353811da71aeeb48d42805271"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -524,18 +524,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"57978e18cd264285f50093246ade4f1ebdc7a289"'
+      - '"48e5fc0eb5b04aeb3dd79a25b941f287c4adbfb9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -590,20 +590,20 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/23/69/f1/0a/2369f10a-bf1b-4f27-be33-538b17596a45>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/b/d7/7c/ee/e9/d77ceee9-5f28-481e-812b-50fcd53d74ff#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/64/d1/33/f9/64d133f9-abea-4441-8590-b6467cd41876>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/b/1d/49/2a/90/1d492a90-31e9-4b09-ac26-c451f35850b6#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/23/69/f1/0a/2369f10a-bf1b-4f27-be33-538b17596a45>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/64/d1/33/f9/64d133f9-abea-4441-8590-b6467cd41876>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8
     body:
       encoding: US-ASCII
       string: ''
@@ -622,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a6cdc19aba77f02a91e61bf6a454dca8de1690ba"'
+      - '"11b911c9e8768b001ac73a1aa29cda25bcd05a41"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -658,9 +658,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/06/db/9d/eb/06db9deb-a1c6-41ca-912d-e329cfb9e47f/t/61/29/46/45/61294645-44a7-408f-bb96-a6954c305a80>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1a/92/c2/1e/1a92c21e-2c30-445a-9426-fd90275d7ffc/t/ae/e1/0f/81/aee10f81-829a-4bb7-ba81-861a048df4e8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ab4e3f79b0fe5a81c9530b34294607a960c487f8"'
+      - '"b91bb7684d4b78008d5af1a2c9a02303c780b8a5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"768a1ee5bb2d3b6485023ed2de5d4668f0d55d6d"'
+      - '"d2895f39698b87c672bd5c92b927cb6714f7475b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8ae8f6e56ff5149a0e23e6c1cfe13b625c119278"'
+      - '"983d01fa0a276603053792986aaaf26e89e5d40d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b
     body:
       encoding: UTF-8
       string: |
@@ -169,23 +169,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1d400ab5582f9d8ff652107beb1e7ad4fcb3890a"'
+      - '"3314eff1fdf4098b8e3354aafad57970d963d8e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
     body:
       encoding: UTF-8
       string: |
@@ -195,7 +195,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -215,23 +215,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1830441dd80f11579b1facbf046137059e4b7c5c"'
+      - '"63770c6c44dc4a511d3b11499fd3c455bece98da"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e3c0c0d04447285f3eeaaf2c447a8d2379ab0fbb"'
+      - '"98d468185b245b0df09395959f004aac8e4a31ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd5c0ecf4c03241d42bce69d2876db29f49cf517"'
+      - '"81dd7b7cbeb999a257632a8afa28e330132c4fc6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -329,18 +329,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d400ab5582f9d8ff652107beb1e7ad4fcb3890a"'
+      - '"3314eff1fdf4098b8e3354aafad57970d963d8e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -395,21 +395,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/72/0d/7c/1d/720d7c1d-c9d2-410d-bc66-2bfe66c75dd2>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/83/4b/1c/4e/834b1c4e-77f4-4c87-8078-dd96986814ec>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/0d/7c/1d/720d7c1d-c9d2-410d-bc66-2bfe66c75dd2>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/83/4b/1c/4e/834b1c4e-77f4-4c87-8078-dd96986814ec>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c
     body:
       encoding: US-ASCII
       string: ''
@@ -428,9 +428,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e3c0c0d04447285f3eeaaf2c447a8d2379ab0fbb"'
+      - '"98d468185b245b0df09395959f004aac8e4a31ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -464,14 +464,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd5c0ecf4c03241d42bce69d2876db29f49cf517"'
+      - '"81dd7b7cbeb999a257632a8afa28e330132c4fc6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -526,18 +526,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d400ab5582f9d8ff652107beb1e7ad4fcb3890a"'
+      - '"3314eff1fdf4098b8e3354aafad57970d963d8e9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -592,21 +592,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/72/0d/7c/1d/720d7c1d-c9d2-410d-bc66-2bfe66c75dd2>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/b/7a/a3/d6/ea/7aa3d6ea-3c64-404b-a880-ae18169e39ab#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/83/4b/1c/4e/834b1c4e-77f4-4c87-8078-dd96986814ec>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/b/6b/69/d2/14/6b69d214-2518-435e-8d45-571780c4af56#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/72/0d/7c/1d/720d7c1d-c9d2-410d-bc66-2bfe66c75dd2>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/83/4b/1c/4e/834b1c4e-77f4-4c87-8078-dd96986814ec>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c
     body:
       encoding: US-ASCII
       string: ''
@@ -625,9 +625,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e3c0c0d04447285f3eeaaf2c447a8d2379ab0fbb"'
+      - '"98d468185b245b0df09395959f004aac8e4a31ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -661,9 +661,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/89/01/12/cc/890112cc-1d4a-451b-9855-bda66d5bb39e/t/ab/e2/5a/95/abe25a95-9a73-4858-92cf-74dffcc2d1f2>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5c/fa/b3/ab/5cfab3ab-e678-4f66-ac2b-e917221cec99/t/ae/84/5c/5c/ae845c5c-c62d-472e-a9d4-ac7e796ab10c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b013e30a815bb49b1a2c3138f92c82265293b46"'
+      - '"5ae4d47e0ab32c1983b568cd5293841d1a033fab"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e3e4356e6470a5acf846ed467964d29a417948af"'
+      - '"da36c639a645f0a1134884b5cae4e4165638f943"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b925b5dd1c291dbd74c60f317ff517d0fbdbf3bd"'
+      - '"7db6bc1aa62b228a4fe96268c9fc2d97094cac3d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ad26b89298e625b6df913324ec51ff3c2db39322"'
+      - '"3c474c9abeee5f255ded9aa21127ab02140cc58e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7ddd1e48a72c87664887097b72ba1174d79193db"'
+      - '"4c3a0a9227755237f18a1bd7786f2b20035a5687"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t
     body:
       encoding: UTF-8
       string: |
@@ -260,23 +260,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ce35b9d5986c54de5ede8344280ed8eab7b3dda5"'
+      - '"10011722b4912d2dcaa41efc301c468eedfeb36f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
     body:
       encoding: US-ASCII
       string: ''
@@ -295,9 +295,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0894a0e7ea46727514c7c85bd1789cf658b68937"'
+      - '"e6111858229d20741d0563cb7757c918d455127a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -331,18 +331,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8
     body:
       encoding: US-ASCII
       string: ''
@@ -361,9 +361,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ad26b89298e625b6df913324ec51ff3c2db39322"'
+      - '"3c474c9abeee5f255ded9aa21127ab02140cc58e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -397,14 +397,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974
     body:
       encoding: US-ASCII
       string: ''
@@ -423,9 +423,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ce35b9d5986c54de5ede8344280ed8eab7b3dda5"'
+      - '"10011722b4912d2dcaa41efc301c468eedfeb36f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -459,19 +459,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/46/74/de/77/4674de77-e342-4933-943b-9a63c6d81625>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0f/2e/18/03/0f2e1803-9763-41b1-83a4-f1f20e204623>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974#source>
         a dcmitype:Image ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/46/74/de/77/4674de77-e342-4933-943b-9a63c6d81625>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0f/2e/18/03/0f2e1803-9763-41b1-83a4-f1f20e204623>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0894a0e7ea46727514c7c85bd1789cf658b68937"'
+      - '"e6111858229d20741d0563cb7757c918d455127a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -526,18 +526,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ad26b89298e625b6df913324ec51ff3c2db39322"'
+      - '"3c474c9abeee5f255ded9aa21127ab02140cc58e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -592,14 +592,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/b/2f/1f/83/fc/2f1f83fc-c773-49bd-b788-e6bbd6427068>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/b/10/32/75/29/10327529-2e95-4163-b05d-e34716119aa8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974
     body:
       encoding: US-ASCII
       string: ''
@@ -618,9 +618,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ce35b9d5986c54de5ede8344280ed8eab7b3dda5"'
+      - '"10011722b4912d2dcaa41efc301c468eedfeb36f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:21:00 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -654,14 +654,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/46/74/de/77/4674de77-e342-4933-943b-9a63c6d81625>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/1b/d5/95/65/1bd59565-c819-4b54-a703-0a5366730244/t/74/bc/0c/69/74bc0c69-faf3-43de-a384-0ae173aa38b7#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0f/2e/18/03/0f2e1803-9763-41b1-83a4-f1f20e204623>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/3e/ea/ac/4f/3eeaac4f-cc46-4432-88f4-348892a7feab/t/a8/88/7f/8d/a8887f8d-56ec-4ceb-9a2b-eb3824f99974#source>
         a dcmitype:Image ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/46/74/de/77/4674de77-e342-4933-943b-9a63c6d81625>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0f/2e/18/03/0f2e1803-9763-41b1-83a4-f1f20e204623>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:21:00 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d220dbd083b37ab3ee9e9aac33e74f94152254d2"'
+      - '"5ff686f9e5766fc73dabae155bfdfabd61a2cb23"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ea808d8f0c5116f02452c12db35dd04f24f609fd"'
+      - '"cd99d499bfc2d5dad317abc48c1b3f038b36ff8a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1351f344dd5c48aea39cdd10305e47fd42099758"'
+      - '"35e0e0020617b7f06ad29b74d30b570b56064fd8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c80d8f700d09b78ab5ebc177f844c027602ccd72"'
+      - '"20ad47bd41722de48a455cc322ec0261b73f4244"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0b28ef9d57b4339ffacfc6ddca8bc745995aabe0"'
+      - '"66f1413708f616ed2d828afc94e5e06c3cb3c479"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"35d18c9c0874a735ed6c0f77841502f5992b8edb"'
+      - '"8650380ad5ecc39c22f248d66cdccc8c52c3c890"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2d17d80fbb2fd1f20e2576c8d496915542a807e"'
+      - '"441d54c8a2924993a4790580c8e7c1204a6dee83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -329,18 +329,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c80d8f700d09b78ab5ebc177f844c027602ccd72"'
+      - '"20ad47bd41722de48a455cc322ec0261b73f4244"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -395,14 +395,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583
     body:
       encoding: US-ASCII
       string: ''
@@ -421,9 +421,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"35d18c9c0874a735ed6c0f77841502f5992b8edb"'
+      - '"8650380ad5ecc39c22f248d66cdccc8c52c3c890"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -457,19 +457,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/84/7e/db/ed/847edbed-8255-4965-b2c8-84f0da562e41>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/07/a3/24/ef/07a324ef-72fd-4555-b251-781b63c40239>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/84/7e/db/ed/847edbed-8255-4965-b2c8-84f0da562e41>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/07/a3/24/ef/07a324ef-72fd-4555-b251-781b63c40239>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2d17d80fbb2fd1f20e2576c8d496915542a807e"'
+      - '"441d54c8a2924993a4790580c8e7c1204a6dee83"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -524,18 +524,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c80d8f700d09b78ab5ebc177f844c027602ccd72"'
+      - '"20ad47bd41722de48a455cc322ec0261b73f4244"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -590,14 +590,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/b/1e/fb/56/8b/1efb568b-c5e2-412d-b9d0-d7a29f0974f7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/b/aa/da/81/9c/aada819c-8d57-4681-b1f3-aa26b59b9ed9>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"35d18c9c0874a735ed6c0f77841502f5992b8edb"'
+      - '"8650380ad5ecc39c22f248d66cdccc8c52c3c890"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -652,14 +652,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/84/7e/db/ed/847edbed-8255-4965-b2c8-84f0da562e41>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/7c/1c/9c/be/7c1c9cbe-5bf5-48e2-a7b2-28b019c6c33b/t/b2/a4/95/8b/b2a4958b-48dc-4369-8f29-446e2838857f#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/07/a3/24/ef/07a324ef-72fd-4555-b251-781b63c40239>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5a/53/cb/fb/5a53cbfb-a350-4ad7-bab5-42ea888cc6df/t/88/af/51/37/88af5137-c4ad-4f38-a00e-09d078567583#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/84/7e/db/ed/847edbed-8255-4965-b2c8-84f0da562e41>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/07/a3/24/ef/07a324ef-72fd-4555-b251-781b63c40239>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:57 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f9b9376254f81722b7ef32a5709f71c054bdfb63"'
+      - '"1faa1badc5ea5ba8575d3123a3d0a3718b7df46e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:57 GMT
+      - Wed, 08 Jul 2015 18:54:55 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d8f242c187482e43e75d0d659e703a73d51cc165"'
+      - '"213a1e0bc6c362d268bc844c7336534f6334e3be"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8f91ff1acf8912ee5ac3d9a1c45e0d2e3036a73f"'
+      - '"3b8d70cd88e177e53a4e9547cd4b8f4899d5d778"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f5fd93cabf4a0d7bdbeca9a97e5718c393240800"'
+      - '"a59867a566790f6892d1e8d3a575ab17c86196e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c90807350328275e718844ceb613875fe59af3ea"'
+      - '"6164a30dd5454c0b4832ebceb15495c2f9db850c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t
     body:
       encoding: UTF-8
       string: |
@@ -257,23 +257,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ecf6f813fac733e80cc4b55913877f6ec8050a42"'
+      - '"86281dfc87e175a6ddcdb971a47bfa56ee8f77ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
     body:
       encoding: US-ASCII
       string: ''
@@ -292,9 +292,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9d1a85b5060a021fdde6212fe48b15c18f119b41"'
+      - '"6aa611bbc6fe8c12672639195fa14921b00d8c0f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -328,18 +328,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f
     body:
       encoding: US-ASCII
       string: ''
@@ -358,9 +358,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f5fd93cabf4a0d7bdbeca9a97e5718c393240800"'
+      - '"a59867a566790f6892d1e8d3a575ab17c86196e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -394,14 +394,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3
     body:
       encoding: US-ASCII
       string: ''
@@ -420,9 +420,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ecf6f813fac733e80cc4b55913877f6ec8050a42"'
+      - '"86281dfc87e175a6ddcdb971a47bfa56ee8f77ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -456,20 +456,20 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/f9/11/06/d2/f91106d2-a4ea-445b-ac49-a304580b28f0>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/6c/72/16/05/6c721605-2818-4bb5-9994-b3579b856243>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f9/11/06/d2/f91106d2-a4ea-445b-ac49-a304580b28f0>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6c/72/16/05/6c721605-2818-4bb5-9994-b3579b856243>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9d1a85b5060a021fdde6212fe48b15c18f119b41"'
+      - '"6aa611bbc6fe8c12672639195fa14921b00d8c0f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -524,18 +524,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f5fd93cabf4a0d7bdbeca9a97e5718c393240800"'
+      - '"a59867a566790f6892d1e8d3a575ab17c86196e3"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -590,14 +590,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/b/1f/ce/fd/c2/1fcefdc2-d12c-4b9b-916d-1c81af05f6ff>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/b/ce/3d/4d/66/ce3d4d66-ddbb-477e-ae6b-507172bf783f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ecf6f813fac733e80cc4b55913877f6ec8050a42"'
+      - '"86281dfc87e175a6ddcdb971a47bfa56ee8f77ee"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -652,15 +652,15 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/f9/11/06/d2/f91106d2-a4ea-445b-ac49-a304580b28f0>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ce/63/0d/96/ce630d96-aa25-4262-a970-a5e24a1561c5/t/9e/65/69/5f/9e65695f-a94b-496e-8d3e-d44bd876760f#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/6c/72/16/05/6c721605-2818-4bb5-9994-b3579b856243>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/11/69/74/01116974-05ee-4ff0-9141-49b66f0b4b1f/t/df/4d/07/7c/df4d077c-f242-4cb3-a319-e7e84b9947e3#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f9/11/06/d2/f91106d2-a4ea-445b-ac49-a304580b28f0>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/6c/72/16/05/6c721605-2818-4bb5-9994-b3579b856243>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:58 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b0f6a798770a00d7452395f6c1a6692acb0d99eb"'
+      - '"61c751524f68d73359c37a715534f957b7a5d912"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:58 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"579b79b89d0d40da23799db0ae0bf2260b3e7577"'
+      - '"43a52667fbe3262e66449d667b1f6983a910f54e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f3d0c611898b89e195d195b437e1cabe9bf7971e"'
+      - '"007254a482c1c1f73849450cf6d7a60f5da3e933"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"60d480f411f96af5efee3102e6cee82b1b991816"'
+      - '"09ec0da35bd0ab6abc6c234e09d8de10d3474a05"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a0ceef51b9c035fd19a336a2ffd57f3d0783f47d"'
+      - '"331d59deb8b29b898a33e56b4c2a0d1d25014cb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:56 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ff433f328014a64aec4ea846ccdd3625ff166028"'
+      - '"5bb8a056618758642e22a7cebc113a1a797ea4a7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ea897ee899932603aa45111e23de40bb2d9ba659"'
+      - '"34fcbd233203410fd703644318fb7ddfd6bdd6ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -329,18 +329,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"60d480f411f96af5efee3102e6cee82b1b991816"'
+      - '"09ec0da35bd0ab6abc6c234e09d8de10d3474a05"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -395,14 +395,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a
     body:
       encoding: US-ASCII
       string: ''
@@ -421,9 +421,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ff433f328014a64aec4ea846ccdd3625ff166028"'
+      - '"5bb8a056618758642e22a7cebc113a1a797ea4a7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -457,21 +457,21 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0c/dd/ba/2b/0cddba2b-b272-4c81-b925-2228c93d8222>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/9f/95/0a/8a/9f950a8a-3d06-4315-8527-a058ac68d413>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0c/dd/ba/2b/0cddba2b-b272-4c81-b925-2228c93d8222>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/9f/95/0a/8a/9f950a8a-3d06-4315-8527-a058ac68d413>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ea897ee899932603aa45111e23de40bb2d9ba659"'
+      - '"34fcbd233203410fd703644318fb7ddfd6bdd6ad"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -526,18 +526,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"60d480f411f96af5efee3102e6cee82b1b991816"'
+      - '"09ec0da35bd0ab6abc6c234e09d8de10d3474a05"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:56 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -592,14 +592,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/b/d9/34/58/fb/d93458fb-e5d1-47cb-a456-61c5b279a6f9>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/b/54/5b/b2/cd/545bb2cd-cfb3-4291-819f-f69ba405211d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a
     body:
       encoding: US-ASCII
       string: ''
@@ -618,9 +618,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ff433f328014a64aec4ea846ccdd3625ff166028"'
+      - '"5bb8a056618758642e22a7cebc113a1a797ea4a7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:59 GMT
+      - Wed, 08 Jul 2015 18:54:57 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -654,16 +654,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/0c/dd/ba/2b/0cddba2b-b272-4c81-b925-2228c93d8222>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/59/fe/51/c059fe51-f3e0-4cd3-9b78-261ea3f81a12/t/7a/a4/b1/0f/7aa4b10f-f82e-41b7-8b5e-eb9523006497#source>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/9f/95/0a/8a/9f950a8a-3d06-4315-8527-a058ac68d413>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/5e/81/a0/e8/5e81a0e8-56ff-4429-948d-c0ca4edbe577/t/34/12/4d/65/34124d65-ea0d-4c7b-ad61-dc50d413fc5a#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/0c/dd/ba/2b/0cddba2b-b272-4c81-b925-2228c93d8222>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/9f/95/0a/8a/9f950a8a-3d06-4315-8527-a058ac68d413>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:59 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:57 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"291b7fd1d3ec1314488ce5aeb44266d4b431f13b"'
+      - '"c1da535648c1d2eea48ec6f771d3aae15daad3da"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"07691957bfdce8c28e6f274ccdcb61a1d8e053fd"'
+      - '"f5afc280bf3520f82eb15dc81ead6a3efd3b308d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2008e38de962224abbe5918e938a57c538381f40"'
+      - '"cf1ca6bc253e7182998efddb8e41bc66f6a1672f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '68'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2008e38de962224abbe5918e938a57c538381f40"'
+      - '"cf1ca6bc253e7182998efddb8e41bc66f6a1672f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"45c970b18e9e1f59fe1ba0092a915d9f753bba17"'
+      - '"d8ed67b90eff2361bdb3183d5a3845531e9498d5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9ff223c0ce95d5c68be7752b75c8838b8da42132"'
+      - '"875a08acdbf9aaca67b5c1fb611471fe9c28e8f9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"701b45568f90980e78c20d670220371bace1ae04"'
+      - '"da7e84c63cabfbd6acca10a20b60694c9524a3b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d88ceca51ac37ad4c880ecf3752c14a556d9c670"'
+      - '"a9947679d8a32cd8290d38bcb6f677a695f9cbb1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"554f2a19f0292156a9e454b671c852673ac6fcae"'
+      - '"806be81ca06cb445e03936037619a00a47f07bb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6bbfad22d1cfb9529fd61e971327a0b485173a5"'
+      - '"f840543892f9863fd89c377a3fbbc843d8f2a3d6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -322,18 +322,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"701b45568f90980e78c20d670220371bace1ae04"'
+      - '"da7e84c63cabfbd6acca10a20b60694c9524a3b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -388,14 +388,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"554f2a19f0292156a9e454b671c852673ac6fcae"'
+      - '"806be81ca06cb445e03936037619a00a47f07bb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -450,14 +450,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed
     body:
       encoding: US-ASCII
       string: ''
@@ -476,9 +476,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6bbfad22d1cfb9529fd61e971327a0b485173a5"'
+      - '"f840543892f9863fd89c377a3fbbc843d8f2a3d6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -512,18 +512,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:42 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2
     body:
       encoding: US-ASCII
       string: ''
@@ -542,9 +542,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"701b45568f90980e78c20d670220371bace1ae04"'
+      - '"da7e84c63cabfbd6acca10a20b60694c9524a3b8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -578,14 +578,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/b/00/2d/4a/3b/002d4a3b-a0a3-4c73-9e32-9a02137057b0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/b/39/61/95/68/39619568-8813-4c23-a1fb-b65ba558cbc2>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e
     body:
       encoding: US-ASCII
       string: ''
@@ -604,9 +604,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"554f2a19f0292156a9e454b671c852673ac6fcae"'
+      - '"806be81ca06cb445e03936037619a00a47f07bb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -640,9 +640,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/61/f6/46/de/61f646de-1bd1-4f11-b76a-20d29efa9bdd/t/6c/7b/15/6c/6c7b156c-9cf7-41f2-a939-1c341930090b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/70/ad/50/b0/70ad50b0-ee3e-4940-b30d-073b06ede4ed/t/60/04/52/14/60045214-d69d-4b47-9b64-d19212e44a4e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0e2cdd31b1876c93437a5bf95600357b3901ca53"'
+      - '"699461a337bc11d649a231e3d8b56ddd91af99a9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"afc909b3e0d7cfff4ac2dd04b7f0a35117d0cd1f"'
+      - '"8bf8700806778531abe17471c6eb914fb1b0d810"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"eb01c0e4697b39107a1d83a3df3cd29d89a93b5c"'
+      - '"0030ffd3b323ddbe854a78bd99aae908a2dc361c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:44 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b
     body:
       encoding: UTF-8
       string: |
@@ -165,23 +165,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3941022d178bd55ba9756e1f090291cba6c0eee1"'
+      - '"fb4cd49c6fe8d7588168e4aa413356a64c4864a8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
     body:
       encoding: UTF-8
       string: |
@@ -191,7 +191,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -211,23 +211,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"15f6a45dcbe224bfa4978095c31ada28c4c55cac"'
+      - '"0302356e55370380a6cd0306560e4e1f611bead9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t
     body:
       encoding: UTF-8
       string: |
@@ -254,23 +254,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"39b2b161a7a52b5c64418dd487306e05eac79f9e"'
+      - '"7bb71a78aad389b9e61d2f7d43ca25272ce7e80d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
     body:
       encoding: US-ASCII
       string: ''
@@ -289,9 +289,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ddac61845317e1d3bc7dd0cc990c022c5bcb7a41"'
+      - '"c8b8d118f0775874458eeb510c6523fd49c4fa7f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -325,18 +325,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85
     body:
       encoding: US-ASCII
       string: ''
@@ -355,9 +355,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3941022d178bd55ba9756e1f090291cba6c0eee1"'
+      - '"fb4cd49c6fe8d7588168e4aa413356a64c4864a8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -391,16 +391,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tdc:language
         \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f
     body:
       encoding: US-ASCII
       string: ''
@@ -419,9 +419,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"39b2b161a7a52b5c64418dd487306e05eac79f9e"'
+      - '"7bb71a78aad389b9e61d2f7d43ca25272ce7e80d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -455,14 +455,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066
     body:
       encoding: US-ASCII
       string: ''
@@ -481,9 +481,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ddac61845317e1d3bc7dd0cc990c022c5bcb7a41"'
+      - '"c8b8d118f0775874458eeb510c6523fd49c4fa7f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -517,18 +517,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85
     body:
       encoding: US-ASCII
       string: ''
@@ -547,9 +547,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3941022d178bd55ba9756e1f090291cba6c0eee1"'
+      - '"fb4cd49c6fe8d7588168e4aa413356a64c4864a8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -583,16 +583,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/b/c9/26/52/b7/c92652b7-7aba-41e1-8bdd-26e9280473de>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/b/e1/65/f9/a6/e165f9a6-502e-491d-a935-b4fe92dd9c85>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tdc:language
         \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f
     body:
       encoding: US-ASCII
       string: ''
@@ -611,9 +611,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"39b2b161a7a52b5c64418dd487306e05eac79f9e"'
+      - '"7bb71a78aad389b9e61d2f7d43ca25272ce7e80d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -647,9 +647,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/4d/61/ad/ab/4d61adab-885f-4fb2-a13a-021c142692c0/t/e1/3b/3f/59/e13b3f59-9358-4bc8-8a78-17ee0719385c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/43/e4/b7/13/43e4b713-2db4-4b9b-a55b-c2b42d716066/t/7d/ab/96/5c/7dab965c-08a4-478d-b537-8fe834f0349f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5859f3de7aad961e26d45433faf87e9a382cda14"'
+      - '"2815b61af4f0c46621c17915eeadfa2be39a2be0"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:44 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8a334be2054dce031508b3a60cc5c1278d0520c2"'
+      - '"05e685f282016a110f59cd0f17dd64753693f57d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6fdfa03db5b6630c91937c85af3af89c14252bd6"'
+      - '"ee3203db7dbda3380306dab010f43ff0bffb9eb2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"70afe482099baf710a53ca5f1f3be78f53f5ec73"'
+      - '"ffafbe6d6386402ccfb15f261d83d683204f063c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b
     body:
       encoding: UTF-8
       string: |
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e75907163ae9d64ec9d2fbca6c164d02ad684f19"'
+      - '"4b3f952bcaa582cf85eeaeca9d124396b7f3f64c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
     body:
       encoding: UTF-8
       string: |
@@ -235,7 +235,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -255,23 +255,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3e0509a7b62b0f1aba54b83146ba036b03979cde"'
+      - '"c24905bba790d48a44fc9f4adb5b0a3337dd5e82"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t
     body:
       encoding: UTF-8
       string: |
@@ -298,23 +298,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3c8bdb47a5ab95f9dcdbbeb9cdaa24512b7aedd0"'
+      - '"a5059ca2209cd7291d26a43a145d0489363d1f86"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
     body:
       encoding: US-ASCII
       string: ''
@@ -333,9 +333,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b062e270520e9477aea07eb2f775c78f00dd2bb9"'
+      - '"d1941db7e13001b3e18263ef3a3b6fff5e67d835"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -369,19 +369,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75
     body:
       encoding: US-ASCII
       string: ''
@@ -400,9 +400,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"70afe482099baf710a53ca5f1f3be78f53f5ec73"'
+      - '"ffafbe6d6386402ccfb15f261d83d683204f063c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -436,14 +436,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9
     body:
       encoding: US-ASCII
       string: ''
@@ -462,9 +462,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e75907163ae9d64ec9d2fbca6c164d02ad684f19"'
+      - '"4b3f952bcaa582cf85eeaeca9d124396b7f3f64c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -498,14 +498,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4
     body:
       encoding: US-ASCII
       string: ''
@@ -524,9 +524,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3c8bdb47a5ab95f9dcdbbeb9cdaa24512b7aedd0"'
+      - '"a5059ca2209cd7291d26a43a145d0489363d1f86"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -560,14 +560,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877
     body:
       encoding: US-ASCII
       string: ''
@@ -586,9 +586,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b062e270520e9477aea07eb2f775c78f00dd2bb9"'
+      - '"d1941db7e13001b3e18263ef3a3b6fff5e67d835"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -622,19 +622,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75
     body:
       encoding: US-ASCII
       string: ''
@@ -653,9 +653,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"70afe482099baf710a53ca5f1f3be78f53f5ec73"'
+      - '"ffafbe6d6386402ccfb15f261d83d683204f063c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -689,14 +689,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/cf/f2/a2/fc/cff2a2fc-1949-41a7-b30c-42b35a449e50>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/18/fb/d2/8f/18fbd28f-948d-41b9-b97e-b5b02aaf5f75>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9
     body:
       encoding: US-ASCII
       string: ''
@@ -715,9 +715,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e75907163ae9d64ec9d2fbca6c164d02ad684f19"'
+      - '"4b3f952bcaa582cf85eeaeca9d124396b7f3f64c"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -751,14 +751,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/b/02/ea/c2/1e/02eac21e-55a7-4255-857d-8ad53d8b1a13>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/b/1a/13/64/37/1a136437-6cc5-48ab-97fd-d5ed5ac6c3c9>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4
     body:
       encoding: US-ASCII
       string: ''
@@ -777,9 +777,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3c8bdb47a5ab95f9dcdbbeb9cdaa24512b7aedd0"'
+      - '"a5059ca2209cd7291d26a43a145d0489363d1f86"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:45 GMT
+      - Wed, 08 Jul 2015 18:54:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -813,9 +813,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/cf/ae/aa/dd/cfaeaadd-7016-4ca0-8a50-5e2354940fcd/t/89/1e/39/ba/891e39ba-a300-4c2a-9bb7-fdd742c7839d>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/2f/c3/71/39/2fc37139-bf32-488d-875d-99b2381f5877/t/4b/4d/da/a4/4b4ddaa4-7b24-4f41-b7f5-460b322451e4>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:45 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"48cd75ff61971b03da3492bc1576e0655777662f"'
+      - '"879b775813c2a78e0d73504e6cdd246240ef0bc7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"99666a80ede70ea7d1856e5c86a49c490b247b85"'
+      - '"8283150c6392bd17b8e3fef43fe324274ebcbf4e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f61103b73dbffcacc6a4ebd98858cad500784f7d"'
+      - '"31724adcc533f09730a899e9e65cd47ca41f46c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '57'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/external_uri_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"03b4ef9b85ac140e4df832eb8bb9b672bc5778dd"'
+      - '"4e03b389c8cd8fa0154bb24fe7cfd78f40b6b6b4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d3bfc092a7451fb6489e0567aa1d8a21e809ec3f"'
+      - '"98a3610054513e56c3c106c93790d9ab9e407f4b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"869b83c53dd6ab6230052b1f4ebfdbdb38325129"'
+      - '"ca025a11ad519a799ca4d73be5667dacc362e5e5"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"170c568061e6e7caeffae6343168620e02aa4414"'
+      - '"47454314b0188e95e709dda6a4392e0d1bb56676"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ed31f58696b3e70fa70d6d9f6fe275248dbbfe45"'
+      - '"5b074c081f9c3c5ce74efb5929fd5c2d039070c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t
     body:
       encoding: UTF-8
       string: |
@@ -247,23 +247,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c159270c36995f8cd86f4d285297396a74fcf52f"'
+      - '"18c577df837bf8d6c261a2593ee05826cff49253"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
     body:
       encoding: US-ASCII
       string: ''
@@ -282,9 +282,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0cc7c28937ea193cd22867c2baaa2e347ee915e3"'
+      - '"b5a961f9b02b1bf084ced1465e2a17b311ed31af"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -318,18 +318,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d
     body:
       encoding: US-ASCII
       string: ''
@@ -348,9 +348,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"170c568061e6e7caeffae6343168620e02aa4414"'
+      - '"47454314b0188e95e709dda6a4392e0d1bb56676"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -384,14 +384,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e
     body:
       encoding: US-ASCII
       string: ''
@@ -410,9 +410,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c159270c36995f8cd86f4d285297396a74fcf52f"'
+      - '"18c577df837bf8d6c261a2593ee05826cff49253"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -446,14 +446,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367
     body:
       encoding: US-ASCII
       string: ''
@@ -472,9 +472,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0cc7c28937ea193cd22867c2baaa2e347ee915e3"'
+      - '"b5a961f9b02b1bf084ced1465e2a17b311ed31af"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -508,18 +508,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d
     body:
       encoding: US-ASCII
       string: ''
@@ -538,9 +538,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"170c568061e6e7caeffae6343168620e02aa4414"'
+      - '"47454314b0188e95e709dda6a4392e0d1bb56676"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -574,14 +574,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/b/3c/ce/75/51/3cce7551-d1cc-4fc0-8e91-d70f620d19bd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/b/55/8a/a2/2e/558aa22e-8a43-438e-af4d-f03c0cf7b82d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e
     body:
       encoding: US-ASCII
       string: ''
@@ -600,9 +600,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c159270c36995f8cd86f4d285297396a74fcf52f"'
+      - '"18c577df837bf8d6c261a2593ee05826cff49253"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -636,9 +636,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c3/e1/de/1c/c3e1de1c-94b3-44cb-bd44-ee1a2d8225f4/t/ed/23/76/b2/ed2376b2-4fe6-456f-8b79-7627444d0bfb>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/1b/98/c6/d6/1b98c6d6-01cc-4223-af14-75e603149367/t/5b/fc/b9/be/5bfcb9be-d1ba-4430-a268-57625405c17e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"12f860ef795d794ef147f7c1428616601f2d52db"'
+      - '"84baf6ee0a0a8ce30b63c98fb6e81ea5dfd37750"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c9eca4a7b73ccc4b3e89d9de6b1e605a02112186"'
+      - '"14ed8c6f731e1a70fd02e10999827a4859f33847"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"14beb222ceb29244c7432072bcdf7f2005d755aa"'
+      - '"721bafbefb51a2f768b7993a4acbd0cbc9d85902"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b
     body:
       encoding: UTF-8
       string: |
@@ -163,23 +163,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7fed5aa10754c62cfe27678bf7cf8394e5baef1b"'
+      - '"07ad5fba36f45299733de7d08455b3736556b5b6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
     body:
       encoding: UTF-8
       string: |
@@ -189,7 +189,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c66796113c6151135555ef7fd86df5e1f6f0f0d2"'
+      - '"2ec00db62da0211a7afb2076352e2eb33d57d98d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t
     body:
       encoding: UTF-8
       string: |
@@ -252,23 +252,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"79fd2801b207bfc551bc7bbf4e07a967ac76a6f3"'
+      - '"7e397eaf2be98c1203003009926aa59c806fef26"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
     body:
       encoding: US-ASCII
       string: ''
@@ -287,9 +287,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eba2cbe33717639a1d6605bfad6f924c4ec812cf"'
+      - '"5d20baa414cbbd8531c39fb75113a86725d86fa6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -323,18 +323,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120
     body:
       encoding: US-ASCII
       string: ''
@@ -353,9 +353,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7fed5aa10754c62cfe27678bf7cf8394e5baef1b"'
+      - '"07ad5fba36f45299733de7d08455b3736556b5b6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -389,15 +389,15 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120>
         a dcmitype:Sound , ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8
     body:
       encoding: US-ASCII
       string: ''
@@ -416,9 +416,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"79fd2801b207bfc551bc7bbf4e07a967ac76a6f3"'
+      - '"7e397eaf2be98c1203003009926aa59c806fef26"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -452,14 +452,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2
     body:
       encoding: US-ASCII
       string: ''
@@ -478,9 +478,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eba2cbe33717639a1d6605bfad6f924c4ec812cf"'
+      - '"5d20baa414cbbd8531c39fb75113a86725d86fa6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -514,18 +514,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120
     body:
       encoding: US-ASCII
       string: ''
@@ -544,9 +544,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7fed5aa10754c62cfe27678bf7cf8394e5baef1b"'
+      - '"07ad5fba36f45299733de7d08455b3736556b5b6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -580,15 +580,15 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/b/b3/d9/78/d1/b3d978d1-d7d0-4e8c-b6b9-130ee8001f56>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/b/32/29/a0/21/3229a021-be64-4e29-a874-190d8aa4f120>
         a dcmitype:Sound , ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8
     body:
       encoding: US-ASCII
       string: ''
@@ -607,9 +607,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"79fd2801b207bfc551bc7bbf4e07a967ac76a6f3"'
+      - '"7e397eaf2be98c1203003009926aa59c806fef26"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -643,9 +643,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/c4/f6/19/36/c4f61936-d5b3-4ca1-b3c4-af601e8c9dbd/t/74/03/3b/b0/74033bb0-2cf9-41d3-abc1-9ef40903884b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a0/7e/05/c2/a07e05c2-615b-402f-963c-14a385334eb2/t/32/ca/bf/ab/32cabfab-4235-4810-8f0c-d9c82e5637d8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f03607b5c75014efaa68116dad44faeecbf1beeb"'
+      - '"de5e2fffb783764666f7cecf238b5d46209ae4dc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c1bb4f6c8dec85c06df391e6fb88c9b7f12780f7"'
+      - '"35d81fcfe4b26a5979ab340b6a2540717fd32cff"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"25511bb2f8c384528ae24b9c81d1f677c77eb142"'
+      - '"e0fef62f8ad595713ca86bc5125f9e9d6382bdcd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b
     body:
       encoding: UTF-8
       string: |
@@ -160,23 +160,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ad450102840e556f2ee7a904e1e4f37f0b6758b7"'
+      - '"2e20f88e0ec7a12738466b361c4f8a5974dcee5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
     body:
       encoding: UTF-8
       string: |
@@ -186,7 +186,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -206,23 +206,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fbbc09d247e4de41fe0e56455666568f14955b09"'
+      - '"38629efc85249f345fc6d6c108015c726be3c686"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t
     body:
       encoding: UTF-8
       string: |
@@ -249,23 +249,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b18868fdd874d38ec3ef6b4483d3d9a225a48298"'
+      - '"8a53a2b8fdf32b27d4467ebf413637dc8365e7f7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
     body:
       encoding: US-ASCII
       string: ''
@@ -284,9 +284,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4267b0b3c5c20dd63da49d11ce94c00ad03c1c94"'
+      - '"afadf6b56af40ace0b8b038acc1534cab835c64b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -320,18 +320,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755
     body:
       encoding: US-ASCII
       string: ''
@@ -350,9 +350,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ad450102840e556f2ee7a904e1e4f37f0b6758b7"'
+      - '"2e20f88e0ec7a12738466b361c4f8a5974dcee5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -386,14 +386,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755>
         a oa:SemanticTag , ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474
     body:
       encoding: US-ASCII
       string: ''
@@ -412,9 +412,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b18868fdd874d38ec3ef6b4483d3d9a225a48298"'
+      - '"8a53a2b8fdf32b27d4467ebf413637dc8365e7f7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -448,14 +448,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48
     body:
       encoding: US-ASCII
       string: ''
@@ -474,9 +474,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4267b0b3c5c20dd63da49d11ce94c00ad03c1c94"'
+      - '"afadf6b56af40ace0b8b038acc1534cab835c64b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -510,18 +510,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755
     body:
       encoding: US-ASCII
       string: ''
@@ -540,9 +540,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ad450102840e556f2ee7a904e1e4f37f0b6758b7"'
+      - '"2e20f88e0ec7a12738466b361c4f8a5974dcee5f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -576,14 +576,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/b/07/13/9b/9e/07139b9e-7b07-4130-9717-81fc508a97a5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/b/a8/b4/2e/35/a8b42e35-cdcc-4402-9887-7d78f766e755>
         a oa:SemanticTag , ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474
     body:
       encoding: US-ASCII
       string: ''
@@ -602,9 +602,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b18868fdd874d38ec3ef6b4483d3d9a225a48298"'
+      - '"8a53a2b8fdf32b27d4467ebf413637dc8365e7f7"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -638,9 +638,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6c/46/6e/b8/6c466eb8-471f-4895-b4c6-1b4940d9eb2b/t/dc/3a/77/41/dc3a7741-7496-4837-a9ed-0d0a79178820>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/f0/6b/40/c1/f06b40c1-0d04-4f56-b331-a33efa566b48/t/ef/ef/08/84/efef0884-bd5b-4342-a97f-f796fc128474>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"70d3340331406bb3554e919726d635a6e8240cd6"'
+      - '"6244ead008568b3922858f9dfc5a7665398430d9"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f46350baf120747858770a316b10d0a26a8c7d94"'
+      - '"1381aa62bb30877c18c65985fc339f4889a421c4"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3f4a28078dd47af1efe7be5301a5acb33fcdd88a"'
+      - '"befab471ad953ccd7aff2f9161cad7505a26c325"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ade1d289bdb01ff2a9b4a6d93b2f3db750855fa9"'
+      - '"6eed349763252f9d74b98bb6dce2b466922f606b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2dbfb1f6d87d3586824a94dc72b3f7c3f8a979db"'
+      - '"bbff0f1133005f862b279be81fc0bd492e8d57f8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
     body:
       encoding: UTF-8
       string: |
@@ -227,7 +227,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -247,23 +247,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9d845a4cb0e2f7ab776a2510261e9376a4455723"'
+      - '"b2bac4d23600bc8388b6f9face0dab7edcd56fd2"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t
     body:
       encoding: UTF-8
       string: |
@@ -290,23 +290,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b9442baf968cdbba41beb4f096484aae418d73e2"'
+      - '"410ff2e2c2971683d80f425254368ddb31558426"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
     body:
       encoding: US-ASCII
       string: ''
@@ -325,9 +325,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d37d9463f80b2a72f21fb85c7ba48eb2fcdac89"'
+      - '"53e8a6b44dc54b01114ea15c7328f6eceb4c9a17"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -361,19 +361,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134
     body:
       encoding: US-ASCII
       string: ''
@@ -392,9 +392,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ade1d289bdb01ff2a9b4a6d93b2f3db750855fa9"'
+      - '"6eed349763252f9d74b98bb6dce2b466922f606b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -428,14 +428,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383
     body:
       encoding: US-ASCII
       string: ''
@@ -454,9 +454,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2dbfb1f6d87d3586824a94dc72b3f7c3f8a979db"'
+      - '"bbff0f1133005f862b279be81fc0bd492e8d57f8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -490,14 +490,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d
     body:
       encoding: US-ASCII
       string: ''
@@ -516,9 +516,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b9442baf968cdbba41beb4f096484aae418d73e2"'
+      - '"410ff2e2c2971683d80f425254368ddb31558426"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -552,14 +552,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d
     body:
       encoding: US-ASCII
       string: ''
@@ -578,9 +578,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d37d9463f80b2a72f21fb85c7ba48eb2fcdac89"'
+      - '"53e8a6b44dc54b01114ea15c7328f6eceb4c9a17"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -614,19 +614,19 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134
     body:
       encoding: US-ASCII
       string: ''
@@ -645,9 +645,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ade1d289bdb01ff2a9b4a6d93b2f3db750855fa9"'
+      - '"6eed349763252f9d74b98bb6dce2b466922f606b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -681,14 +681,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/33/12/f0/07/3312f007-a786-4577-a933-cf6390fe3bac>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/3d/c2/38/94/3dc23894-194c-4c5a-9576-d5469d20b134>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383
     body:
       encoding: US-ASCII
       string: ''
@@ -707,9 +707,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2dbfb1f6d87d3586824a94dc72b3f7c3f8a979db"'
+      - '"bbff0f1133005f862b279be81fc0bd492e8d57f8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -743,14 +743,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/b/ac/39/67/a9/ac3967a9-beec-45ae-b850-7c4fca4b6cfa>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/b/fc/fa/bb/f7/fcfabbf7-2e69-449a-9f2d-3c3dee0a6383>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d
     body:
       encoding: US-ASCII
       string: ''
@@ -769,9 +769,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b9442baf968cdbba41beb4f096484aae418d73e2"'
+      - '"410ff2e2c2971683d80f425254368ddb31558426"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -805,9 +805,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/2c/b1/76/62/2cb17662-986a-4415-bd1d-896a4c7b5160/t/ab/16/4d/c3/ab164dc3-22b9-424e-879d-ad23c8253f2c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/02/47/77/6e/0247776e-4993-4be2-b265-4f4ccc62b68d/t/bb/a0/33/86/bba03386-d942-4335-b08b-6c50e5337c7d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2ae639c7718867c9c028d7381cfb9bd82cf39471"'
+      - '"49aaea90a55dd60d6e72dcfaac434a49e2f83a5d"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bf8fbd7eb8dcb08ab81cd68e4f9030a8fad40c52"'
+      - '"76df8ddb5a122323cac20ee245300e8eac90abc6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d3921e496d64a9798bc646884f3771b3b99bdae0"'
+      - '"b0062fd3c4d6a7b112f01c59a507fc52d3aebaac"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b78551341e97be92617ad6447b27eb6f9dc67987"'
+      - '"b5f3bfbc8562638658575f1cae1ac3e785952c01"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"87de6707867fcf49481e614d654af4dc80f3f80c"'
+      - '"e40fcbe0ff016f4251feec1bd57265d03927cdfd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f
     body:
       encoding: US-ASCII
       string: ''
@@ -236,9 +236,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5a80607e6a102a672dcd5236c73fc03c292e9678"'
+      - '"9204e8b3c3d0b304d7e667dede2b410d751ee50a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -272,17 +272,17 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356
     body:
       encoding: US-ASCII
       string: ''
@@ -301,9 +301,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b78551341e97be92617ad6447b27eb6f9dc67987"'
+      - '"b5f3bfbc8562638658575f1cae1ac3e785952c01"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -337,14 +337,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd
     body:
       encoding: US-ASCII
       string: ''
@@ -363,9 +363,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"87de6707867fcf49481e614d654af4dc80f3f80c"'
+      - '"e40fcbe0ff016f4251feec1bd57265d03927cdfd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -399,14 +399,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f
     body:
       encoding: US-ASCII
       string: ''
@@ -425,9 +425,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5a80607e6a102a672dcd5236c73fc03c292e9678"'
+      - '"9204e8b3c3d0b304d7e667dede2b410d751ee50a"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -461,17 +461,17 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b78551341e97be92617ad6447b27eb6f9dc67987"'
+      - '"b5f3bfbc8562638658575f1cae1ac3e785952c01"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -526,14 +526,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/2a/f5/f1/8c/2af5f18c-50e0-4030-ae6e-2ee798c835dc>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/6e/ee/13/df/6eee13df-a744-4fcf-b88d-8057c06c0356>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd
     body:
       encoding: US-ASCII
       string: ''
@@ -552,9 +552,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"87de6707867fcf49481e614d654af4dc80f3f80c"'
+      - '"e40fcbe0ff016f4251feec1bd57265d03927cdfd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -588,9 +588,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/73/7c/f1/3b/737cf13b-b40b-461f-bc56-2d72023d86ee/t/d1/0b/c2/52/d10bc252-5368-4654-a12d-ff5024b05dd3>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/8a/0f/33/d4/8a0f33d4-c261-450a-9a88-16765e9f869f/t/e6/05/00/58/e6050058-4e29-4941-a6e2-bc73ea4e44cd>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f61103b73dbffcacc6a4ebd98858cad500784f7d"'
+      - '"31724adcc533f09730a899e9e65cd47ca41f46c8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d1b64cee8d851b978ff39f81e2fee1f700834b6f"'
+      - '"8b4a47ab02291844c33946cdf8479d6fefafb90f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"609b1bb8e010989310fab4432e4823122796e911"'
+      - '"d721e66223ad34b3292e936c96e56539fe19a71e"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d5710a65da0d66806b3dee39325c3c8f2080aaa8"'
+      - '"6edd92fbe11d525d0d3e8dc506aed3bf4edfeaa8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"15a01666481328dbbd597f2041896b18e4be586c"'
+      - '"b313385a167df7dd3fc2dc714be66994dcae2747"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d5710a65da0d66806b3dee39325c3c8f2080aaa8"'
+      - '"6edd92fbe11d525d0d3e8dc506aed3bf4edfeaa8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,14 +293,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +319,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"15a01666481328dbbd597f2041896b18e4be586c"'
+      - '"b313385a167df7dd3fc2dc714be66994dcae2747"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -355,16 +355,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db
     body:
       encoding: US-ASCII
       string: ''
@@ -383,9 +383,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d5710a65da0d66806b3dee39325c3c8f2080aaa8"'
+      - '"6edd92fbe11d525d0d3e8dc506aed3bf4edfeaa8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:46 GMT
+      - Wed, 08 Jul 2015 18:54:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -419,9 +419,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/fa/25/48/94/fa254894-97fc-4d4b-9a17-d725b91ddd01/t/6f/7b/03/4c/6f7b034c-9c44-42f3-ba9b-84a6cd442f42>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/82/29/1a/3a82291a-0fc0-4ff5-8600-5b053c145247/t/c6/5c/32/d9/c65c32d9-86bc-4ed6-b52a-4d2624f098db>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:46 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cad0951ff898b24828bbf1c3bd0318d329eb17e8"'
+      - '"151bbb03fa370e4447766889a03730c276dd1af8"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1212cf8667bdc192036630b4a65b9141c9c14631"'
+      - '"303b89dc1ce1b934cd10d374dd86120a2e17a3cf"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:47 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:47 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"71435966772ccc01d32cd75ab509984d391e09ec"'
+      - '"92d44bd718554cd7ccee555e89e16e5f2b95382f"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:45 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:45 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e1cf1bd273a36295b778849b28f84fc896706937"'
+      - '"a360f88a224c76aa6ecb8f621a92e916cfc1a143"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b02d14ce600ad885b995f02f9f9aab2f65e55e5e"'
+      - '"e3fc5be874787ad7b415731a6dd6d0c9deb3a1fc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t
     body:
       encoding: UTF-8
       string: |
@@ -252,23 +252,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2bbe9f992a91f2731cac9494c9f5d66ce26c4c39"'
+      - '"cf916da9b416926cdae8b7df4547155f518d2c48"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
     body:
       encoding: US-ASCII
       string: ''
@@ -287,9 +287,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"981d0fe667f29bc7cf793113e65939dbdc29b832"'
+      - '"83b35c0c31f0e6e910274287e85e0f52ce5de069"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -323,18 +323,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca
     body:
       encoding: US-ASCII
       string: ''
@@ -353,9 +353,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e1cf1bd273a36295b778849b28f84fc896706937"'
+      - '"a360f88a224c76aa6ecb8f621a92e916cfc1a143"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -389,14 +389,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65
     body:
       encoding: US-ASCII
       string: ''
@@ -415,9 +415,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2bbe9f992a91f2731cac9494c9f5d66ce26c4c39"'
+      - '"cf916da9b416926cdae8b7df4547155f518d2c48"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -451,14 +451,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65>
         a dcmitype:Text , ldp:BasicContainer ;\n\ttriannon:externalReference <http://external.com/index.html>
         ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe
     body:
       encoding: US-ASCII
       string: ''
@@ -477,9 +477,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"981d0fe667f29bc7cf793113e65939dbdc29b832"'
+      - '"83b35c0c31f0e6e910274287e85e0f52ce5de069"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -513,18 +513,18 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca
     body:
       encoding: US-ASCII
       string: ''
@@ -543,9 +543,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e1cf1bd273a36295b778849b28f84fc896706937"'
+      - '"a360f88a224c76aa6ecb8f621a92e916cfc1a143"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -579,14 +579,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/b/66/98/17/8d/6698178d-41bd-4d4b-b7f7-2c23cbd987d7>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/b/a2/c6/0b/0e/a2c60b0e-64da-46ac-8d4e-d18ae661b9ca>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65
     body:
       encoding: US-ASCII
       string: ''
@@ -605,9 +605,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2bbe9f992a91f2731cac9494c9f5d66ce26c4c39"'
+      - '"cf916da9b416926cdae8b7df4547155f518d2c48"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:48 GMT
+      - Wed, 08 Jul 2015 18:54:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -641,9 +641,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/30/16/08/93/30160893-d93b-4cc5-b709-74a584e2958e/t/cf/cd/82/90/cfcd8290-aed7-4d28-8471-c887c07e97a5>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/53/4f/fb/6f534ffb-0db5-4470-a55d-21bf39d67dfe/t/be/bf/c1/e6/bebfc1e6-9485-461f-b22c-65f852232f65>
         a dcmitype:Text , ldp:BasicContainer ;\n\ttriannon:externalReference <http://external.com/index.html>
         ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:48 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"40bba0206b0ebd9248f61dac02824f429f615e29"'
+      - '"e334e633a9a22123fc3da8a509fe3545e7755db1"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f0eee02654d12593cea2f01a81b253e5cfdc2913"'
+      - '"627d7a0e7f1da86f1a3d3d49228c3791fa546986"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1737d6361ea085cecd7d55e2ebbd59ffd20f47c2"'
+      - '"f87d5c0ba5ecd2a1a653118da1bd9162c1527cf6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '64'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1737d6361ea085cecd7d55e2ebbd59ffd20f47c2"'
+      - '"f87d5c0ba5ecd2a1a653118da1bd9162c1527cf6"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"80deafa5b27576c046001aa50adb05220a3990f5"'
+      - '"910380bc1a42ceeb4f513b02a55704f298f3f212"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '113'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"924eeee0527cadd1e31ce450c5a78a30c528bf31"'
+      - '"35c31e4f42eff7ad10f800f7a03b38ee64cba93b"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '115'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1ad5b64894611dc5452ee8c0c2609890b5306149"'
+      - '"a0c13775d72b5221c98b371f48cbc181151032bc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Content-Length:
       - '164'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2809fbf871354b73824c1d3bdc2ceb785222e6cf"'
+      - '"ce5dc0c51cfc538fa11811f438add9e0919a9cbd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -229,16 +229,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c>
+        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1ad5b64894611dc5452ee8c0c2609890b5306149"'
+      - '"a0c13775d72b5221c98b371f48cbc181151032bc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -293,14 +293,14 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +319,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2809fbf871354b73824c1d3bdc2ceb785222e6cf"'
+      - '"ce5dc0c51cfc538fa11811f438add9e0919a9cbd"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -355,16 +355,16 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c>
+        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c
     body:
       encoding: US-ASCII
       string: ''
@@ -383,9 +383,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1ad5b64894611dc5452ee8c0c2609890b5306149"'
+      - '"a0c13775d72b5221c98b371f48cbc181151032bc"'
       Last-Modified:
-      - Fri, 26 Jun 2015 22:20:49 GMT
+      - Wed, 08 Jul 2015 18:54:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -419,9 +419,9 @@ http_interactions:
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
         .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/43/c1/cd/b8/43c1cdb8-5e3f-4a3b-954d-b212e8ed77d3/t/6a/68/d1/28/6a68d128-0f87-42e7-ac47-428f9e09109c>
+        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/74/a9/45/40/74a94540-2008-4b81-8d73-d845b250a4f9/t/ee/7e/d9/6d/ee7ed96d-e89c-46e9-84c3-e142324f991c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Fri, 26 Jun 2015 22:20:49 GMT
+  recorded_at: Wed, 08 Jul 2015 18:54:47 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This PR is designed to cleanup and clarify how to update the gemsets for triannon and the engine cart app that will test triannon.

  - The Gemfile change removes all constraints that are not in the triannon.gemset file when the engine cart is not installed yet (i.e. it removes the 'else' clause that the engine_cart:prepare task creates; this is potentially a moot point, but IMO that all belongs within the engine_cart:generate process and should not 'taint' the parent project Gemfile).

  - The Rakefile changes consolidate the logic for updating the gemset of the triannon parent project and the engine cart test app, allowing the latter to resolve third-party gemsets that should not be defined by the triannon Gemfile.  The key to this solution is removing the triannon parent 'Gemfile.lock' file before running the engine_cart:generate task.  This avoids having to modify the triannon parent Gemfile to handle mysterious third-party conflicts between the parent Gemfile.lock and the engine cart gem requirements (such as the prior 'tilt' pin that really had nothing to do with triannon itself).

These changes have been evaluated by repeatedly running `rake ci` on my laptop and the same task has been run on travis with successful results.

Comments and feedback are especially appreciated from @ndushay and @cbeer.  Please bear in mind that a guiding principle of this PR is to avoid using Gemfile.lock, as much as possible, by containing gem pins solely in triannon.gemspec (i.e. removing them from the triannon Gemspec file).