### PR TITLE
remove extend ActiveModel::Callback  from Annotation model

### DIFF
--- a/app/models/triannon/annotation.rb
+++ b/app/models/triannon/annotation.rb
@@ -1,7 +1,6 @@
 module Triannon
   class Annotation
     include ActiveModel::Model
-    extend ActiveModel::Callbacks
 
     define_model_callbacks :save, :destroy
     after_save :solr_save

--- a/spec/fixtures/vcr_cassettes/Triannon_SearchController/GET_find/returns_http_success.yml
+++ b/spec/fixtures/vcr_cassettes/Triannon_SearchController/GET_find/returns_http_success.yml
@@ -22,7 +22,7 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>0,
+            'QTime'=>6,
             'params'=>{
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>0,'start'=>0,'maxScore'=>0.0,'docs'=>[]
@@ -39,5 +39,5 @@ http_interactions:
             'facet_ranges'=>{},
             'facet_intervals'=>{}}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 20:34:04 GMT
+  recorded_at: Wed, 08 Jul 2015 20:50:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b147560ccfb23b7320b158bc67a0223abc148202"'
+      - '"0bf9f02e5effc06b15dc08751e4c08fbbf7ddf77"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>32}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9c2a7d49d4ac2e2e1265448f99c4da22a706e436"'
+      - '"6b91effa2d667b1993e87818f9e9d25ac24079dc"'
       Last-Modified:
-      - Tue, 09 Jun 2015 21:59:34 GMT
+      - Wed, 08 Jul 2015 20:51:14 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f6355a62cbbb064b228ccf3277ee95541742087e"'
+      - '"92feb6b04fb93ec8f9274992e61169dfe5d57f66"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:30 GMT
       Content-Length:
       - '63'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/choice_integration_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_ContentAsText.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f6355a62cbbb064b228ccf3277ee95541742087e"'
+      - '"92feb6b04fb93ec8f9274992e61169dfe5d57f66"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d96d19340f885f401639accb85d3188bdd624b38"'
+      - '"d038956a9c67b449b2048d9689dafa07b923ce24"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:30 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a97388885fb07ff47d868fe907d80dfab3ee8fce"'
+      - '"fe7176f885183fa780b8f943e4f688ae836612d8"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:30 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:30 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b
     body:
       encoding: UTF-8
       string: |
@@ -174,23 +174,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9e98638cd5c6a3e1ca69865acd9c991d220c6ee3"'
+      - '"2f413cd6374a4618e160f6ca1d43d51ce537e047"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
     body:
       encoding: UTF-8
       string: |
@@ -200,7 +200,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -220,23 +220,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c9767dafb0849b04d01a94a88c127dfdc651d281"'
+      - '"fbdf690050feebaa43193d6c5f1bc8b588add36c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t
     body:
       encoding: UTF-8
       string: |
@@ -263,23 +263,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"06a836edb78ddca64c502dadb7b9a9948f783528"'
+      - '"19dee89fafd6bdb96cab49c05eb279e147246479"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
     body:
       encoding: US-ASCII
       string: ''
@@ -298,9 +298,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a235072f70a8a2cb40c955541bb7984624cd45f4"'
+      - '"9ad0a28fb25b17ce028310ba7cbf27cedb144dad"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -317,7 +317,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -333,19 +333,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298
     body:
       encoding: US-ASCII
       string: ''
@@ -364,9 +364,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9e98638cd5c6a3e1ca69865acd9c991d220c6ee3"'
+      - '"2f413cd6374a4618e160f6ca1d43d51ce537e047"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -383,7 +383,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2084'
+      - '2129'
       Content-Type:
       - application/x-turtle
     body:
@@ -399,22 +399,22 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/ee/60/40/30/ee604030-77f6-4e7b-8769-37251649ede9>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/35/42/06/c8/354206c8-ba35-46af-af6d-0f65ea478693>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ee/60/40/30/ee604030-77f6-4e7b-8769-37251649ede9>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/80/3c/ad/1c/803cad1c-1648-4184-8776-8fdb66ff6456>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/f7/c0/17/e4/f7c017e4-4c73-4b45-94d2-6a8de660d46d>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/80/3c/ad/1c/803cad1c-1648-4184-8776-8fdb66ff6456>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/35/42/06/c8/354206c8-ba35-46af-af6d-0f65ea478693>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f7/c0/17/e4/f7c017e4-4c73-4b45-94d2-6a8de660d46d>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c
     body:
       encoding: US-ASCII
       string: ''
@@ -433,9 +433,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"06a836edb78ddca64c502dadb7b9a9948f783528"'
+      - '"19dee89fafd6bdb96cab49c05eb279e147246479"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -452,7 +452,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -468,15 +468,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244
     body:
       encoding: US-ASCII
       string: ''
@@ -495,9 +495,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a235072f70a8a2cb40c955541bb7984624cd45f4"'
+      - '"9ad0a28fb25b17ce028310ba7cbf27cedb144dad"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -514,7 +514,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -530,19 +530,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298
     body:
       encoding: US-ASCII
       string: ''
@@ -561,9 +561,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9e98638cd5c6a3e1ca69865acd9c991d220c6ee3"'
+      - '"2f413cd6374a4618e160f6ca1d43d51ce537e047"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -580,7 +580,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2084'
+      - '2129'
       Content-Type:
       - application/x-turtle
     body:
@@ -596,22 +596,22 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/b/de/cf/59/fd/decf59fd-b61c-4916-abc1-a8161b9700f7>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/ee/60/40/30/ee604030-77f6-4e7b-8769-37251649ede9>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/35/42/06/c8/354206c8-ba35-46af-af6d-0f65ea478693>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ee/60/40/30/ee604030-77f6-4e7b-8769-37251649ede9>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/b/fa/df/f5/4e/fadff54e-dcd2-4dae-81f6-025c279a8298>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/.well-known/genid/80/3c/ad/1c/803cad1c-1648-4184-8776-8fdb66ff6456>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/.well-known/genid/f7/c0/17/e4/f7c017e4-4c73-4b45-94d2-6a8de660d46d>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/80/3c/ad/1c/803cad1c-1648-4184-8776-8fdb66ff6456>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"fr\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"Je l'aime en Francais!\"^^<http://www.w3.org/2001/XMLSchema#string>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/35/42/06/c8/354206c8-ba35-46af-af6d-0f65ea478693>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f7/c0/17/e4/f7c017e4-4c73-4b45-94d2-6a8de660d46d>
         a dcmitype:Text , cnt:ContentAsText ;\n\tdc:language \"en\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this Englishly!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c
     body:
       encoding: US-ASCII
       string: ''
@@ -630,9 +630,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"06a836edb78ddca64c502dadb7b9a9948f783528"'
+      - '"19dee89fafd6bdb96cab49c05eb279e147246479"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -649,7 +649,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -665,10 +665,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d0/c9/95/72/d0c99572-9c9a-46ec-a7a6-d35032d291ae/t/1d/02/14/39/1d021439-8e48-4124-8ea4-0f4b89ca7cb5>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/a2/63/56/ff/a26356ff-4a6f-4a82-9e6e-cc86c0300244/t/a7/8c/70/1d/a78c701d-786b-4b80-a929-9d57eded307c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/body_is_choice_of_external_URIs_with_addl_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"37d0a14adc3153aaee28dd9c933a5895cf612df8"'
+      - '"5e0a898558b1b5b90d58642f6b33a6beb43b33cf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:30 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"680d1744c33824271d4dc4ba01bbb440c1361fc6"'
+      - '"9559f811a0901bdfed131bce85bf7986ade24245"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0b0ce27e1d55c32a5a829ab4acea36491b020938"'
+      - '"20d70798b2211a41258566a32282aa53640c1243"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b
     body:
       encoding: UTF-8
       string: |
@@ -172,23 +172,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2f0b9e1724c2f3f474db479f2db7c57105336415"'
+      - '"c6664e58d1b36dca8fc6b0a9f568427f7a52d973"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
     body:
       encoding: UTF-8
       string: |
@@ -198,7 +198,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -218,23 +218,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d010d44d1e25af2a2a21222c68e0c17df3bd0caa"'
+      - '"12dca51d44084aade240a80679fa24656792f858"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t
     body:
       encoding: UTF-8
       string: |
@@ -261,23 +261,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9bb65447c5d201ee221c2203193033509213e97f"'
+      - '"3cded65d0dc8026138e99cb02fbb17ff44af4de6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
     body:
       encoding: US-ASCII
       string: ''
@@ -296,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bc121e3cff2ef07ac923e90e4edf9b9245ac9d4a"'
+      - '"29dc20a41f7d9086208e2ccef2a8b21acd31ee68"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -315,7 +315,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -331,19 +331,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc
     body:
       encoding: US-ASCII
       string: ''
@@ -362,9 +362,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2f0b9e1724c2f3f474db479f2db7c57105336415"'
+      - '"c6664e58d1b36dca8fc6b0a9f568427f7a52d973"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -381,7 +381,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2309'
+      - '2354'
       Content-Type:
       - application/x-turtle
     body:
@@ -397,21 +397,21 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#item1>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#item1>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
-        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#default>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#default>
         a dcmitype:Sound ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5
     body:
       encoding: US-ASCII
       string: ''
@@ -430,9 +430,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9bb65447c5d201ee221c2203193033509213e97f"'
+      - '"3cded65d0dc8026138e99cb02fbb17ff44af4de6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -449,7 +449,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -465,15 +465,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234
     body:
       encoding: US-ASCII
       string: ''
@@ -492,9 +492,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bc121e3cff2ef07ac923e90e4edf9b9245ac9d4a"'
+      - '"29dc20a41f7d9086208e2ccef2a8b21acd31ee68"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -511,7 +511,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -527,19 +527,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:31 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc
     body:
       encoding: US-ASCII
       string: ''
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2f0b9e1724c2f3f474db479f2db7c57105336415"'
+      - '"c6664e58d1b36dca8fc6b0a9f568427f7a52d973"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -577,7 +577,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2309'
+      - '2354'
       Content-Type:
       - application/x-turtle
     body:
@@ -593,21 +593,21 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#item1>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#item1>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://text.transcriptions.com>
-        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/b/be/b2/29/07/beb22907-1e0c-46ae-bb9d-bd82ac9da25b#default>
+        ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/b/fb/62/d0/3f/fb62d03f-d216-4f5a-909e-b41186d9eddc#default>
         a dcmitype:Sound ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5
     body:
       encoding: US-ASCII
       string: ''
@@ -626,9 +626,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9bb65447c5d201ee221c2203193033509213e97f"'
+      - '"3cded65d0dc8026138e99cb02fbb17ff44af4de6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -645,7 +645,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -661,10 +661,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/6f/0e/79/92/6f0e7992-83f5-4f31-8bb7-94a23465fdfb/t/26/21/5a/8a/26215a8a-b4ae-4f1f-ae18-69ab8338bcb8>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/63/7c/66/2c/637c662c-24d2-42b5-9879-8ab1a395c234/t/dd/6d/62/59/dd6d6259-89b2-43f3-95ed-075612d36fb5>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_external_URIs_default_w_addl_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a85a88915c53fe635212b7101f87df52002568c3"'
+      - '"e04f98266bc7fc97ff532884533db95998fc2d9a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:56 GMT
+      - Wed, 08 Jul 2015 21:14:31 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9d0cd369bd7ebcf6bb2e67f687d65c5485b316ac"'
+      - '"5aac9d06cd3674fbf80efa58865f21f4bae4a3fd"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8e324a35b5b8831491139273d6d0f1699dcc0ce2"'
+      - '"b6559f458a3414e11243cc995612fa15481e2c6f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8765606cae2ace519844ae4ae4c3c14e566dbd23"'
+      - '"8582850b6741fc6058ab56345d56f693c9fbc29e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"49f6ed907d928c2a13c0b6f43563743f6d23fa4f"'
+      - '"af1ed97233d620182d2ff682f4ab85897eb0ca04"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t
     body:
       encoding: UTF-8
       string: |
@@ -256,23 +256,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c93eada6de6fcad17b46df5c3ca4ce32c318c1ce"'
+      - '"8e6c3d4769088576f5e2fb895f05548033839acf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
     body:
       encoding: US-ASCII
       string: ''
@@ -291,9 +291,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0b5d9656666550192d3de8f2765d2669f009f618"'
+      - '"72dab34baf87bcb2e90626a53f10b1ac27f11b67"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -310,7 +310,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -326,19 +326,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277
     body:
       encoding: US-ASCII
       string: ''
@@ -357,9 +357,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8765606cae2ace519844ae4ae4c3c14e566dbd23"'
+      - '"8582850b6741fc6058ab56345d56f693c9fbc29e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -376,7 +376,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -392,15 +392,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406
     body:
       encoding: US-ASCII
       string: ''
@@ -419,9 +419,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c93eada6de6fcad17b46df5c3ca4ce32c318c1ce"'
+      - '"8e6c3d4769088576f5e2fb895f05548033839acf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -438,7 +438,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2144'
+      - '2189'
       Content-Type:
       - application/x-turtle
     body:
@@ -454,19 +454,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#item1>
-        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#default>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#default>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://some.external.ref/default>
-        .\n"
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#item1>
+        triannon:externalReference <http://some.external.ref/item> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f
     body:
       encoding: US-ASCII
       string: ''
@@ -485,9 +485,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0b5d9656666550192d3de8f2765d2669f009f618"'
+      - '"72dab34baf87bcb2e90626a53f10b1ac27f11b67"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -504,7 +504,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -520,19 +520,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277
     body:
       encoding: US-ASCII
       string: ''
@@ -551,9 +551,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8765606cae2ace519844ae4ae4c3c14e566dbd23"'
+      - '"8582850b6741fc6058ab56345d56f693c9fbc29e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -570,7 +570,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -586,15 +586,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/b/2c/97/ca/eb/2c97caeb-53c4-4b56-8c23-7aa1bf288b05>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/b/b2/be/06/0c/b2be060c-f018-4213-a1e0-d6816717e277>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406
     body:
       encoding: US-ASCII
       string: ''
@@ -613,9 +613,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c93eada6de6fcad17b46df5c3ca4ce32c318c1ce"'
+      - '"8e6c3d4769088576f5e2fb895f05548033839acf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -632,7 +632,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2144'
+      - '2189'
       Content-Type:
       - application/x-turtle
     body:
@@ -648,14 +648,14 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#item1>
-        triannon:externalReference <http://some.external.ref/item> .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/59/42/df/855942df-5ab5-4830-a638-f412dec78524/t/ec/aa/ce/0b/ecaace0b-28b4-4bbe-8e13-fbf1ec450ca5#default>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#default>
         a dcmitype:Text ;\n\ttriannon:externalReference <http://some.external.ref/default>
-        .\n"
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/85/58/c1/56/8558c156-9b4a-411c-b699-22edb4b4431f/t/42/44/b8/c8/4244b8c8-c841-45b1-a659-4f85f1370406#item1>
+        triannon:externalReference <http://some.external.ref/item> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Choice/target_is_choice_of_three_images_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2887a2b5488c1abc3481d38ceb2639e4af0fe407"'
+      - '"201bfeca629c8e4d9381b819ab01cd406e9df936"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2d3d8802aa11ffedcb9f96868153d03270b3c6ab"'
+      - '"768e5842b82c3dc79dad41de239f1326f84a406c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"45d931a126158be9b4eb96bc780bbd7e0bff8ced"'
+      - '"989420cfec58419b276d164f367f716a138a3c77"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"03d113afb2a1cb85a354c26c33cbe27d26092717"'
+      - '"4c9e087e18cf2801b598dd8d2f337f1b0439822b"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"54857843ba0c254bcaffc1835cb434b02af222f8"'
+      - '"52ad07c4e61c3b931260e0d8358965a5bb73f329"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '114'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t
     body:
       encoding: UTF-8
       string: |
@@ -261,23 +261,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"54d5eee0dec012caf3c2eacc4f7fa5d721d32acc"'
+      - '"4265c3a2697bac7c1de0c7b75db893629c69325e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Content-Length:
       - '163'
       Location:
-      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9
+      - http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9
+      string: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
     body:
       encoding: US-ASCII
       string: ''
@@ -296,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"179a03fd09a9602f1d60c3e579d4eb2d31218df8"'
+      - '"38a9ad51f1688281e260fea36ba13141449c72b5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -315,7 +315,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -331,19 +331,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c
     body:
       encoding: US-ASCII
       string: ''
@@ -362,9 +362,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"03d113afb2a1cb85a354c26c33cbe27d26092717"'
+      - '"4c9e087e18cf2801b598dd8d2f337f1b0439822b"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -381,7 +381,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -397,15 +397,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425
     body:
       encoding: US-ASCII
       string: ''
@@ -424,9 +424,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"54d5eee0dec012caf3c2eacc4f7fa5d721d32acc"'
+      - '"4265c3a2697bac7c1de0c7b75db893629c69325e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -443,7 +443,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2571'
+      - '2616'
       Content-Type:
       - application/x-turtle
     body:
@@ -459,23 +459,23 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item2>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item2>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item1>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#default>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item2>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#default>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/small>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item2>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item1>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd
     body:
       encoding: US-ASCII
       string: ''
@@ -494,9 +494,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"179a03fd09a9602f1d60c3e579d4eb2d31218df8"'
+      - '"38a9ad51f1688281e260fea36ba13141449c72b5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -513,7 +513,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1880'
+      - '1925'
       Content-Type:
       - application/x-turtle
     body:
@@ -529,19 +529,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9>
+        <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c
     body:
       encoding: US-ASCII
       string: ''
@@ -560,9 +560,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"03d113afb2a1cb85a354c26c33cbe27d26092717"'
+      - '"4c9e087e18cf2801b598dd8d2f337f1b0439822b"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -579,7 +579,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1338'
+      - '1383'
       Content-Type:
       - application/x-turtle
     body:
@@ -595,15 +595,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/b/fd/80/4c/58/fd804c58-d507-4757-9486-06e7ce471d2a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/b/77/5f/13/81/775f1381-2258-4695-870c-2387d510b72c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9
+    uri: http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425
     body:
       encoding: US-ASCII
       string: ''
@@ -622,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"54d5eee0dec012caf3c2eacc4f7fa5d721d32acc"'
+      - '"4265c3a2697bac7c1de0c7b75db893629c69325e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:32 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -641,7 +641,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2571'
+      - '2616'
       Content-Type:
       - application/x-turtle
     body:
@@ -657,18 +657,18 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9>
-        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item2>
-        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item1>
-        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#default>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item2>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#item1>
-        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
-        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/d2/23/26/20/d2232620-ff90-4c21-9a1c-839202b7856b/t/4f/40/8c/2f/4f408c2f-6202-460f-9b89-f8c8929bfad9#default>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425>
+        a oa:Choice , ldp:BasicContainer ;\n\toa:item <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item2>
+        , <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item1>
+        ;\n\toa:default <http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#default>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#default>
         a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/small>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item2>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/huge>
+        .\n\n<http://localhost:8983/fedora/rest/anno/choice_integration_specs/5a/62/4f/e6/5a624fe6-0cd0-4757-8d33-ecd1b9ac82bd/t/7c/5b/0e/a9/7c5b0ea9-8dbf-4f87-a0d6-8fa035e2c425#item1>
+        a dcmitype:Image ;\n\ttriannon:externalReference <http://images.com/large>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:00:57 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:32 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/after_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       message: Gone
     headers:
       Link:
-      - <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/fcr:tombstone>;
+      - <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/fcr:tombstone>;
         rel="hasTombstone"
       Content-Type:
       - text/html;charset=ISO-8859-1
@@ -29,10 +29,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     body:
       encoding: US-ASCII
       string: ''
@@ -47,9 +47,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b1eb78f153fc7d162e18c31ec4d95569ae23cec4"'
+      - '"566b661a04d3178f2c5a38044305b23bbae7617e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -68,10 +68,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     body:
       encoding: US-ASCII
       string: ''
@@ -93,10 +93,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -116,10 +116,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: head
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     body:
       encoding: US-ASCII
       string: ''
@@ -134,9 +134,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"050d02f87ee57a910462f933bba9e9cc1f153d51"'
+      - '"b44e16674d91400b4bfef52406968e0846e4db7e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -155,10 +155,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     body:
       encoding: US-ASCII
       string: ''
@@ -180,10 +180,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/fcr:tombstone
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/fcr:tombstone
     body:
       encoding: US-ASCII
       string: ''
@@ -203,7 +203,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -221,9 +221,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"60bca1cb4c33df03f2ada1ae7e44667f2bfc05e9"'
+      - '"57df1fb902b8c19996b6bce12aea0954963fd645"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -242,7 +242,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -267,7 +267,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/fcr:tombstone
@@ -290,13 +290,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -314,13 +314,13 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -336,9 +336,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>0}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -360,7 +360,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>9}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>10}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4ea68f5da2b2962593b7299fd2b6d2fd1bfd6770"'
+      - '"13dda47114e5832fe85d113a63f07f6a56f1b45e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:37:47 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:03 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:03 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f972c87e24c0d6d4c5ffce8bf625f0297a366c58"'
+      - '"560966a3089a5fb9b4e59b6e983199ab1c831bd4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '61'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/solr_integration_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/deletes_from_Solr.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f972c87e24c0d6d4c5ffce8bf625f0297a366c58"'
+      - '"560966a3089a5fb9b4e59b6e983199ab1c831bd4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8788bf6de3a2afa6d3e328c568080f56d9e5b049"'
+      - '"27def44ca8b9692342a5d09167e23c29a06eaca0"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"96b03f3ffb3ad2fd0a6538f56f405f840b88ca79"'
+      - '"30bb4ec8c499b17356c431907ecacaa0767dd9a7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"00bd1914cca1e5969afb0998e0e93038252c307b"'
+      - '"970a7a0df881d7653d1395eea20c0b74a837f337"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b/89/84/c9/e0/8984c9e0-2a38-42f5-b2f8-0ae0697bb6a3
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b/61/55/40/32/61554032-84ed-4929-9110-516886aa721c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b/89/84/c9/e0/8984c9e0-2a38-42f5-b2f8-0ae0697bb6a3
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b/61/55/40/32/61554032-84ed-4929-9110-516886aa721c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"36a6e158e6b0cf0c1d8db0c63a9fb563beab9aa6"'
+      - '"034365a0cedda8a4657588b1dffd5c60ed58b432"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:04 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"dc4b48ddef2f6f3c95aea07fcbe188046d04a173"'
+      - '"18ed5211841d19406ac06bc63bedd011e37baeca"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:05 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t/a1/67/fc/e4/a167fce4-19b9-462a-a13e-e887dcacd860
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t/a4/d1/e7/dc/a4d1e7dc-a246-442f-ba82-0bc7f02739a6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t/a1/67/fc/e4/a167fce4-19b9-462a-a13e-e887dcacd860
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t/a4/d1/e7/dc/a4d1e7dc-a246-442f-ba82-0bc7f02739a6
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:05 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1ffb5756e06e4eb89d18d7e5234057f79c155b86"'
+      - '"2ae0f7961b866f5ac57384ca895497ff0b0f6b9c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -305,7 +305,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1870'
+      - '1915'
       Content-Type:
       - application/x-turtle
     body:
@@ -321,19 +321,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b/89/84/c9/e0/8984c9e0-2a38-42f5-b2f8-0ae0697bb6a3>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t/a1/67/fc/e4/a167fce4-19b9-462a-a13e-e887dcacd860>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b/61/55/40/32/61554032-84ed-4929-9110-516886aa721c>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t/a4/d1/e7/dc/a4d1e7dc-a246-442f-ba82-0bc7f02739a6>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:05 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b/89/84/c9/e0/8984c9e0-2a38-42f5-b2f8-0ae0697bb6a3
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b/61/55/40/32/61554032-84ed-4929-9110-516886aa721c
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"00bd1914cca1e5969afb0998e0e93038252c307b"'
+      - '"970a7a0df881d7653d1395eea20c0b74a837f337"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -371,7 +371,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1383'
+      - '1428'
       Content-Type:
       - application/x-turtle
     body:
@@ -387,15 +387,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/b/89/84/c9/e0/8984c9e0-2a38-42f5-b2f8-0ae0697bb6a3>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/b/61/55/40/32/61554032-84ed-4929-9110-516886aa721c>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:05 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t/a1/67/fc/e4/a167fce4-19b9-462a-a13e-e887dcacd860
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t/a4/d1/e7/dc/a4d1e7dc-a246-442f-ba82-0bc7f02739a6
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"dc4b48ddef2f6f3c95aea07fcbe188046d04a173"'
+      - '"18ed5211841d19406ac06bc63bedd011e37baeca"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:05 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -433,7 +433,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1340'
+      - '1385'
       Content-Type:
       - application/x-turtle
     body:
@@ -449,24 +449,24 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b/t/a1/67/fc/e4/a167fce4-19b9-462a-a13e-e887dcacd860>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2/t/a4/d1/e7/dc/a4d1e7dc-a246-442f-ba82-0bc7f02739a6>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:05 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b</field><field
+        name="id">solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277452670580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b","@type":"oa:Annotation","hasBody":"_:g70277452670580","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313931333560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2","@type":"oa:Annotation","hasBody":"_:g70313931333560","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,12 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>104}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>81}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:06 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:06 GMT
+      - Wed, 08 Jul 2015 21:14:39 GMT
       Etag:
-      - '"YzAwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"ZjQwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -513,26 +513,26 @@ http_interactions:
             'status'=>0,
             'QTime'=>6,
             'params'=>{
-              'id'=>'solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b',
+              'id'=>'solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b',
+                'id'=>'solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277452670580","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b","@type":"oa:Annotation","hasBody":"_:g70277452670580","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1503545876479475712,
-                'timestamp'=>'2015-06-09T23:38:05.91Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313931333560","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2","@type":"oa:Annotation","hasBody":"_:g70313931333560","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506164163233185792,
+                'timestamp'=>'2015-07-08T21:14:38.765Z'}]
           }}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:07 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:39 GMT
 - request:
     method: delete
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2
     body:
       encoding: US-ASCII
       string: ''
@@ -554,13 +554,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:07 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b</id></delete>
+      string: <?xml version="1.0" encoding="UTF-8"?><delete><id>solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2</id></delete>
     headers:
       Content-Type:
       - text/xml
@@ -578,7 +578,7 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:07 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:39 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -600,12 +600,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>11}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>14}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:07 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:39 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:07 GMT
+      - Wed, 08 Jul 2015 21:14:39 GMT
       Etag:
-      - '"YTAwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"OGMwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -629,12 +629,12 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>0,
+            'QTime'=>1,
             'params'=>{
-              'id'=>'solr_integration_specs/15/6b/b1/7b/156bb17b-6749-41f8-95c2-7a23df5f3a6b',
+              'id'=>'solr_integration_specs/a6/65/78/9e/a665789e-93a9-4e0a-ad46-81d351905bf2',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]
           }}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/all_fields_in_Solr_doc.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8ea2cf79963c649315d9515d334436ddadc6ff6a"'
+      - '"b15f4d516f7cfc6058b504deaf1c63f458e8d441"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:04 GMT
+      - Wed, 08 Jul 2015 21:14:38 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:42 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0ae1c1a31c2f05c1f607099a32cd8cdb560bb3ca"'
+      - '"d408ba5653db4c7b0a3d4b5c53cf2f3c1bd63826"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:42 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:42 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1b5e0ccea2fca8af86fdaa681ea527ec8591db76"'
+      - '"8e6e61a43736e9de15bf35c7655291ca64862c10"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1edab108d58cffe0bcb4cecb26015d0a7d179fc8"'
+      - '"f1c8a686a4997acb2a008a5e9b61e5630632f3a6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b/5e/9e/d9/bb/5e9ed9bb-d4ac-4938-b5d6-83335d97aee9
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b/05/24/e1/65/0524e165-b407-4fc3-b9b4-6e4173f19475
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b/5e/9e/d9/bb/5e9ed9bb-d4ac-4938-b5d6-83335d97aee9
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b/05/24/e1/65/0524e165-b407-4fc3-b9b4-6e4173f19475
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1a9a64a27ef262e2cbf157cfe4831d12e25731f4"'
+      - '"cbd3ec35b43a2ea3cf3451cd9db062cd64812c34"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d65d732152697bfd45a7925d5edb9da15648da2d"'
+      - '"3cfe187337cc70ad903b2cc62fccfdd55c2ad465"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t/7a/08/77/ea/7a0877ea-a88d-4b8b-983a-612af4f00532
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t/b3/3a/8f/58/b33a8f58-29ea-4607-9b22-a95258c7e671
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t/7a/08/77/ea/7a0877ea-a88d-4b8b-983a-612af4f00532
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t/b3/3a/8f/58/b33a8f58-29ea-4607-9b22-a95258c7e671
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"b1eb78f153fc7d162e18c31ec4d95569ae23cec4"'
+      - '"566b661a04d3178f2c5a38044305b23bbae7617e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -305,7 +305,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1870'
+      - '1915'
       Content-Type:
       - application/x-turtle
     body:
@@ -321,19 +321,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t/7a/08/77/ea/7a0877ea-a88d-4b8b-983a-612af4f00532>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b/5e/9e/d9/bb/5e9ed9bb-d4ac-4938-b5d6-83335d97aee9>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b/05/24/e1/65/0524e165-b407-4fc3-b9b4-6e4173f19475>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t/b3/3a/8f/58/b33a8f58-29ea-4607-9b22-a95258c7e671>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b/5e/9e/d9/bb/5e9ed9bb-d4ac-4938-b5d6-83335d97aee9
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b/05/24/e1/65/0524e165-b407-4fc3-b9b4-6e4173f19475
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1edab108d58cffe0bcb4cecb26015d0a7d179fc8"'
+      - '"f1c8a686a4997acb2a008a5e9b61e5630632f3a6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -371,7 +371,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1383'
+      - '1428'
       Content-Type:
       - application/x-turtle
     body:
@@ -387,15 +387,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/b/5e/9e/d9/bb/5e9ed9bb-d4ac-4938-b5d6-83335d97aee9>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/b/05/24/e1/65/0524e165-b407-4fc3-b9b4-6e4173f19475>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t/7a/08/77/ea/7a0877ea-a88d-4b8b-983a-612af4f00532
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t/b3/3a/8f/58/b33a8f58-29ea-4607-9b22-a95258c7e671
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d65d732152697bfd45a7925d5edb9da15648da2d"'
+      - '"3cfe187337cc70ad903b2cc62fccfdd55c2ad465"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -433,7 +433,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1340'
+      - '1385'
       Content-Type:
       - application/x-turtle
     body:
@@ -449,24 +449,24 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f/t/7a/08/77/ea/7a0877ea-a88d-4b8b-983a-612af4f00532>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071/t/b3/3a/8f/58/b33a8f58-29ea-4607-9b22-a95258c7e671>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f</field><field
+        name="id">solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277492477000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f","@type":"oa:Annotation","hasBody":"_:g70277492477000","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313884678860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071","@type":"oa:Annotation","hasBody":"_:g70313884678860","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,12 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:10 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:43 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:43 GMT
       Etag:
-      - '"ZTAwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"Y2MwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -511,23 +511,23 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>1,
+            'QTime'=>2,
             'params'=>{
-              'id'=>'solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f',
+              'id'=>'solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f',
+                'id'=>'solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277492477000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/18/a4/9f/4d/18a49f4d-9a3c-452f-8035-83184ca6028f","@type":"oa:Annotation","hasBody":"_:g70277492477000","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1503545881177096192,
-                'timestamp'=>'2015-06-09T23:38:10.417Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313884678860","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/7e/04/ac/cc/7e04accc-687d-4ff1-86c5-881e21a58071","@type":"oa:Annotation","hasBody":"_:g70313884678860","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506164167923466240,
+                'timestamp'=>'2015-07-08T21:14:43.239Z'}]
           }}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_Solr/writes_to_Solr/has_non-empty_id_value_for_outer_node_of_anno_jsonld.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9dcda772b3447a62411a5a89ae9a947b1fd6fb88"'
+      - '"cbfb2256005131bd48099b4d47b621fbf101700a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:10 GMT
+      - Wed, 08 Jul 2015 21:14:42 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4588dd4c68e21ccc7b516e0d080fee250921d05e"'
+      - '"089c17f21884bdfdc28201092c1248ba40afb99e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Content-Length:
       - '110'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0dcd3a48c7c2c012c884f0d5aaa998e07ff25d5e"'
+      - '"933ac7532ab06c36764b8f39bf436d1320511ddf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"da17a63418d6f734e09107927229a541c78f3445"'
+      - '"352120116275e6f767092ceab69f735d1a8bdc23"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b/e5/aa/0e/16/e5aa0e16-cd53-4851-b75b-67975bb5356c
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b/12/aa/8d/60/12aa8d60-6448-4ef9-bb0a-b098c29bd1e9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b/e5/aa/0e/16/e5aa0e16-cd53-4851-b75b-67975bb5356c
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b/12/aa/8d/60/12aa8d60-6448-4ef9-bb0a-b098c29bd1e9
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a3702b0bbedfcec636580c6e462ec53ecbdc91ab"'
+      - '"e1d5b12f6a4c5f8a02d477b091e3550324eb34b0"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Content-Length:
       - '112'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ee6b69efd5b8764f4432c5728ce6756dba79e22f"'
+      - '"1c3c57a48db0023158466e79625ebd807761aff4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Content-Length:
       - '161'
       Location:
-      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t/1f/43/fd/f0/1f43fdf0-ca63-4a4d-98a8-f5ab8fbfbe04
+      - http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t/fc/b0/e8/41/fcb0e841-c33d-408c-bbed-9afbdc4b470d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t/1f/43/fd/f0/1f43fdf0-ca63-4a4d-98a8-f5ab8fbfbe04
+      string: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t/fc/b0/e8/41/fcb0e841-c33d-408c-bbed-9afbdc4b470d
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"050d02f87ee57a910462f933bba9e9cc1f153d51"'
+      - '"b44e16674d91400b4bfef52406968e0846e4db7e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -305,7 +305,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1870'
+      - '1915'
       Content-Type:
       - application/x-turtle
     body:
@@ -321,19 +321,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b>
-        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t/1f/43/fd/f0/1f43fdf0-ca63-4a4d-98a8-f5ab8fbfbe04>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b/e5/aa/0e/16/e5aa0e16-cd53-4851-b75b-67975bb5356c>
+        <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b>
+        , <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t/fc/b0/e8/41/fcb0e841-c33d-408c-bbed-9afbdc4b470d>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b/12/aa/8d/60/12aa8d60-6448-4ef9-bb0a-b098c29bd1e9>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b/e5/aa/0e/16/e5aa0e16-cd53-4851-b75b-67975bb5356c
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b/12/aa/8d/60/12aa8d60-6448-4ef9-bb0a-b098c29bd1e9
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"da17a63418d6f734e09107927229a541c78f3445"'
+      - '"352120116275e6f767092ceab69f735d1a8bdc23"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -371,7 +371,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1383'
+      - '1428'
       Content-Type:
       - application/x-turtle
     body:
@@ -387,15 +387,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/b/e5/aa/0e/16/e5aa0e16-cd53-4851-b75b-67975bb5356c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/b/12/aa/8d/60/12aa8d60-6448-4ef9-bb0a-b098c29bd1e9>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"Solr
         integration test\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t/1f/43/fd/f0/1f43fdf0-ca63-4a4d-98a8-f5ab8fbfbe04
+    uri: http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t/fc/b0/e8/41/fcb0e841-c33d-408c-bbed-9afbdc4b470d
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ee6b69efd5b8764f4432c5728ce6756dba79e22f"'
+      - '"1c3c57a48db0023158466e79625ebd807761aff4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:11 GMT
+      - Wed, 08 Jul 2015 21:14:44 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -433,7 +433,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1340'
+      - '1385'
       Content-Type:
       - application/x-turtle
     body:
@@ -449,24 +449,24 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe/t/1f/43/fd/f0/1f43fdf0-ca63-4a4d-98a8-f5ab8fbfbe04>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81/t/fc/b0/e8/41/fcb0e841-c33d-408c-bbed-9afbdc4b470d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://example.com/solr-integration-test>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><add commitWithin="500"><doc><field
-        name="id">solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe</field><field
+        name="id">solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81</field><field
         name="root">solr_integration_specs</field><field name="motivation">commenting</field><field
         name="target_url">http://example.com/solr-integration-test</field><field name="target_type">external_URI</field><field
         name="body_type">content_as_text</field><field name="body_chars_exact">Solr
-        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277482380980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
-        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe","@type":"oa:Annotation","hasBody":"_:g70277482380980","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
+        integration test</field><field name="anno_jsonld">{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313932248000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr
+        integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81","@type":"oa:Annotation","hasBody":"_:g70313932248000","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}</field></doc></add>
     headers:
       Content-Type:
       - text/xml
@@ -482,12 +482,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>4}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>3}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:11 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:44 GMT
 - request:
     method: get
-    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe&wt=ruby
+    uri: http://localhost:8983/solr/triannon/doc?id=solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81&wt=ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -498,9 +498,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Tue, 09 Jun 2015 23:38:12 GMT
+      - Wed, 08 Jul 2015 21:14:45 GMT
       Etag:
-      - '"OTAwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"YWMwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - text/plain;charset=UTF-8
       Transfer-Encoding:
@@ -511,23 +511,23 @@ http_interactions:
         {
           'responseHeader'=>{
             'status'=>0,
-            'QTime'=>1,
+            'QTime'=>0,
             'params'=>{
-              'id'=>'solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe',
+              'id'=>'solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81',
               'wt'=>'ruby'}},
           'response'=>{'numFound'=>1,'start'=>0,'docs'=>[
               {
-                'id'=>'solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe',
+                'id'=>'solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81',
                 'root'=>'solr_integration_specs',
                 'motivation'=>['commenting'],
                 'target_url'=>['http://example.com/solr-integration-test'],
                 'target_type'=>['external_URI'],
                 'body_type'=>['content_as_text'],
                 'body_chars_exact'=>['Solr integration test'],
-                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70277482380980","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/a8/fe/e6/ea/a8fee6ea-22e0-4cd0-a028-015b9caa7fbe","@type":"oa:Annotation","hasBody":"_:g70277482380980","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
-                '_version_'=>1503545882592673792,
-                'timestamp'=>'2015-06-09T23:38:11.766Z'}]
+                'anno_jsonld'=>'{"@context":"http://www.w3.org/ns/oa-context-20130208.json","@graph":[{"@id":"_:g70313932248000","@type":["dctypes:Text","cnt:ContentAsText"],"chars":"Solr integration test"},{"@id":"http://your.triannon-server.com/annotations/solr_integration_specs/45/30/02/e3/453002e3-f2fa-4a5e-aae5-643140e36a81","@type":"oa:Annotation","hasBody":"_:g70313932248000","hasTarget":"http://example.com/solr-integration-test","motivatedBy":"oa:commenting"}]}',
+                '_version_'=>1506164169388326912,
+                'timestamp'=>'2015-07-08T21:14:44.637Z'}]
           }}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 23:38:12 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"42043a912ae43a594ad4f7488a2b9a57174c39d4"'
+      - '"9f68d89eea0ae611b80f58789c22e41632eb75e1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c2a93bd1a7189ce23352e4bc5f186f6644c61eb0"'
+      - '"d0d9962e0a1e6262fcd9193991241061b6826c06"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"01388ccd8895ac30069f83bc78c1f8afbdb9eab1"'
+      - '"70687cf8d1d6a05930f9463a3b46b1d7ccb57cee"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:45 GMT
       Content-Length:
       - '69'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:45 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_FragmentSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"423249e91fce3fb11ddacfbd23eae94d6d1ae916"'
+      - '"98449bb5f0bfd22145d62b6bf59a5682427fac44"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3b234b1f8982b8ea2f3bb3cfb33232a58f6aa602"'
+      - '"4cff47604257e1a314f93649e38d4641e6af9081"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"469c9de56ba92af0650f53ea28ae580ba324a9ca"'
+      - '"56ea13cb4b50d1637c0bfa900fb2809f5ad9b0de"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b
     body:
       encoding: UTF-8
       string: |
@@ -169,23 +169,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"cab619d55ae470baba4996a25cc388896f564bfa"'
+      - '"9f470411468ce5efbc83f2961460d4a0061dc2d3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
     body:
       encoding: UTF-8
       string: |
@@ -195,7 +195,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -215,23 +215,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"db3a505ebc6a764878cabc2b8c006ab80c31f28f"'
+      - '"0196bee5b424a481844dc4674b1094f0c1d957bd"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1098693ffb0a731d6dc68402b8278ef169712c06"'
+      - '"6e70b17a8313487c00f40ab73c88a02bcf00bf8d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cf8a6d11a10274c05353bfb290f592db66a06f75"'
+      - '"b5fef05046c5f18e854ac39159c4bb98849c35fa"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -312,7 +312,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -328,19 +328,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cab619d55ae470baba4996a25cc388896f564bfa"'
+      - '"9f470411468ce5efbc83f2961460d4a0061dc2d3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -378,7 +378,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2149'
+      - '2194'
       Content-Type:
       - application/x-turtle
     body:
@@ -394,20 +394,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/57/9b/1e/1d/579b1e1d-cc99-4080-9e9f-d2f0638fce37>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/68/b3/b9/4e/68b3b94e-3f33-4b5a-9c1e-7726ee111b8c>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/57/9b/1e/1d/579b1e1d-cc99-4080-9e9f-d2f0638fce37>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/68/b3/b9/4e/68b3b94e-3f33-4b5a-9c1e-7726ee111b8c>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1098693ffb0a731d6dc68402b8278ef169712c06"'
+      - '"6e70b17a8313487c00f40ab73c88a02bcf00bf8d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -445,7 +445,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -461,15 +461,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cf8a6d11a10274c05353bfb290f592db66a06f75"'
+      - '"b5fef05046c5f18e854ac39159c4bb98849c35fa"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -507,7 +507,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -523,19 +523,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cab619d55ae470baba4996a25cc388896f564bfa"'
+      - '"9f470411468ce5efbc83f2961460d4a0061dc2d3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -573,7 +573,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2149'
+      - '2194'
       Content-Type:
       - application/x-turtle
     body:
@@ -589,20 +589,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/57/9b/1e/1d/579b1e1d-cc99-4080-9e9f-d2f0638fce37>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/b/9f/b0/3d/e0/9fb03de0-61dc-406d-b8be-517577609c1a#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/68/b3/b9/4e/68b3b94e-3f33-4b5a-9c1e-7726ee111b8c>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/b/67/78/a0/82/6778a082-40c5-4893-935b-bae2113bcb9c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/57/9b/1e/1d/579b1e1d-cc99-4080-9e9f-d2f0638fce37>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/68/b3/b9/4e/68b3b94e-3f33-4b5a-9c1e-7726ee111b8c>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2
     body:
       encoding: US-ASCII
       string: ''
@@ -621,9 +621,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1098693ffb0a731d6dc68402b8278ef169712c06"'
+      - '"6e70b17a8313487c00f40ab73c88a02bcf00bf8d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -640,7 +640,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -656,10 +656,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/71/8a/36/bf/718a36bf-2d74-486a-b42a-9ae07a4793b2/t/62/3a/88/8c/623a888c-4086-4962-8635-4768ef999b5f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/9a/4f/d9/5f/9a4fd95f-6ff6-419a-a7f6-a2b82f210540/t/59/f6/45/33/59f64533-8418-4a25-b771-ee702459c0a2>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextPositionSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c62abefb53f0ffe31aeeca372dec65bc31fd8dbd"'
+      - '"bd399f12745f524a2e6d7d8050c50ae81703da90"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5ba4f474ca2f4a1c34064ff06ae5707980acb1fb"'
+      - '"58580ba9e367ffff4cc4f21735cffc610df48f94"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ea33f4951f617d1c4124188dd4bb56fe4425fb2a"'
+      - '"9c6bdae48fa166f35f7bd505e5ac966c55e37700"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b
     body:
       encoding: UTF-8
       string: |
@@ -168,23 +168,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9351277a63980b2452351a82e53fca67b7e85582"'
+      - '"0333d31d813ee7ed42655a349b46c4c894b9bc3e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
     body:
       encoding: UTF-8
       string: |
@@ -194,7 +194,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -214,23 +214,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"841dc418f584b84c5623fb3c021c7857d0c25c44"'
+      - '"24d9311c207f6916035932cfbcadac738d3095e3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t
     body:
       encoding: UTF-8
       string: |
@@ -257,23 +257,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"58a25da3d0849694477fe07dd5cde3b5213df343"'
+      - '"9016d2bb5bd6da805c31cca34ed0701954cc812c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
     body:
       encoding: US-ASCII
       string: ''
@@ -292,9 +292,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"777339ae5c5ecd8f4ad37573a90ad95e1c5639c7"'
+      - '"afd484ba9f1126c05c4e9496cc7cfc199482f4e2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -311,7 +311,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -327,19 +327,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc
     body:
       encoding: US-ASCII
       string: ''
@@ -358,9 +358,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9351277a63980b2452351a82e53fca67b7e85582"'
+      - '"0333d31d813ee7ed42655a349b46c4c894b9bc3e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -377,7 +377,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2166'
+      - '2211'
       Content-Type:
       - application/x-turtle
     body:
@@ -393,21 +393,21 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/3a/e0/c5/76/3ae0c576-0b32-4c2c-af7f-49dbd9d33637>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/93/22/7d/6d/93227d6d-269c-44eb-af12-ad6fe908eeff>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/3a/e0/c5/76/3ae0c576-0b32-4c2c-af7f-49dbd9d33637>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/93/22/7d/6d/93227d6d-269c-44eb-af12-ad6fe908eeff>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3
     body:
       encoding: US-ASCII
       string: ''
@@ -426,9 +426,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"58a25da3d0849694477fe07dd5cde3b5213df343"'
+      - '"9016d2bb5bd6da805c31cca34ed0701954cc812c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -445,7 +445,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -461,15 +461,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"777339ae5c5ecd8f4ad37573a90ad95e1c5639c7"'
+      - '"afd484ba9f1126c05c4e9496cc7cfc199482f4e2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -507,7 +507,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -523,19 +523,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9351277a63980b2452351a82e53fca67b7e85582"'
+      - '"0333d31d813ee7ed42655a349b46c4c894b9bc3e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -573,7 +573,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2166'
+      - '2211'
       Content-Type:
       - application/x-turtle
     body:
@@ -589,21 +589,21 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/3a/e0/c5/76/3ae0c576-0b32-4c2c-af7f-49dbd9d33637>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/b/c6/4e/25/6d/c64e256d-8f5a-456d-a56b-3262b5363725#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/93/22/7d/6d/93227d6d-269c-44eb-af12-ad6fe908eeff>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/b/39/be/b4/48/39beb448-d177-4b34-8730-e2fec50d83dc#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/3a/e0/c5/76/3ae0c576-0b32-4c2c-af7f-49dbd9d33637>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/93/22/7d/6d/93227d6d-269c-44eb-af12-ad6fe908eeff>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3
     body:
       encoding: US-ASCII
       string: ''
@@ -622,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"58a25da3d0849694477fe07dd5cde3b5213df343"'
+      - '"9016d2bb5bd6da805c31cca34ed0701954cc812c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -641,7 +641,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -657,10 +657,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fc/cf/72/61/fccf7261-45ec-41fa-8b1c-df947fcd7758/t/82/87/a0/99/8287a099-0372-4dbd-837e-7295d7e3d981>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/01/1e/7c/d7/011e7cd7-2177-4977-9d9b-80fc3a81b1de/t/c6/1b/c5/69/c61bc569-0294-4f2f-8634-b5fa64b7ede3>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/body_is_TextQuoteSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"63f7113c95193c3852740fe2da3b048122852b71"'
+      - '"65ac23d12880658a4db3840be7fc3cd0c5467802"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5fa3021871a0ef44fdf72d1ec83566e6fa042eba"'
+      - '"758bdadabc761922bd6a7057a0dd694bac503340"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"440d61808c70ff7c6a7e97c34be83d127809ccb3"'
+      - '"61edfa0d3fec789f166a1cfd694bcedc8fee249c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b
     body:
       encoding: UTF-8
       string: |
@@ -169,23 +169,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c0e8dfe2332c379b1624eaeae537677371e9b12c"'
+      - '"8cf9ab242ff5f3bc4505116c8626322ba4f4775e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
     body:
       encoding: UTF-8
       string: |
@@ -195,7 +195,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -215,23 +215,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9fb6d1bf522ddd42302e3c543c229acdb847bc43"'
+      - '"dc0a03de1c0676d0fe8c0bb79cd2dda47abb03a9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4edec4ddee65ba1265abcad966bea6d1331f0299"'
+      - '"efa57669d7e5137e1c56b1afb9e749637fe7463c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df5101153d1bcc1f5a2ba0f298e7605739f2013a"'
+      - '"d89a0335c2779bb86f008f50d8c13c34eb8bbdc9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -312,7 +312,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -328,19 +328,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c0e8dfe2332c379b1624eaeae537677371e9b12c"'
+      - '"8cf9ab242ff5f3bc4505116c8626322ba4f4775e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -378,7 +378,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2281'
+      - '2326'
       Content-Type:
       - application/x-turtle
     body:
@@ -394,22 +394,22 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/aa/23/86/f3/aa2386f3-0b7a-401d-bcd1-26c741dee553>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/ff/c3/9e/87/ffc39e87-25c4-4390-9416-b7ba53cfcc86>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/aa/23/86/f3/aa2386f3-0b7a-401d-bcd1-26c741dee553>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ff/c3/9e/87/ffc39e87-25c4-4390-9416-b7ba53cfcc86>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa
     body:
       encoding: US-ASCII
       string: ''
@@ -428,9 +428,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4edec4ddee65ba1265abcad966bea6d1331f0299"'
+      - '"efa57669d7e5137e1c56b1afb9e749637fe7463c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -447,7 +447,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -463,15 +463,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df5101153d1bcc1f5a2ba0f298e7605739f2013a"'
+      - '"d89a0335c2779bb86f008f50d8c13c34eb8bbdc9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -509,7 +509,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -525,19 +525,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c0e8dfe2332c379b1624eaeae537677371e9b12c"'
+      - '"8cf9ab242ff5f3bc4505116c8626322ba4f4775e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -575,7 +575,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2281'
+      - '2326'
       Content-Type:
       - application/x-turtle
     body:
@@ -591,22 +591,22 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/aa/23/86/f3/aa2386f3-0b7a-401d-bcd1-26c741dee553>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/b/fa/61/92/23/fa619223-5422-453f-ba73-a8854bce90f5#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/ff/c3/9e/87/ffc39e87-25c4-4390-9416-b7ba53cfcc86>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/b/59/a1/00/60/59a10060-3205-42bd-83df-654056e9cac4#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/aa/23/86/f3/aa2386f3-0b7a-401d-bcd1-26c741dee553>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/ff/c3/9e/87/ffc39e87-25c4-4390-9416-b7ba53cfcc86>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa
     body:
       encoding: US-ASCII
       string: ''
@@ -625,9 +625,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4edec4ddee65ba1265abcad966bea6d1331f0299"'
+      - '"efa57669d7e5137e1c56b1afb9e749637fe7463c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -644,7 +644,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -660,10 +660,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c5/72/ed/34/c572ed34-6e41-45cc-86f7-922ad66908c0/t/83/b3/ff/3d/83b3ff3d-40f6-4d5d-86a7-eaa38ce16a06>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/dd/ff/6f/00/ddff6f00-e42b-4ff0-854c-96f511e7e3f8/t/62/a2/d2/3e/62a2d23e-19ca-4301-8e92-b2c2799440aa>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/source_uri_has_additional_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd936f2db4da9bfaa33bc8279953e57dd7266608"'
+      - '"c537acef9afe5c2476479d1d60d19be8490921fe"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c6089db2000b15918e28a301f228b1891b315123"'
+      - '"ddc7afe038a71f918e320e81f143618381a66f48"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"749fd086875d4beb0cf01c9973d75130da4e2316"'
+      - '"c6ff7140fc481e4d5d4e75e09d6c6b3bbe3f75cc"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"26477da0a8dbe8ec283e20b9da74040455fbe2e6"'
+      - '"82069b315e9400b6ea3bcf724eb1209d95ba8f4e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d5efba64deaa4979df7386beb4442111fbc80c1e"'
+      - '"12de5366d5511e22c72da6c684f59800c6d80e89"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t
     body:
       encoding: UTF-8
       string: |
@@ -260,23 +260,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"bb12107c063d2b323641cac55837832abfefed23"'
+      - '"5dc6fa0ba1e8a151572367da321edb19641a4b3f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
     body:
       encoding: US-ASCII
       string: ''
@@ -295,9 +295,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"88fb35c90af3e5b7b4d1c403b8ce0d3f04ebdd45"'
+      - '"7d3e704776a4eecdb24cb4560581bdd9fdc0fbf4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -314,7 +314,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -330,19 +330,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e
     body:
       encoding: US-ASCII
       string: ''
@@ -361,9 +361,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"26477da0a8dbe8ec283e20b9da74040455fbe2e6"'
+      - '"82069b315e9400b6ea3bcf724eb1209d95ba8f4e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -380,7 +380,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -396,15 +396,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b
     body:
       encoding: US-ASCII
       string: ''
@@ -423,9 +423,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bb12107c063d2b323641cac55837832abfefed23"'
+      - '"5dc6fa0ba1e8a151572367da321edb19641a4b3f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -442,7 +442,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2169'
+      - '2214'
       Content-Type:
       - application/x-turtle
     body:
@@ -458,20 +458,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/38/f9/68/0e/38f9680e-93b0-4a79-b2a7-020faed3b192>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/57/25/0f/12/57250f12-fd8d-4e74-b07a-dd222fd9882f>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b#source>
         a dcmitype:Image ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/38/f9/68/0e/38f9680e-93b0-4a79-b2a7-020faed3b192>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/57/25/0f/12/57250f12-fd8d-4e74-b07a-dd222fd9882f>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"88fb35c90af3e5b7b4d1c403b8ce0d3f04ebdd45"'
+      - '"7d3e704776a4eecdb24cb4560581bdd9fdc0fbf4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -509,7 +509,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -525,19 +525,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"26477da0a8dbe8ec283e20b9da74040455fbe2e6"'
+      - '"82069b315e9400b6ea3bcf724eb1209d95ba8f4e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -575,7 +575,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -591,15 +591,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/b/58/58/5a/3d/58585a3d-066a-4c39-b578-9deb343e8a11>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/b/43/c3/9f/8d/43c39f8d-8f32-41a7-9173-06c0eff4a23e>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b
     body:
       encoding: US-ASCII
       string: ''
@@ -618,9 +618,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"bb12107c063d2b323641cac55837832abfefed23"'
+      - '"5dc6fa0ba1e8a151572367da321edb19641a4b3f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:36 GMT
+      - Wed, 08 Jul 2015 21:14:48 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -637,7 +637,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2169'
+      - '2214'
       Content-Type:
       - application/x-turtle
     body:
@@ -653,15 +653,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/38/f9/68/0e/38f9680e-93b0-4a79-b2a7-020faed3b192>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/e8/58/6f/2a/e8586f2a-1321-4bef-8446-e16bbcb1589b/t/42/ca/99/97/42ca9997-4166-40db-aa54-34d4b3398324#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/57/25/0f/12/57250f12-fd8d-4e74-b07a-dd222fd9882f>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/ff/1f/0b/b5/ff1f0bb5-0615-4a34-a687-26e927c5531c/t/d7/e6/51/dd/d7e651dd-4b48-4143-bfc2-c0ee402e792b#source>
         a dcmitype:Image ;\n\ttriannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/38/f9/68/0e/38f9680e-93b0-4a79-b2a7-020faed3b192>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/57/25/0f/12/57250f12-fd8d-4e74-b07a-dd222fd9882f>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:36 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:49 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_FragmentSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"01388ccd8895ac30069f83bc78c1f8afbdb9eab1"'
+      - '"70687cf8d1d6a05930f9463a3b46b1d7ccb57cee"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:45 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e301047191c2b0b5c1d8433c2347de4a340d653d"'
+      - '"deedca0db7b2a647a361f48563be7b50930090fa"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"05931556528210b75b8353c2ea874bb522177ee7"'
+      - '"49170e16f08d47aaaf04649baf032f162fd30c44"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"73a15d66908eb300c73c4321b80102a358431a5c"'
+      - '"5b0189d2e3d64308cf2a3736681275a4ee33c292"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b2d2b10e66531d2afdc79887f8af62222bd5b1ac"'
+      - '"cf2b85fbcdea6f35cc3d2a25a77f188863b8b1f1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c9435a6478a3c061bba7ca710e1c29aa9a359d02"'
+      - '"8eb04237dad9cafc9029bf03231d1d09439c62e5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f03a912fe229842e9c400539ec2234c783b58cf5"'
+      - '"59934f27e344053dd33586a4c241537d0f480383"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -312,7 +312,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -328,19 +328,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:33 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"73a15d66908eb300c73c4321b80102a358431a5c"'
+      - '"5b0189d2e3d64308cf2a3736681275a4ee33c292"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -378,7 +378,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -394,15 +394,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b
     body:
       encoding: US-ASCII
       string: ''
@@ -421,9 +421,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c9435a6478a3c061bba7ca710e1c29aa9a359d02"'
+      - '"8eb04237dad9cafc9029bf03231d1d09439c62e5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -440,7 +440,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2149'
+      - '2194'
       Content-Type:
       - application/x-turtle
     body:
@@ -456,20 +456,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/df/a9/c3/7a/dfa9c37a-1b10-4e84-8c1a-cfff8ecf5ed2>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/75/ad/08/6f/75ad086f-0cd0-4703-ab55-5e9f87caa52a>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/df/a9/c3/7a/dfa9c37a-1b10-4e84-8c1a-cfff8ecf5ed2>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/75/ad/08/6f/75ad086f-0cd0-4703-ab55-5e9f87caa52a>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f03a912fe229842e9c400539ec2234c783b58cf5"'
+      - '"59934f27e344053dd33586a4c241537d0f480383"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -507,7 +507,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -523,19 +523,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"73a15d66908eb300c73c4321b80102a358431a5c"'
+      - '"5b0189d2e3d64308cf2a3736681275a4ee33c292"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -573,7 +573,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -589,15 +589,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/b/a7/46/0e/81/a7460e81-3bc1-4ea8-b2c0-c29847da285f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/b/99/4f/98/a3/994f98a3-86f0-4802-beb4-b0ab8aa1cac1>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"c9435a6478a3c061bba7ca710e1c29aa9a359d02"'
+      - '"8eb04237dad9cafc9029bf03231d1d09439c62e5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:33 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -635,7 +635,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2149'
+      - '2194'
       Content-Type:
       - application/x-turtle
     body:
@@ -651,15 +651,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/df/a9/c3/7a/dfa9c37a-1b10-4e84-8c1a-cfff8ecf5ed2>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/b7/b3/99/03/b7b39903-d95c-4e84-8b43-38f2e56af85b/t/e2/61/78/1f/e261781f-3bd2-49f7-97aa-8c61e4f4e17f#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/75/ad/08/6f/75ad086f-0cd0-4703-ab55-5e9f87caa52a>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/c0/0b/5e/e3/c00b5ee3-eb75-48bb-93c4-fdb6c570ec5d/t/2a/7b/25/10/2a7b2510-2bc7-44a1-8e5d-c9c956372a3b#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/df/a9/c3/7a/dfa9c37a-1b10-4e84-8c1a-cfff8ecf5ed2>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/75/ad/08/6f/75ad086f-0cd0-4703-ab55-5e9f87caa52a>
         a oa:FragmentSelector ;\n\trdf:value \"xywh=0,0,200,200\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tdc:conformsTo <http://www.w3.org/TR/media-frags/> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextPositionSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"faf99b08e2a661f7d59b442aefecd336cfa87c69"'
+      - '"dac186c6059d891e1a27be7db16ae11f6c38bae1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"887d4a6cc118d98a72f74ff631c6bf7b022de367"'
+      - '"da7f517753c2bcc021dbfed50c383d4e50ec9f7f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:46 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:46 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4146f776805de0b4bdc95c38d27b21c67c912dda"'
+      - '"f6dba6423221ca2ef20d72e6509ca672c85602c3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"df8199f6e631d44a482d318c18758a4b6d4be1e8"'
+      - '"ef7a159143b450ce504980e4d4351e8bfbb3635f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a586918e289efd279bb2d291274d518162f2cd0c"'
+      - '"f62f4ef10af8599a38cb3a4bfaf2530a4d29b492"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t
     body:
       encoding: UTF-8
       string: |
@@ -257,23 +257,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"04064d0b6bd54401f4f75e14c6d89afe718fdf76"'
+      - '"43fa4386de77bac1fb20dc0985d1d86c810a0ba2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
     body:
       encoding: US-ASCII
       string: ''
@@ -292,9 +292,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fb1002315955e87612be236c808403962898bf64"'
+      - '"f587ad3c9263304873883d27216a0193b9e7340a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -311,7 +311,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -327,19 +327,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242
     body:
       encoding: US-ASCII
       string: ''
@@ -358,9 +358,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df8199f6e631d44a482d318c18758a4b6d4be1e8"'
+      - '"ef7a159143b450ce504980e4d4351e8bfbb3635f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -377,7 +377,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -393,15 +393,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c
     body:
       encoding: US-ASCII
       string: ''
@@ -420,9 +420,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"04064d0b6bd54401f4f75e14c6d89afe718fdf76"'
+      - '"43fa4386de77bac1fb20dc0985d1d86c810a0ba2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -439,7 +439,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2166'
+      - '2211'
       Content-Type:
       - application/x-turtle
     body:
@@ -455,21 +455,21 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/a0/4a/2d/4b/a04a2d4b-c40d-45f2-a448-7eea97b7c100>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7c/e0/f3/d6/7ce0f3d6-6690-4443-96bf-a99afafd68eb>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/a0/4a/2d/4b/a04a2d4b-c40d-45f2-a448-7eea97b7c100>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7c/e0/f3/d6/7ce0f3d6-6690-4443-96bf-a99afafd68eb>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853
     body:
       encoding: US-ASCII
       string: ''
@@ -488,9 +488,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fb1002315955e87612be236c808403962898bf64"'
+      - '"f587ad3c9263304873883d27216a0193b9e7340a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -507,7 +507,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -523,19 +523,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242
     body:
       encoding: US-ASCII
       string: ''
@@ -554,9 +554,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"df8199f6e631d44a482d318c18758a4b6d4be1e8"'
+      - '"ef7a159143b450ce504980e4d4351e8bfbb3635f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -573,7 +573,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -589,15 +589,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/b/0e/77/8a/ae/0e778aae-24ea-424c-918f-6ac920b496ee>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/b/7e/0d/53/ae/7e0d53ae-ce4e-46ef-968b-3eae52f7a242>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c
     body:
       encoding: US-ASCII
       string: ''
@@ -616,9 +616,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"04064d0b6bd54401f4f75e14c6d89afe718fdf76"'
+      - '"43fa4386de77bac1fb20dc0985d1d86c810a0ba2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -635,7 +635,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2166'
+      - '2211'
       Content-Type:
       - application/x-turtle
     body:
@@ -651,16 +651,16 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/a0/4a/2d/4b/a04a2d4b-c40d-45f2-a448-7eea97b7c100>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/df/52/60/8b/df52608b-3afd-44ab-8ce3-93cd7aad7c2f/t/82/e8/32/d4/82e832d4-cdf8-406a-85de-1f1ac458709d#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/7c/e0/f3/d6/7ce0f3d6-6690-4443-96bf-a99afafd68eb>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/48/18/9e/ac/48189eac-7222-4fd5-9a8e-6d78f5aca853/t/45/fb/b0/93/45fbb093-ea71-4652-b19b-2bfdad78a90c#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/a0/4a/2d/4b/a04a2d4b-c40d-45f2-a448-7eea97b7c100>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/7c/e0/f3/d6/7ce0f3d6-6690-4443-96bf-a99afafd68eb>
         a oa:TextPositionSelector ;\n\toa:end \"66\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         ;\n\toa:start \"0\"^^<http://www.w3.org/2001/XMLSchema#nonNegativeInteger>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:34 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_SpecificResource/target_is_TextQuoteSelector.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d70a6c46fc756256c8c70b8913c7cb26f3c21dcf"'
+      - '"d9df2e24aa6cb60ab97b148249028b05ae77faea"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:34 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b4a349a8d394f313267d68ece4df0534add723d5"'
+      - '"63ba69a28b2dcc731ba69013ad1f0ae51cb47b23"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '118'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"76700778e001f9cfb7b82efc3eb8523d644df5ad"'
+      - '"a972612825859ad0aa23b23eeb5394f366517f0c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1d07ce89b5ac2524ffbb2583913f1c719960b0a8"'
+      - '"339693be0b4d877baa22ebf929c22b94d154508f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"a3d3f80109360cec5e9464b3158dfc98f9a7288a"'
+      - '"880a42a830cad07ca8eae837cf22970c27ef3428"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '120'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:47 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t
     body:
       encoding: UTF-8
       string: |
@@ -258,23 +258,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"72d68f7f83bbbcf47ae37b1f55e4ba3fbec90709"'
+      - '"694c9479be71742654bc65b11b8caa979c65eed4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Content-Length:
       - '169'
       Location:
-      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a
+      - http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a
+      string: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
     body:
       encoding: US-ASCII
       string: ''
@@ -293,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1ce7c0c70dd24bccb1f9c48ae6bae09ac2620ddb"'
+      - '"b7201e777a28e2080cfaefbb14726af92c3ce50a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -312,7 +312,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -328,19 +328,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8
     body:
       encoding: US-ASCII
       string: ''
@@ -359,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d07ce89b5ac2524ffbb2583913f1c719960b0a8"'
+      - '"339693be0b4d877baa22ebf929c22b94d154508f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -378,7 +378,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -394,15 +394,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113
     body:
       encoding: US-ASCII
       string: ''
@@ -421,9 +421,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"72d68f7f83bbbcf47ae37b1f55e4ba3fbec90709"'
+      - '"694c9479be71742654bc65b11b8caa979c65eed4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -440,7 +440,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2281'
+      - '2326'
       Content-Type:
       - application/x-turtle
     body:
@@ -456,22 +456,22 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/f0/9f/6f/cc/f09f6fcc-2dac-4d6f-96f7-90f80bafc6aa>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/53/26/f6/3c/5326f63c-e0f8-476e-bd1f-6d535d0de17f>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f0/9f/6f/cc/f09f6fcc-2dac-4d6f-96f7-90f80bafc6aa>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/53/26/f6/3c/5326f63c-e0f8-476e-bd1f-6d535d0de17f>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1ce7c0c70dd24bccb1f9c48ae6bae09ac2620ddb"'
+      - '"b7201e777a28e2080cfaefbb14726af92c3ce50a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -509,7 +509,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1903'
+      - '1948'
       Content-Type:
       - application/x-turtle
     body:
@@ -525,19 +525,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b>
-        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a>
+        <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b>
+        , <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8
     body:
       encoding: US-ASCII
       string: ''
@@ -556,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1d07ce89b5ac2524ffbb2583913f1c719960b0a8"'
+      - '"339693be0b4d877baa22ebf929c22b94d154508f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -575,7 +575,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1337'
+      - '1382'
       Content-Type:
       - application/x-turtle
     body:
@@ -591,15 +591,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/b/12/61/82/5a/1261825a-4c22-49ce-800e-ae9abaf5f9ce>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/b/63/53/e3/8c/6353e38c-7997-47b3-89fa-895788a58cd8>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a
+    uri: http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113
     body:
       encoding: US-ASCII
       string: ''
@@ -618,9 +618,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"72d68f7f83bbbcf47ae37b1f55e4ba3fbec90709"'
+      - '"694c9479be71742654bc65b11b8caa979c65eed4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:20:35 GMT
+      - Wed, 08 Jul 2015 21:14:47 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -637,7 +637,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2281'
+      - '2326'
       Content-Type:
       - application/x-turtle
     body:
@@ -653,17 +653,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/terms/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a>
-        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/f0/9f/6f/cc/f09f6fcc-2dac-4d6f-96f7-90f80bafc6aa>
-        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a#source>
-        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/fa/91/7b/52/fa917b52-a5ec-4072-afd1-64be91613f7e/t/f2/ed/9d/a6/f2ed9da6-ef1a-4c82-b493-327a417da40a#source>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/terms/> .\n\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113>
+        a oa:SpecificResource , ldp:BasicContainer ;\n\toa:hasSelector <http://localhost:8983/fedora/rest/.well-known/genid/53/26/f6/3c/5326f63c-e0f8-476e-bd1f-6d535d0de17f>
+        ;\n\toa:hasSource <http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113#source>
+        .\n\n<http://localhost:8983/fedora/rest/anno/specific_res_integration_specs/34/d8/78/d6/34d878d6-03af-4f15-b39c-a84e4d1ac32c/t/d4/d9/dc/a6/d4d9dca6-e452-44f6-bda9-7dc8ad30b113#source>
         triannon:externalReference <https://stacks.stanford.edu/image/kq131cs7229/kq131cs7229_05_0032_large.jpg>
-        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/f0/9f/6f/cc/f09f6fcc-2dac-4d6f-96f7-90f80bafc6aa>
+        .\n\n<http://localhost:8983/fedora/rest/.well-known/genid/53/26/f6/3c/5326f63c-e0f8-476e-bd1f-6d535d0de17f>
         a oa:TextQuoteSelector ;\n\toa:suffix \" and The Canonical Epistles,\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:prefix \"manuscript which comprised the \"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\toa:exact \"third and fourth Gospels\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:20:35 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:48 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ff59612d7d2784dda4b78e47a86082faa453b9fb"'
+      - '"c195c55b7a584e7bef460b71c56662994af32e82"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d7ae7524298b966694297ef6de3eafe6f6842d2a"'
+      - '"4ebb2888de2a0a324eec408a09137af6b618e15c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:00:57 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f485861ab9a64278502377f4388c1feb48c4a764"'
+      - '"6c8bb07dbc36627d20653a470a86c9111a59635d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '68'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f485861ab9a64278502377f4388c1feb48c4a764"'
+      - '"6c8bb07dbc36627d20653a470a86c9111a59635d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"165a4411fb77be932ad7b466f9f565d6630ce8c9"'
+      - '"ff08f173cb3d9c2c9747a416632957a79eb5808c"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3996eac418cb179398fcfe2f8de0e5e2dd6c5ec9"'
+      - '"d3e4400643bfefcfb74e257086d15fe4d5425b53"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"50ce7598c667855f073b7e8688f84742db02b7b2"'
+      - '"9edc977067556bf741dc35ec6288d4fdb693bf0a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
     body:
       encoding: UTF-8
       string: |
@@ -188,7 +188,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -208,23 +208,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"db0f812adde88d66d7aa23dd88c421a6a9980543"'
+      - '"acc0dc8ba5c727a62587a76374646ded143faf45"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t
     body:
       encoding: UTF-8
       string: |
@@ -251,23 +251,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0417d04ad48cf06717ffabae0b7d2700f0bf07e9"'
+      - '"b8f527605f77e71fef69a71d7d34deb2a0514985"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
     body:
       encoding: US-ASCII
       string: ''
@@ -286,9 +286,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34452a12e37af1a34776d562d0576041c6706577"'
+      - '"5caaf9a7ad9db78db743854664cd04bd31d3c82e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -305,7 +305,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1905'
+      - '1950'
       Content-Type:
       - application/x-turtle
     body:
@@ -321,19 +321,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263
     body:
       encoding: US-ASCII
       string: ''
@@ -352,9 +352,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"50ce7598c667855f073b7e8688f84742db02b7b2"'
+      - '"9edc977067556bf741dc35ec6288d4fdb693bf0a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -371,7 +371,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -387,15 +387,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b
     body:
       encoding: US-ASCII
       string: ''
@@ -414,9 +414,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0417d04ad48cf06717ffabae0b7d2700f0bf07e9"'
+      - '"b8f527605f77e71fef69a71d7d34deb2a0514985"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -433,7 +433,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -449,15 +449,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177
     body:
       encoding: US-ASCII
       string: ''
@@ -476,9 +476,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"34452a12e37af1a34776d562d0576041c6706577"'
+      - '"5caaf9a7ad9db78db743854664cd04bd31d3c82e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -495,7 +495,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1905'
+      - '1950'
       Content-Type:
       - application/x-turtle
     body:
@@ -511,19 +511,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263
     body:
       encoding: US-ASCII
       string: ''
@@ -542,9 +542,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"50ce7598c667855f073b7e8688f84742db02b7b2"'
+      - '"9edc977067556bf741dc35ec6288d4fdb693bf0a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -561,7 +561,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -577,15 +577,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/b/46/75/e9/11/4675e911-08a0-439b-b023-d2b19339024f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/b/d8/f1/ab/13/d8f1ab13-eff1-492f-bcc2-5ac1c6fdf263>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b
     body:
       encoding: US-ASCII
       string: ''
@@ -604,9 +604,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"0417d04ad48cf06717ffabae0b7d2700f0bf07e9"'
+      - '"b8f527605f77e71fef69a71d7d34deb2a0514985"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -623,7 +623,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -639,10 +639,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/be/43/6c/01/be436c01-491a-40d1-b925-109e411cb111/t/48/d7/a0/77/48d7a077-bdb4-40f5-ae06-f4b16ad1645c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/d9/c9/82/c3/d9c982c3-5f8a-4096-a2dc-84ed05f85177/t/82/24/c6/9d/8224c69d-d089-4d57-85b1-579b1dc1618b>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/body_is_blank_node_with_content_as_text_w_diff_triples.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8b7fa67309b3ef511cf5d6699d5eb98bdc32608b"'
+      - '"f026bd3250ea67710b78a4587493763efe9e8673"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:54 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"df3e783ae65da353311cf67714b24da06ecf5bb2"'
+      - '"d5febcdbd67aeffc40c1ce92fd78276af131a871"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"20579296c960bb520b26c84cc13d010e44ef4865"'
+      - '"627cde8dfb251bc11bde5936f20f7a706c37f831"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b
     body:
       encoding: UTF-8
       string: |
@@ -165,23 +165,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4a1913a2e305c3a5a163eafab494c68afa782ba0"'
+      - '"a79d52c00fcbd966e63e54f7a7f587a98c5111d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
     body:
       encoding: UTF-8
       string: |
@@ -191,7 +191,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -211,23 +211,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e45c3b0ea5aff99a32494700bcabfc8f597c5d09"'
+      - '"eb5913271bd9f1d61d5ab85e855d3a338d827f65"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t
     body:
       encoding: UTF-8
       string: |
@@ -254,23 +254,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8d4cca6f90da1bc5c840e037dc7ac5c7db60f924"'
+      - '"5e103040f0bb5cfc4193d68deb6b2fc8865789d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
     body:
       encoding: US-ASCII
       string: ''
@@ -289,9 +289,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f28983c8914b079415ff6525397bec0ea5028247"'
+      - '"f4517aa7a4e3b3fb8664155095904300dd3ceacb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -308,7 +308,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1905'
+      - '1950'
       Content-Type:
       - application/x-turtle
     body:
@@ -324,19 +324,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8
     body:
       encoding: US-ASCII
       string: ''
@@ -355,9 +355,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4a1913a2e305c3a5a163eafab494c68afa782ba0"'
+      - '"a79d52c00fcbd966e63e54f7a7f587a98c5111d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -374,7 +374,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1513'
+      - '1558'
       Content-Type:
       - application/x-turtle
     body:
@@ -390,17 +390,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tdc:language
         \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:33 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f
     body:
       encoding: US-ASCII
       string: ''
@@ -419,9 +419,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8d4cca6f90da1bc5c840e037dc7ac5c7db60f924"'
+      - '"5e103040f0bb5cfc4193d68deb6b2fc8865789d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -438,7 +438,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -454,15 +454,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703
     body:
       encoding: US-ASCII
       string: ''
@@ -481,9 +481,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f28983c8914b079415ff6525397bec0ea5028247"'
+      - '"f4517aa7a4e3b3fb8664155095904300dd3ceacb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -500,7 +500,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1905'
+      - '1950'
       Content-Type:
       - application/x-turtle
     body:
@@ -516,19 +516,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8
     body:
       encoding: US-ASCII
       string: ''
@@ -547,9 +547,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4a1913a2e305c3a5a163eafab494c68afa782ba0"'
+      - '"a79d52c00fcbd966e63e54f7a7f587a98c5111d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -566,7 +566,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1513'
+      - '1558'
       Content-Type:
       - application/x-turtle
     body:
@@ -582,17 +582,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/b/72/dd/e2/ee/72dde2ee-0f5e-4939-b8ac-e1a4a9c17831>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/b/ab/12/3a/51/ab123a51-09b4-4377-9504-a91b1b3563f8>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tdc:language
         \"en\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n\tdc:format \"text/plain\"^^<http://www.w3.org/2001/XMLSchema#string>
         ;\n\tcnt:chars \"I love this!\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f
     body:
       encoding: US-ASCII
       string: ''
@@ -611,9 +611,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8d4cca6f90da1bc5c840e037dc7ac5c7db60f924"'
+      - '"5e103040f0bb5cfc4193d68deb6b2fc8865789d1"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -630,7 +630,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -646,10 +646,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/8b/b8/75/bb8bb875-926f-4288-ad3c-73114fd1b485/t/56/98/84/d3/569884d3-14db-46c1-b9b0-aff29c9c223a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/36/e6/2f/d3/36e62fd3-2a3a-468c-aaa5-9fd338519703/t/dd/67/81/d7/dd6781d7-3bc7-44bd-89f5-edca9bb4da7f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_content_as_text/two_bodies_each_as_blank_nodes.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5a001c3d6a8370543e8fcee2185e42d7ee11dcff"'
+      - '"f56fca350b2ab17076842b39f0f7bf87dac309c7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:33 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c260c01dd653e753253c01b39e73e9696cfd2da2"'
+      - '"95d135769fe01634d2de4e40dc4fbc1047fb11f5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '117'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2af9e06c27d6fb499529022113c329f7115a78ba"'
+      - '"fdccb5b0671d5eb636ca76384cd1244bbc918a91"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b
     body:
       encoding: UTF-8
       string: |
@@ -162,23 +162,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2a19454d7020d6e849eefc4103532db4b47adf79"'
+      - '"050f98e98f181f745c00ee3fb0ece15862d63a76"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b
     body:
       encoding: UTF-8
       string: |
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9fa82a4a53a20099cdeb76ca62d56965ed796241"'
+      - '"61712bd8cfcedc5d6ac5aba032b5faa923b22e32"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
     body:
       encoding: UTF-8
       string: |
@@ -235,7 +235,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -255,23 +255,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"25b79eb59924ff7be0f368f9cfff05daee2e68e4"'
+      - '"bd4993c8e7c9f975296d0c30a0d8120ea27b5693"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '119'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t
     body:
       encoding: UTF-8
       string: |
@@ -298,23 +298,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5c925c65b95735bd97d44626c6cd09d100881a53"'
+      - '"f773ef3f29eebc845f2678408410c6bf7e1b4ff7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:56 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '168'
       Location:
-      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466
+      - http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466
+      string: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
     body:
       encoding: US-ASCII
       string: ''
@@ -333,9 +333,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4e2f094674deaf121428e6ddf6dee703678cf78e"'
+      - '"d5e43112bbc9754fb5b5515a6dc3fe1475cb3de9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -352,7 +352,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2078'
+      - '2123'
       Content-Type:
       - application/x-turtle
     body:
@@ -368,20 +368,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391
     body:
       encoding: US-ASCII
       string: ''
@@ -400,9 +400,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2a19454d7020d6e849eefc4103532db4b47adf79"'
+      - '"050f98e98f181f745c00ee3fb0ece15862d63a76"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -419,7 +419,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -435,15 +435,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0
     body:
       encoding: US-ASCII
       string: ''
@@ -462,9 +462,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9fa82a4a53a20099cdeb76ca62d56965ed796241"'
+      - '"61712bd8cfcedc5d6ac5aba032b5faa923b22e32"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -481,7 +481,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -497,15 +497,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1
     body:
       encoding: US-ASCII
       string: ''
@@ -524,9 +524,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5c925c65b95735bd97d44626c6cd09d100881a53"'
+      - '"f773ef3f29eebc845f2678408410c6bf7e1b4ff7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:56 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -543,7 +543,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -559,15 +559,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2
     body:
       encoding: US-ASCII
       string: ''
@@ -586,9 +586,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4e2f094674deaf121428e6ddf6dee703678cf78e"'
+      - '"d5e43112bbc9754fb5b5515a6dc3fe1475cb3de9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -605,7 +605,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2078'
+      - '2123'
       Content-Type:
       - application/x-turtle
     body:
@@ -621,20 +621,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:commenting ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c>
-        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb>
+        <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391>
+        , <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391
     body:
       encoding: US-ASCII
       string: ''
@@ -653,9 +653,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2a19454d7020d6e849eefc4103532db4b47adf79"'
+      - '"050f98e98f181f745c00ee3fb0ece15862d63a76"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -672,7 +672,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -688,15 +688,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/12/dc/17/3c/12dc173c-b8e0-44ac-ae50-76bfde10822c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/ba/5b/91/74/ba5b9174-f5bc-4af1-8b79-db1e73424391>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         love this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0
     body:
       encoding: US-ASCII
       string: ''
@@ -715,9 +715,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"9fa82a4a53a20099cdeb76ca62d56965ed796241"'
+      - '"61712bd8cfcedc5d6ac5aba032b5faa923b22e32"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:55 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -734,7 +734,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1381'
+      - '1426'
       Content-Type:
       - application/x-turtle
     body:
@@ -750,15 +750,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/b/ff/e6/ad/29/ffe6ad29-2e40-43be-840d-5760b26815cb>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/b/a3/32/7d/b2/a3327db2-78f6-44bc-bccc-2969e1cf85d0>
         a dcmitype:Text , ldp:BasicContainer , cnt:ContentAsText ;\n\tcnt:chars \"I
         hate this!\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466
+    uri: http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1
     body:
       encoding: US-ASCII
       string: ''
@@ -777,9 +777,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5c925c65b95735bd97d44626c6cd09d100881a53"'
+      - '"f773ef3f29eebc845f2678408410c6bf7e1b4ff7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:56 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -796,7 +796,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1343'
+      - '1388'
       Content-Type:
       - application/x-turtle
     body:
@@ -812,10 +812,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/3d/e0/f6/ab/3de0f6ab-cc2a-47ee-b378-aaa69dd7df5e/t/5e/53/b4/61/5e53b461-d123-4a92-8921-894b518ab466>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/context_as_text_intgrtn_specs/bb/83/82/64/bb838264-fe99-4bbb-8d64-9497cf80ebb2/t/9a/53/6e/58/9a536e58-e8c0-4bfd-ace0-c163f8856cc1>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:07:56 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5fcc65a9f248e2fb1f9eaa972efd2ba1803bfd22"'
+      - '"1179a01d39fe8769f9ea0404d2ab7398eaf2b6de"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -110,5 +110,5 @@ http_interactions:
       string: |
         {'responseHeader'=>{'status'=>0,'QTime'=>2}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:55 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1c7656f19718f7fd1ce8d51872b01509a1ca0c42"'
+      - '"dc0e4ac7d657b1acb9815378b7e69b6054bfb41f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:07:56 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"7b8d8ab87401d3ca6e3953812e4efcaeeb570067"'
+      - '"084b667f2e626c1b3922c2132c7beef0cffdf500"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '57'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/external_uri_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_and_target_have_plain_external_URI.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"cd7a8d426baedb8387b892dabbfdeff90d75a94a"'
+      - '"b75e6370ad6c230c43b7048a3a87d2a5705fcece"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8fd67060f2e3c01e22ae8954d142f48e95ab8780"'
+      - '"34b3d9885a3b629d318c3b5dfdf36da102ef7d54"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"adf31fd25d65d0c9d82abe1be26239931342e6c6"'
+      - '"3c9fb4d433f6ab4166aaaeacf134cdc67065dc59"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3c4366f5a099794f0c9af6e70c2661a37d0b72fe"'
+      - '"e8a287eb871e65fa64696fd54e0b403219be9ab6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"693194e0c152f9af33b0a5cf6fcab22c1853f3c3"'
+      - '"55b7db2fe10510f9e5fe387825adc10e906651e5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t
     body:
       encoding: UTF-8
       string: |
@@ -247,23 +247,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2e314b3573dc814d3bb33d54305d327b1e00a1c1"'
+      - '"5b11c634bfa80bd49a2efe43af5d905e61e7cdaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
     body:
       encoding: US-ASCII
       string: ''
@@ -282,9 +282,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7898702aa2c8be337c9dd98994789c8d34e09a02"'
+      - '"2898438bd92a3a92b61cc411499afedf7df7e1d9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -301,7 +301,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -317,19 +317,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae
     body:
       encoding: US-ASCII
       string: ''
@@ -348,9 +348,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3c4366f5a099794f0c9af6e70c2661a37d0b72fe"'
+      - '"e8a287eb871e65fa64696fd54e0b403219be9ab6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -367,7 +367,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -383,15 +383,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35
     body:
       encoding: US-ASCII
       string: ''
@@ -410,9 +410,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2e314b3573dc814d3bb33d54305d327b1e00a1c1"'
+      - '"5b11c634bfa80bd49a2efe43af5d905e61e7cdaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -429,7 +429,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -445,15 +445,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0
     body:
       encoding: US-ASCII
       string: ''
@@ -472,9 +472,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7898702aa2c8be337c9dd98994789c8d34e09a02"'
+      - '"2898438bd92a3a92b61cc411499afedf7df7e1d9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -491,7 +491,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -507,19 +507,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae
     body:
       encoding: US-ASCII
       string: ''
@@ -538,9 +538,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3c4366f5a099794f0c9af6e70c2661a37d0b72fe"'
+      - '"e8a287eb871e65fa64696fd54e0b403219be9ab6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -557,7 +557,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -573,15 +573,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/b/a2/4c/c8/c7/a24cc8c7-86b9-4218-9054-eb7e802624db>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/b/c3/f2/d9/07/c3f2d907-4468-430b-902d-985f653c40ae>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35
     body:
       encoding: US-ASCII
       string: ''
@@ -600,9 +600,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2e314b3573dc814d3bb33d54305d327b1e00a1c1"'
+      - '"5b11c634bfa80bd49a2efe43af5d905e61e7cdaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -619,7 +619,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -635,10 +635,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/e6/fe/7e/09/e6fe7e09-4660-46be-b6d6-6446520f4117/t/84/ff/fe/4e/84fffe4e-291e-4e1f-8b54-35c7317e5c2c>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/68/9c/38/62/689c3862-e2e0-49b0-b653-4625233539f0/t/f5/2f/75/8d/f52f758d-190e-41d5-908d-4b7ca7271f35>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_metadata.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4ce17e9909fcb65681072856db9ee32dc661ebd9"'
+      - '"8a421329e191d83838db26f13e4a7457757a6493"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"9b9827d0eb474181b7eb0993bfdb1d0e87eaeac2"'
+      - '"f4d41c3f171cfc4c7e84fac02879b12b9757a5c3"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"beb778543f25ab02ce339b1998b24e7e46cadb9b"'
+      - '"7ddfe933f91ec9869ad0b813bfe8c53abfd491a6"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b
     body:
       encoding: UTF-8
       string: |
@@ -163,23 +163,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ee95979a0710e59692e93e4e40b6c711ea3bd67b"'
+      - '"05a2d253d0923c549b079cbf29ef61d621756048"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
     body:
       encoding: UTF-8
       string: |
@@ -189,7 +189,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -209,23 +209,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"8ddd8c5337c9cb6ab4e0a7196890602419f3c059"'
+      - '"691273c350808fc1774a8a14a565706f175cae75"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t
     body:
       encoding: UTF-8
       string: |
@@ -252,23 +252,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"6a4a5161ccc50a186e7edb30da48d078bf36c3f9"'
+      - '"5895d9a416388f5b4b1a67c2571211a001bbeaf5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
     body:
       encoding: US-ASCII
       string: ''
@@ -287,9 +287,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"887820c00a1e5f3db2adf56feceebc563eba0fec"'
+      - '"f6327efe858260d104bbc43ac02209b2403f4efa"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -306,7 +306,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -322,19 +322,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc
     body:
       encoding: US-ASCII
       string: ''
@@ -353,9 +353,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ee95979a0710e59692e93e4e40b6c711ea3bd67b"'
+      - '"05a2d253d0923c549b079cbf29ef61d621756048"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -372,7 +372,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1420'
+      - '1465'
       Content-Type:
       - application/x-turtle
     body:
@@ -388,16 +388,16 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc>
         a dcmitype:Sound , ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd
     body:
       encoding: US-ASCII
       string: ''
@@ -416,9 +416,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6a4a5161ccc50a186e7edb30da48d078bf36c3f9"'
+      - '"5895d9a416388f5b4b1a67c2571211a001bbeaf5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -435,7 +435,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -451,15 +451,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342
     body:
       encoding: US-ASCII
       string: ''
@@ -478,9 +478,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"887820c00a1e5f3db2adf56feceebc563eba0fec"'
+      - '"f6327efe858260d104bbc43ac02209b2403f4efa"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -497,7 +497,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -513,19 +513,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc
     body:
       encoding: US-ASCII
       string: ''
@@ -544,9 +544,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ee95979a0710e59692e93e4e40b6c711ea3bd67b"'
+      - '"05a2d253d0923c549b079cbf29ef61d621756048"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -563,7 +563,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1420'
+      - '1465'
       Content-Type:
       - application/x-turtle
     body:
@@ -579,16 +579,16 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/b/d7/82/5e/df/d7825edf-24fe-4e49-a74c-77c20450580e>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/b/7b/cb/2f/02/7bcb2f02-55f9-420a-bb76-a711761521fc>
         a dcmitype:Sound , ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         ;\n\tdc:format \"audio/mpeg3\"^^<http://www.w3.org/2001/XMLSchema#string>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd
     body:
       encoding: US-ASCII
       string: ''
@@ -607,9 +607,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"6a4a5161ccc50a186e7edb30da48d078bf36c3f9"'
+      - '"5895d9a416388f5b4b1a67c2571211a001bbeaf5"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -626,7 +626,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -642,10 +642,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/35/ab/28/70/35ab2870-c374-47cf-aa0e-1c2652fdf3b3/t/cc/4f/4b/fb/cc4f4bfb-b33a-4597-aad9-77217363b73a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3c/93/36/1b/3c93361b-2b60-4f06-bb01-0110502e9342/t/2e/9f/2d/09/2e9f2d09-530a-473f-a809-c40fefeaeebd>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/body_uri_with_semantic_tag.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5c56f3f0e675782607e0446eef220c11366dd531"'
+      - '"17cba18d9ea67eeab56188fb1fe4762501e43ce7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1f62a3415a75e09a2785860a2ac4f3fc2b932003"'
+      - '"2f053b0508d1fe21a60a74af95ce8dc398756913"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4fe4173db180e5cac553ad879d5eab5fc5c7ba8a"'
+      - '"c8dd8368ae0d65a54e44798572b92b575e6387ea"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b
     body:
       encoding: UTF-8
       string: |
@@ -160,23 +160,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"ec1d375f130260e5010b18bccdf519fc199da872"'
+      - '"7bb178e295ec0b68fd5b66360f46e87f7c0b09eb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
     body:
       encoding: UTF-8
       string: |
@@ -186,7 +186,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -206,23 +206,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3e315704742106558021f81e5c7a953818ec2e7c"'
+      - '"4edff351c88a585f7aec0ea1f059bcac2f2ecfb2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t
     body:
       encoding: UTF-8
       string: |
@@ -249,23 +249,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"f30d99274c531d3dbcb2971b1d04bc5060abfb3f"'
+      - '"f1403151e7b7106cb86d6e4e9eea449d18526678"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
     body:
       encoding: US-ASCII
       string: ''
@@ -284,9 +284,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a5d451e1e1a66215af35af736e385d68ae3f063d"'
+      - '"ba588ba2ada661a9a3d7558f66efce1a6d990e47"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -303,7 +303,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -319,19 +319,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3
     body:
       encoding: US-ASCII
       string: ''
@@ -350,9 +350,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ec1d375f130260e5010b18bccdf519fc199da872"'
+      - '"7bb178e295ec0b68fd5b66360f46e87f7c0b09eb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -369,7 +369,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1349'
+      - '1394'
       Content-Type:
       - application/x-turtle
     body:
@@ -385,15 +385,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3>
         a oa:SemanticTag , ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211
     body:
       encoding: US-ASCII
       string: ''
@@ -412,9 +412,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f30d99274c531d3dbcb2971b1d04bc5060abfb3f"'
+      - '"f1403151e7b7106cb86d6e4e9eea449d18526678"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -431,7 +431,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -447,15 +447,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86
     body:
       encoding: US-ASCII
       string: ''
@@ -474,9 +474,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"a5d451e1e1a66215af35af736e385d68ae3f063d"'
+      - '"ba588ba2ada661a9a3d7558f66efce1a6d990e47"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -493,7 +493,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -509,19 +509,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3
     body:
       encoding: US-ASCII
       string: ''
@@ -540,9 +540,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"ec1d375f130260e5010b18bccdf519fc199da872"'
+      - '"7bb178e295ec0b68fd5b66360f46e87f7c0b09eb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -559,7 +559,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1349'
+      - '1394'
       Content-Type:
       - application/x-turtle
     body:
@@ -575,15 +575,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/b/d1/dd/4c/44/d1dd4c44-4238-4835-a8c1-70fac6bc602a>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/b/18/9c/00/e4/189c00e4-92cc-4199-849f-faebc3ba80e3>
         a oa:SemanticTag , ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211
     body:
       encoding: US-ASCII
       string: ''
@@ -602,9 +602,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"f30d99274c531d3dbcb2971b1d04bc5060abfb3f"'
+      - '"f1403151e7b7106cb86d6e4e9eea449d18526678"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -621,7 +621,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -637,10 +637,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/4b/b8/c2/61/4bb8c261-ac2d-4bc6-8fa3-f7116c69259a/t/98/6c/cb/74/986ccb74-62dd-4b44-84f3-870e0ae108e0>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/5c/b3/10/71/5cb31071-1fca-4c62-8b55-ad0d48f2ee86/t/c4/60/90/0a/c460900a-e086-4c8c-9c66-a17550273211>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_bodies_with_plain_external_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8a6d6ad335501af696575a063f9e502159934f1a"'
+      - '"3c822c5b266bf6cc948ea6db1c742a9ac0fa00de"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"0c74b47edc79dcf2d47dc63b5a881f2e527619cf"'
+      - '"7e2f8679a237255b387faec2d814f82853396874"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2f85302eafde264ce9c73a4dddd509439553d61d"'
+      - '"79766a26bfd6a57e973821cc3acc4e5ad3cfe5e9"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"fd775e990c867195aed10729b0778abd2df863d8"'
+      - '"6f06efc5001b9d575c84e9a659148853af05c0e2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"89e79e3f6eb1c7cbfa93a152f23dd356ecdda902"'
+      - '"a428391cebe320495b28e903d8eb80e9017730c4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
     body:
       encoding: UTF-8
       string: |
@@ -227,7 +227,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -247,23 +247,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"5715b6da42b72a85b0dc3f013981689a5ec6792a"'
+      - '"916b7d01ae81b870335421c508c1e947b46ff67e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t
     body:
       encoding: UTF-8
       string: |
@@ -290,23 +290,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4edcc1d411190e3e96c18cb27b166428053f6b51"'
+      - '"74b0a689e6e51fb72ad963d94556f545e82175af"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
     body:
       encoding: US-ASCII
       string: ''
@@ -325,9 +325,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8f93fbfbca4e7242e972e5496ea70cf21bdba48c"'
+      - '"e20f7505b0eaaa8315eb7e5556c013c8a0b6440f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -344,7 +344,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2013'
+      - '2058'
       Content-Type:
       - application/x-turtle
     body:
@@ -360,20 +360,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d
     body:
       encoding: US-ASCII
       string: ''
@@ -392,9 +392,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd775e990c867195aed10729b0778abd2df863d8"'
+      - '"6f06efc5001b9d575c84e9a659148853af05c0e2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -411,7 +411,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -427,15 +427,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0
     body:
       encoding: US-ASCII
       string: ''
@@ -454,9 +454,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"89e79e3f6eb1c7cbfa93a152f23dd356ecdda902"'
+      - '"a428391cebe320495b28e903d8eb80e9017730c4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -473,7 +473,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1328'
+      - '1373'
       Content-Type:
       - application/x-turtle
     body:
@@ -489,15 +489,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f
     body:
       encoding: US-ASCII
       string: ''
@@ -516,9 +516,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4edcc1d411190e3e96c18cb27b166428053f6b51"'
+      - '"74b0a689e6e51fb72ad963d94556f545e82175af"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -535,7 +535,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -551,15 +551,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9
     body:
       encoding: US-ASCII
       string: ''
@@ -578,9 +578,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"8f93fbfbca4e7242e972e5496ea70cf21bdba48c"'
+      - '"e20f7505b0eaaa8315eb7e5556c013c8a0b6440f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -597,7 +597,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '2013'
+      - '2058'
       Content-Type:
       - application/x-turtle
     body:
@@ -613,20 +613,20 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d
     body:
       encoding: US-ASCII
       string: ''
@@ -645,9 +645,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"fd775e990c867195aed10729b0778abd2df863d8"'
+      - '"6f06efc5001b9d575c84e9a659148853af05c0e2"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -664,7 +664,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -680,15 +680,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/a4/83/4a/de/a4834ade-b15c-441e-b719-04020961fef9>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/84/0a/83/8f/840a838f-590f-47aa-bc7c-9a6ce31cce4d>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Otto_Ege>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0
     body:
       encoding: US-ASCII
       string: ''
@@ -707,9 +707,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"89e79e3f6eb1c7cbfa93a152f23dd356ecdda902"'
+      - '"a428391cebe320495b28e903d8eb80e9017730c4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -726,7 +726,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1328'
+      - '1373'
       Content-Type:
       - application/x-turtle
     body:
@@ -742,15 +742,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/b/b9/52/84/0b/b952840b-3d9d-4fb4-acf0-c2f1a6b396de>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/b/d4/f0/6f/91/d4f06f91-377b-4859-b68f-e10d46c36ff0>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://dbpedia.org/resource/Love>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f
     body:
       encoding: US-ASCII
       string: ''
@@ -769,9 +769,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"4edcc1d411190e3e96c18cb27b166428053f6b51"'
+      - '"74b0a689e6e51fb72ad963d94556f545e82175af"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -788,7 +788,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -804,10 +804,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0f/14/87/cb/0f1487cb-eed1-4f25-a6ed-7f13e19a152f/t/9c/9d/49/97/9c9d4997-bf2e-4f61-9713-54dfe3a2b116>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/6f/d7/67/f9/6fd767f9-a292-4ed7-bd77-c2d2bab6b3a9/t/7c/52/a1/c0/7c52a1c0-8173-4c22-8bd2-0618d255942f>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/mult_targets_with_plain_external_URIs.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"5413642e3bd5b65ffd33504ea0ed596b2da1a363"'
+      - '"becb924adc69248292b9712d5c59135096daed8f"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c01c13cde0f87e41ff9b7914a221235a5937bc4b"'
+      - '"ded9fea79fc2a7646a6e95d5b55471d9d2d8a5e4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e533ff2b531379afc5c55c2121c4106252dec947"'
+      - '"eb3ea1003ec55e2509a3f501f9d07e5ced2e7518"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"1f3d2fba55189ca1b9494f7a714cadb23943f8c2"'
+      - '"65438dc2f79b4164dcc479a464d2cd9489208aaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t
     body:
       encoding: UTF-8
       string: |
@@ -201,23 +201,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"d063a9ceff16a4f429d1be13d257fc1fd970d3b1"'
+      - '"490379f23a3bebf85ec078fd6715082be98be371"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf
     body:
       encoding: US-ASCII
       string: ''
@@ -236,9 +236,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eca27710e94ff7774d9451b42bb4a5f642ebf8c9"'
+      - '"38616b6dbd996e40d61388e52afbf89cc122831d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -255,7 +255,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1726'
+      - '1771'
       Content-Type:
       - application/x-turtle
     body:
@@ -271,18 +271,18 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6
     body:
       encoding: US-ASCII
       string: ''
@@ -301,9 +301,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1f3d2fba55189ca1b9494f7a714cadb23943f8c2"'
+      - '"65438dc2f79b4164dcc479a464d2cd9489208aaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -320,7 +320,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -336,15 +336,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25
     body:
       encoding: US-ASCII
       string: ''
@@ -363,9 +363,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d063a9ceff16a4f429d1be13d257fc1fd970d3b1"'
+      - '"490379f23a3bebf85ec078fd6715082be98be371"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -382,7 +382,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -398,15 +398,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf
     body:
       encoding: US-ASCII
       string: ''
@@ -425,9 +425,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"eca27710e94ff7774d9451b42bb4a5f642ebf8c9"'
+      - '"38616b6dbd996e40d61388e52afbf89cc122831d"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -444,7 +444,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1726'
+      - '1771'
       Content-Type:
       - application/x-turtle
     body:
@@ -460,18 +460,18 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6
     body:
       encoding: US-ASCII
       string: ''
@@ -490,9 +490,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1f3d2fba55189ca1b9494f7a714cadb23943f8c2"'
+      - '"65438dc2f79b4164dcc479a464d2cd9489208aaf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -509,7 +509,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -525,15 +525,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/8f/4e/aa/77/8f4eaa77-8af2-463e-9837-974e064fb9a8>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/f0/b9/40/df/f0b940df-46fc-4a1c-a103-25980ba06bd6>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/cd666ef4444>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25
     body:
       encoding: US-ASCII
       string: ''
@@ -552,9 +552,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d063a9ceff16a4f429d1be13d257fc1fd970d3b1"'
+      - '"490379f23a3bebf85ec078fd6715082be98be371"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:35 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -571,7 +571,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -587,10 +587,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/31/fa/df/4b/31fadf4b-500a-40ea-8cc6-85ff896d23f4/t/22/9e/14/38/229e1438-dbd5-40bc-8a0c-698fe2038dea>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/a7/2e/2d/94/a72e2d94-c131-402f-8f86-8ba1d2e22baf/t/28/b3/6a/d8/28b36ad8-23a8-40e9-b7a6-d49ec437cb25>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/ab123cd4567>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_has_external_URI.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"7b8d8ab87401d3ca6e3953812e4efcaeeb570067"'
+      - '"084b667f2e626c1b3922c2132c7beef0cffdf500"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"c25a9f47fd1986cbf33d9d95e8551b7116498f18"'
+      - '"9bcd27d12fb607c84cef7f2d7120e0da918a1ff0"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"322f7a7ab2e3bd266a28950523499c2ae9d21ac2"'
+      - '"f7fe5ed9b12cdf46376c36c15f42033af8ccfe7a"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"e6ed78eca8e983ed118a8c9232b3961074feac42"'
+      - '"94a771da3ff7754e01b9ce4fcc184caa27e09796"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"364ee6c06493353f437972d14d14c3a1e6bfc72b"'
+      - '"48a5f0a17056c14d8e1746e388ee37ecd6b4b41e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -212,7 +212,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1564'
+      - '1609'
       Content-Type:
       - application/x-turtle
     body:
@@ -228,17 +228,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6ed78eca8e983ed118a8c9232b3961074feac42"'
+      - '"94a771da3ff7754e01b9ce4fcc184caa27e09796"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -276,7 +276,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -292,15 +292,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:52 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:34 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +319,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"364ee6c06493353f437972d14d14c3a1e6bfc72b"'
+      - '"48a5f0a17056c14d8e1746e388ee37ecd6b4b41e"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -338,7 +338,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1564'
+      - '1609'
       Content-Type:
       - application/x-turtle
     body:
@@ -354,17 +354,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c
     body:
       encoding: US-ASCII
       string: ''
@@ -383,9 +383,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"e6ed78eca8e983ed118a8c9232b3961074feac42"'
+      - '"94a771da3ff7754e01b9ce4fcc184caa27e09796"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:52 GMT
+      - Wed, 08 Jul 2015 21:14:34 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -402,7 +402,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1332'
+      - '1377'
       Content-Type:
       - application/x-turtle
     body:
@@ -418,10 +418,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/0a/9a/4a/92/0a9a4a92-9908-4a64-b025-61508078b754/t/b1/5e/61/ff/b15e61ff-077f-4a9d-a170-d41e9bc4f5ca>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3a/b6/36/90/3ab63690-7224-48cf-90c2-0aa59298825f/t/b0/c3/09/e4/b0c309e4-45f2-484a-bc6b-ef7d5a647a4c>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:53 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_external_URIs/target_uri_has_additional_properties.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"206a0cdf75286017fb09b924c3e9bce3bbe15a8d"'
+      - '"73bf78062ad8b0601cb7356856a40188f58431b8"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:53 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/external_uri_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"825b397eb327c5a48c3ae71e7775f30ee0b5f30b"'
+      - '"93020dd14a45486c56ec2e2d6d5c24462dc9e874"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '106'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasBody;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"570c5588a72fc34c42c9f2abb05a4d10a80e5f46"'
+      - '"aab48aeb2865146e7acf7cc69283b346ea57fad4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"90c75b89355999a01b70807e0c6d900ed9dd9194"'
+      - '"fe9ddc9549daefa01df77d175a67ae094fc0eeeb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
     body:
       encoding: UTF-8
       string: |
@@ -184,7 +184,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -204,23 +204,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"b27b443f68a631cf4e53311b8ea0d9cedc230797"'
+      - '"57eda268c8a74cf2d012bf86fbed246a86be5ca4"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '108'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t
     body:
       encoding: UTF-8
       string: |
@@ -252,23 +252,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"029d33c11c64bf3c8c836e6f9a2450085860b4c8"'
+      - '"0afa5e687680b251940ef52b1e251c1a795c8806"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Content-Length:
       - '157'
       Location:
-      - http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41
+      - http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41
+      string: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
     body:
       encoding: US-ASCII
       string: ''
@@ -287,9 +287,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d69e2c64621987c886bc857feada5c0c75165b71"'
+      - '"2ad74f2783ce00afdfd6b88d5b7edb845209d7d7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -306,7 +306,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -322,19 +322,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18
     body:
       encoding: US-ASCII
       string: ''
@@ -353,9 +353,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"90c75b89355999a01b70807e0c6d900ed9dd9194"'
+      - '"fe9ddc9549daefa01df77d175a67ae094fc0eeeb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -372,7 +372,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1333'
+      - '1378'
       Content-Type:
       - application/x-turtle
     body:
@@ -388,15 +388,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd
     body:
       encoding: US-ASCII
       string: ''
@@ -415,9 +415,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"029d33c11c64bf3c8c836e6f9a2450085860b4c8"'
+      - '"0afa5e687680b251940ef52b1e251c1a795c8806"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -434,7 +434,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1410'
+      - '1455'
       Content-Type:
       - application/x-turtle
     body:
@@ -450,15 +450,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd>
         a dcmitype:Text , ldp:BasicContainer ;\n\ttriannon:externalReference <http://external.com/index.html>
         ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b
     body:
       encoding: US-ASCII
       string: ''
@@ -477,9 +477,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"d69e2c64621987c886bc857feada5c0c75165b71"'
+      - '"2ad74f2783ce00afdfd6b88d5b7edb845209d7d7"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -496,7 +496,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1851'
+      - '1896'
       Content-Type:
       - application/x-turtle
     body:
@@ -512,19 +512,19 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:identifying ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b>
-        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t>
-        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41>
+        <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b>
+        , <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t>
+        ;\n\toa:hasBody <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18
     body:
       encoding: US-ASCII
       string: ''
@@ -543,9 +543,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"90c75b89355999a01b70807e0c6d900ed9dd9194"'
+      - '"fe9ddc9549daefa01df77d175a67ae094fc0eeeb"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -562,7 +562,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1333'
+      - '1378'
       Content-Type:
       - application/x-turtle
     body:
@@ -578,15 +578,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/b/4e/d9/59/a7/4ed959a7-a07a-49fe-b96e-9f3031cffd72>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/b/7c/ba/86/2d/7cba862d-d430-418c-b631-91e1da2dce18>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://www.myaudioblog.com/post/1.mp3>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41
+    uri: http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd
     body:
       encoding: US-ASCII
       string: ''
@@ -605,9 +605,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"029d33c11c64bf3c8c836e6f9a2450085860b4c8"'
+      - '"0afa5e687680b251940ef52b1e251c1a795c8806"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:54 GMT
+      - Wed, 08 Jul 2015 21:14:36 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -624,7 +624,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1410'
+      - '1455'
       Content-Type:
       - application/x-turtle
     body:
@@ -640,10 +640,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/3f/91/cb/66/3f91cb66-5bc9-4a83-a2c4-965431c75480/t/37/b1/fe/1e/37b1fe1e-50b1-42bb-9151-e2799d166f41>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/external_uri_specs/66/6d/c6/1d/666dc61d-0b5d-4241-acdd-0693aef0230b/t/56/98/37/0a/5698370a-f215-4347-8715-8ed3060852bd>
         a dcmitype:Text , ldp:BasicContainer ;\n\ttriannon:externalReference <http://external.com/index.html>
         ;\n\tdc:format \"text/html\"^^<http://www.w3.org/2001/XMLSchema#string> .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:14:54 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/after_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/after_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"3ed53cf066f5300052a7286891c9ea199a7fa42a"'
+      - '"4bb41a535f61a87d2623284e6e1fea891a4cb142"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:13 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -63,7 +63,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: delete
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/fcr:tombstone
@@ -86,7 +86,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 - request:
     method: post
     uri: http://localhost:8983/solr/triannon/update?wt=ruby
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {'responseHeader'=>{'status'=>0,'QTime'=>2}}
+        {'responseHeader'=>{'status'=>0,'QTime'=>1}}
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/before_spec.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/before_spec.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"1f15c33f29fae789d4f2f1e2a2d523aa0647d64a"'
+      - '"69798706fb7cc084bcace243071e094794097a85"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:14:55 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:13 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: head
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -65,7 +65,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:13 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno
@@ -93,9 +93,9 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2ce880c0888c14a1c3849697434964c1243a1783"'
+      - '"32712ab3e1886ac1f320c8a6d1673b0ef57c5e95"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:13 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '64'
       Location:
@@ -106,5 +106,5 @@ http_interactions:
       encoding: UTF-8
       string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:13 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
+++ b/spec/fixtures/vcr_cassettes/integration_tests_for_no_body/bookmark.yml
@@ -17,9 +17,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2ce880c0888c14a1c3849697434964c1243a1783"'
+      - '"32712ab3e1886ac1f320c8a6d1673b0ef57c5e95"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:13 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -38,7 +38,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:13 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
     uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs
@@ -69,23 +69,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"3bc220be372e720b3436a2959baf88ede4eb821a"'
+      - '"b6d3fa0b252eb0197937bcfe39802f310b454adf"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:13 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '113'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7
     body:
       encoding: UTF-8
       string: |
@@ -95,7 +95,7 @@ http_interactions:
 
         <> a ldp:DirectContainer;
            ldp:hasMemberRelation oa:hasTarget;
-           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc> .
+           ldp:membershipResource <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7> .
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -115,23 +115,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"4654e2c20d5a276abe048161ffd279f3863bbf12"'
+      - '"82d97f5dfaa397e6a57bd6f863d717451d25d9ed"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '115'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: post
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t
     body:
       encoding: UTF-8
       string: |
@@ -158,23 +158,23 @@ http_interactions:
       message: Created
     headers:
       Etag:
-      - '"2da31e4e1eb6c5bfb0c60024f9b0ce50df13dd1e"'
+      - '"2fb912746f05727251c7d0307095b1764d181516"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Content-Length:
       - '164'
       Location:
-      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1
+      - http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221
       Content-Type:
       - text/plain
     body:
       encoding: UTF-8
-      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1
+      string: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7
     body:
       encoding: US-ASCII
       string: ''
@@ -193,9 +193,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"84e14e0bcbc50e900841abda6fb8c294d88a65f2"'
+      - '"3dced5394a09f516177614785e200f50a9dee391"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -212,7 +212,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1585'
+      - '1630'
       Content-Type:
       - application/x-turtle
     body:
@@ -228,17 +228,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1>
+        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221
     body:
       encoding: US-ASCII
       string: ''
@@ -257,9 +257,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2da31e4e1eb6c5bfb0c60024f9b0ce50df13dd1e"'
+      - '"2fb912746f05727251c7d0307095b1764d181516"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -276,7 +276,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1339'
+      - '1384'
       Content-Type:
       - application/x-turtle
     body:
@@ -292,15 +292,15 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7
     body:
       encoding: US-ASCII
       string: ''
@@ -319,9 +319,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"84e14e0bcbc50e900841abda6fb8c294d88a65f2"'
+      - '"3dced5394a09f516177614785e200f50a9dee391"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -338,7 +338,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1585'
+      - '1630'
       Content-Type:
       - application/x-turtle
     body:
@@ -354,17 +354,17 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7>
         a oa:Annotation , ldp:BasicContainer ;\n\toa:motivatedBy oa:bookmarking ;\n\tldp:contains
-        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t>
-        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1>
+        <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t>
+        ;\n\toa:hasTarget <http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:37 GMT
 - request:
     method: get
-    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1
+    uri: http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221
     body:
       encoding: US-ASCII
       string: ''
@@ -383,9 +383,9 @@ http_interactions:
       message: OK
     headers:
       Etag:
-      - '"2da31e4e1eb6c5bfb0c60024f9b0ce50df13dd1e"'
+      - '"2fb912746f05727251c7d0307095b1764d181516"'
       Last-Modified:
-      - Tue, 09 Jun 2015 22:17:14 GMT
+      - Wed, 08 Jul 2015 21:14:37 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -402,7 +402,7 @@ http_interactions:
       - Accept, Range, Accept-Encoding, Accept-Language
       - Prefer
       Content-Length:
-      - '1339'
+      - '1384'
       Content-Type:
       - application/x-turtle
     body:
@@ -418,10 +418,10 @@ http_interactions:
         xml: <http://www.w3.org/XML/1998/namespace> .\n@prefix ldp: <http://www.w3.org/ns/ldp#>
         .\n@prefix xs: <http://www.w3.org/2001/XMLSchema> .\n@prefix fedoraconfig:
         <http://fedora.info/definitions/v4/config#> .\n@prefix mix: <http://www.jcp.org/jcr/mix/1.0>
-        .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix dc: <http://purl.org/dc/elements/1.1/>
-        .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/b1/55/87/76/b1558776-2893-40ae-bed0-60a2640a91bc/t/18/80/22/8f/1880228f-e618-45eb-9407-9d8692153eb1>
+        .\n@prefix prov: <http://www.w3.org/ns/prov#> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/>
+        .\n@prefix dc: <http://purl.org/dc/elements/1.1/> .\n\n\n<http://localhost:8983/fedora/rest/anno/no_body_integration_specs/f0/89/9b/d6/f0899bd6-d12b-41f2-b6e3-2f858fdf0fe7/t/0c/46/93/87/0c469387-ad22-41cd-9eff-b0fb38588221>
         a ldp:BasicContainer ;\n\ttriannon:externalReference <http://purl.stanford.edu/kq131cs7229>
         .\n"
     http_version: 
-  recorded_at: Tue, 09 Jun 2015 22:17:14 GMT
+  recorded_at: Wed, 08 Jul 2015 21:14:38 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
as it is redundant (thanks to @cbeer for chasing that down - I was too lazy).

Also, more vcr cassettes expired.  whee.