### PR TITLE
Feature/gem update task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,19 +13,16 @@ gemspec
 # To use a debugger
 gem 'pry-byebug', group: [:development, :test]
 
-group :test do
-  file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
-  if File.exists?(file)
-    puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
-    instance_eval File.read(file)
+file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
+if File.exists?(file)
+  puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(file)
+else
+  gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+  if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] =~ /^4.2/
+    gem 'responders', "~> 2.0"
+    gem 'sass-rails', ">= 5.0"
   else
-    gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
-
-    if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] =~ /^4.2/
-      gem 'responders', "~> 2.0"
-      gem 'sass-rails', ">= 5.0"
-    else
-      gem 'sass-rails', "< 5.0"
-    end
+    gem 'sass-rails', "< 5.0"
   end
 end


### PR DESCRIPTION
In the Rakefile, this reverts gem management changes to the Gemfile.lock file while running the 'ci' task.  It adds a developer convenience rake task for updating gemsets in triannon and it's engine cart app.  In the Gemfile, it should be consistent with the current engine_cart:prepare input.  This PR is against the 'develop' branch.